### PR TITLE
Fix J.Tibell style for record syntax: add line before '}'

### DIFF
--- a/src/HIndent/Styles/JohanTibell.hs
+++ b/src/HIndent/Styles/JohanTibell.hs
@@ -232,7 +232,6 @@ decl _ (PatBind _ pat mty rhs mbinds) =
     Nothing ->
       do pretty pat
          pretty rhs
-         indentSpaces <- getIndentSpaces
          case mbinds of
            Nothing -> return ()
            Just binds ->
@@ -386,5 +385,6 @@ recDecl (RecDecl _ name fields) =
             (do depend (write "{")
                        (prefixedLined ","
                                       (map (depend space . pretty) fields))
+                newline
                 write "} ")
 recDecl r = prettyNoExt r


### PR DESCRIPTION
https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md

``` haskell
data Person = Person
    { firstName :: !String  -- ^ First name
    , lastName  :: !String  -- ^ Last name
    , age       :: !Int     -- ^ Age
    } deriving (Eq, Show)
```
