### PR TITLE
Set base-4.7 as lower-bound for lib in cabal file.

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -25,7 +25,7 @@ library
                      HIndent.Styles.ChrisDone
                      HIndent.Styles.JohanTibell
                      HIndent.Styles.Gibiansky
-  build-depends:     base >= 4 && <5
+  build-depends:     base >= 4.7 && <5
                    , data-default
                    , haskell-src-exts == 1.15.*
                    , monad-loops


### PR DESCRIPTION
This hopefully fixes #23.
