### PR TITLE
Establish a lower-bound for haskell-src-exts.

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -27,7 +27,7 @@ library
                      HIndent.Styles.JohanTibell
   build-depends:     base >= 4 && <5
                    , data-default
-                   , haskell-src-exts
+                   , haskell-src-exts >= 1.15.0
                    , mtl
                    , text
 


### PR DESCRIPTION
Several items only present in newer versions of the library are used, so there really ought to be a lower bound.
