### PR TITLE
Add basic vim support via formatexpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,12 @@ called `.dir-locals.el` in the project root directory like this:
 
 ## Vim
 
-No support yet. Patches welcome.
+Basic support is provided through [vim/hindent.vim](https://github.com/chrisdone/hindent/blob/master/vim/hindent.vim),
+which sets hindent as the formatter used by `gq` for haskell files. The formatting style
+defaults to `fundamental` but can be configured by setting `g:hindent_style` to the desired style.
+
+Note that unlike in emacs you have to take care of selecting a sensible buffer region as input to
+hindent yourself.
 
 ## Contributing your own printer style
 

--- a/vim/hindent.vim
+++ b/vim/hindent.vim
@@ -1,0 +1,13 @@
+if exists("g:loaded_hindent") || !executable("hindent")
+    finish
+endif
+let g:loaded_hindent = 1
+
+if !exists("g:hindent_style")
+    let g:hindent_style = "fundamental"
+endif
+
+if has("autocmd")
+  let hindent = "hindent --style " . g:hindent_style
+  autocmd FileType haskell setlocal formatexpr=FormatprgLocal(hindent)
+endif


### PR DESCRIPTION
This adds basic vim support though use of formatexpr. Selecting sensible regions to be formatted is for now still up to the user.
