### PR TITLE
Align :: with -> in multiline type sigs

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -351,17 +351,17 @@ foo :: $([t|Bool|]) -> a
 Long argument list should line break
 
 ```haskell
-longLongFunction ::
-     ReaderT r (WriterT w (StateT s m)) a
+longLongFunction
+  :: ReaderT r (WriterT w (StateT s m)) a
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
-Class constraints should leave `::` on same line
+Consistency for type signatures with class constraints
 
 ``` haskell
 -- see https://github.com/chrisdone/hindent/pull/266#issuecomment-244182805
-fun ::
-     (Class a, Class b)
+fun
+  :: (Class a, Class b)
   => fooooooooooo bar mu zot
   -> fooooooooooo bar mu zot
   -> c
@@ -836,8 +836,8 @@ c :: forall new.
   => Book' new
 c = set #pitch C (def :: Book' (Map.AsMap (new Map.:\ "pitch")))
 
-foo ::
-     ( Foooooooooooooooooooooooooooooooooooooooooo
+foo
+  :: ( Foooooooooooooooooooooooooooooooooooooooooo
      , Foooooooooooooooooooooooooooooooooooooooooo
      )
   => A
@@ -1124,8 +1124,8 @@ expipiplus1 Always break before `::` on overlong signatures #390
 fun :: Is => Short
 fun = undefined
 
-someFunctionSignature ::
-     Wiiiiiiiiiiiiiiiiith
+someFunctionSignature
+  :: Wiiiiiiiiiiiiiiiiith
   -> Enough
   -> (Arguments -> To ())
   -> Overflow (The Line Limit)
@@ -1148,8 +1148,8 @@ ocharles Type application differs from function application (leading to long lin
 
 ```haskell
 -- https://github.com/commercialhaskell/hindent/issues/359
-thing ::
-     ( ResB.BomEx
+thing
+  :: ( ResB.BomEx
      , Maybe [( Entity BomSnapshot
               , ( [ResBS.OrderSubstituteAggr]
                 , ( Maybe (Entity BomSnapshotHistory)

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1843,9 +1843,8 @@ decl' (TypeSig _ names ty') = do
       commas (map prettyTopName names)
       indentSpaces <- getIndentSpaces
       if allNamesLength >= indentSpaces
-        then do write " ::"
-                newline
-                indented indentSpaces (depend (write "   ") (declTy ty'))
+        then do newline
+                indented indentSpaces (depend (write ":: ") (declTy ty'))
         else (depend (write " :: ") (declTy ty'))
     Just st -> put st
   where


### PR DESCRIPTION
This seems to be the prevailing style in Haskell code in the wild.