### PR TITLE
mention vim-textobj-haskell in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ which sets hindent as the formatter used by `gq` for haskell files. The formatti
 defaults to `fundamental` but can be configured by setting `g:hindent_style` to the desired style.
 
 Note that unlike in emacs you have to take care of selecting a sensible buffer region as input to
-hindent yourself.
+hindent yourself. If that is too much trouble you can try [vim-textobj-haskell](https://github.com/gilligan/vim-textobj-haskell) which provides a text object for top level bindings.
 
 ## Contributing your own printer style
 


### PR DESCRIPTION
Not entirely sure if this is worth mentioning in the readme but I wrote a little vim plugin that provides a text object for haskell bindings which (i hope) is pretty useful for this plugin since now you can make single simple mapping to indent the current function just like you can with emacs. It depends on textobj-user and just generally is beyond the scope of hindent hence a separate plugin.
