### PR TITLE
Fixes comma position for data def. with records

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -97,6 +97,53 @@ instance C a where
     k p
 ```
 
+Data declarations
+
+```haskell
+data X
+  = X
+  | X'
+```
+
+```haskell
+data X
+  = X
+  | X'
+  deriving (Show)
+```
+
+```haskell
+data X = X
+  { x :: Int
+  }
+```
+
+```haskell
+data X = X
+  { x :: Int
+  } deriving (Show)
+```
+
+```haskell
+data X
+  = X { x :: Int}
+  | X'
+```
+
+```haskell
+data X = X
+  { x :: Int
+  , x' :: Int
+  }
+```
+
+```haskell
+data X
+  = X { x :: Int
+      , x' :: Int}
+  | X'
+```
+
 GADT declarations
 ```haskell
 data Ty :: (* -> *) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1783,7 +1783,7 @@ conDecl (RecDecl _ name fields) =
   depend (do pretty name
              write " ")
          (do depend (write "{")
-                    (prefixedLined ", "
+                    (prefixedLined ","
                                    (map (depend space . pretty) fields))
              write "}")
 conDecl x = case x of


### PR DESCRIPTION
Fixes #393

This is a blind fix. I don't know exactly what I changed there. I includes a test that fails with v5.2.2.