### PR TITLE
Multiline comments preceeding items now printed in correct order

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -55,7 +55,7 @@ reformat style x =
                   -- For the time being, assume that all "free-floating" comments come at the beginning.
                   -- If they were not at the beginning, they would be after some ast node.
                   -- Thus, print them before going for the ast.
-                  (do mapM_ (printComment Nothing) cs
+                  (do mapM_ (printComment Nothing) (reverse cs)
                       pretty ast))
     ParseFailed _ e -> Left e
 

--- a/test/gibiansky/expected/20.exp
+++ b/test/gibiansky/expected/20.exp
@@ -1,0 +1,3 @@
+-- Comment 1
+-- Comment 2
+f x = x

--- a/test/gibiansky/tests/20.test
+++ b/test/gibiansky/tests/20.test
@@ -1,0 +1,3 @@
+-- Comment 1
+-- Comment 2
+f x = x


### PR DESCRIPTION
Issue summarized in the title. This is a pretty big issue and I don't know how it wasn't spotted earlier – I am fairly sure I introduced this bug a while ago. It appears in all styles when you have multiple comments preceding an item. (See the example tests, which are failing until this change.)
