### PR TITLE
Make hindent source use hindent

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -1,29 +1,28 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE OverloadedStrings, TupleSections, ScopedTypeVariables, PatternGuards #-}
+{-# LANGUAGE OverloadedStrings, TupleSections, ScopedTypeVariables,
+  PatternGuards #-}
 
 -- | Haskell indenter.
-
 module HIndent
-  (-- * Formatting functions.
-   reformat
-  ,prettyPrint
-  ,parseMode
+   -- * Formatting functions.
+  ( reformat
+  , prettyPrint
+  , parseMode
   -- * Testing
-  ,test
-  ,testFile
-  ,testAst
-  ,testFileAst
-  ,defaultExtensions
-  ,getExtensions
-  )
-  where
+  , test
+  , testFile
+  , testAst
+  , testFileAst
+  , defaultExtensions
+  , getExtensions
+  ) where
 
-import           Control.Monad.State.Strict
-import           Control.Monad.Trans.Maybe
-import           Data.ByteString (ByteString)
+import Control.Monad.State.Strict
+import Control.Monad.Trans.Maybe
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as S
-import           Data.ByteString.Builder (Builder)
+import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Internal as S
@@ -31,122 +30,127 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.ByteString.Unsafe as S
-import           Data.Char
-import           Data.Either
-import           Data.Function
-import           Data.Functor.Identity
-import           Data.List
-import           Data.Maybe
-import           Data.Monoid
-import           Data.Text (Text)
+import Data.Char
+import Data.Either
+import Data.Function
+import Data.Functor.Identity
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Data.Text (Text)
 import qualified Data.Text as T
-import           Data.Traversable hiding (mapM)
-import           HIndent.Pretty
-import           HIndent.Types
+import Data.Traversable hiding (mapM)
+import HIndent.Pretty
+import HIndent.Types
 import qualified Language.Haskell.Exts as Exts
-import           Language.Haskell.Exts hiding (Style, prettyPrint, Pretty, style, parse)
-import           Prelude
+import Language.Haskell.Exts
+       hiding (Pretty, Style, parse, prettyPrint, style)
+import Prelude
 
 -- | A block of code.
 data CodeBlock
-    = Shebang ByteString
-    | HaskellSource Int ByteString
+  = Shebang ByteString
+  | HaskellSource Int
+                  ByteString
     -- ^ Includes the starting line (indexed from 0) for error reporting
-    | CPPDirectives ByteString
-     deriving (Show, Eq)
+  | CPPDirectives ByteString
+  deriving (Show, Eq)
 
 -- | Format the given source.
-reformat :: Config -> Maybe [Extension] -> Maybe FilePath -> ByteString -> Either String Builder
+reformat ::
+     Config
+  -> Maybe [Extension]
+  -> Maybe FilePath
+  -> ByteString
+  -> Either String Builder
 reformat config mexts mfilepath =
-    preserveTrailingNewline
-        (fmap (mconcat . intersperse "\n") . mapM processBlock . cppSplitBlocks)
+  preserveTrailingNewline
+    (fmap (mconcat . intersperse "\n") . mapM processBlock . cppSplitBlocks)
   where
     processBlock :: CodeBlock -> Either String Builder
     processBlock (Shebang text) = Right $ S.byteString text
     processBlock (CPPDirectives text) = Right $ S.byteString text
     processBlock (HaskellSource line text) =
-        let ls = S8.lines text
-            prefix = findPrefix ls
-            code = unlines' (map (stripPrefix prefix) ls)
-            exts = readExtensions (UTF8.toString code)
-            mode'' = case exts of
-                       Nothing -> mode'
-                       Just (Nothing, exts') ->
-                         mode' { extensions = exts' ++ extensions mode' }
-                       Just (Just lang, exts') ->
-                         mode' { baseLanguage = lang
-                               , extensions = exts' ++ extensions mode' }
-        in case parseModuleWithComments mode'' (UTF8.toString code) of
-               ParseOk (m, comments) ->
-                   fmap
-                       (S.lazyByteString . addPrefix prefix . S.toLazyByteString)
-                       (prettyPrint config m comments)
-               ParseFailed loc e ->
-                 Left (Exts.prettyPrint (loc {srcLine = srcLine loc + line}) ++ ": " ++ e)
+      let ls = S8.lines text
+          prefix = findPrefix ls
+          code = unlines' (map (stripPrefix prefix) ls)
+          exts = readExtensions (UTF8.toString code)
+          mode'' =
+            case exts of
+              Nothing -> mode'
+              Just (Nothing, exts') ->
+                mode' {extensions = exts' ++ extensions mode'}
+              Just (Just lang, exts') ->
+                mode'
+                {baseLanguage = lang, extensions = exts' ++ extensions mode'}
+      in case parseModuleWithComments mode'' (UTF8.toString code) of
+           ParseOk (m, comments) ->
+             fmap
+               (S.lazyByteString . addPrefix prefix . S.toLazyByteString)
+               (prettyPrint config m comments)
+           ParseFailed loc e ->
+             Left
+               (Exts.prettyPrint (loc {srcLine = srcLine loc + line}) ++
+                ": " ++ e)
     unlines' = S.concat . intersperse "\n"
     unlines'' = L.concat . intersperse "\n"
     addPrefix :: ByteString -> L8.ByteString -> L8.ByteString
     addPrefix prefix = unlines'' . map (L8.fromStrict prefix <>) . L8.lines
     stripPrefix :: ByteString -> ByteString -> ByteString
     stripPrefix prefix line =
-        if S.null (S8.dropWhile (== '\n') line)
-            then line
-            else fromMaybe (error "Missing expected prefix") . s8_stripPrefix prefix $
-                 line
+      if S.null (S8.dropWhile (== '\n') line)
+        then line
+        else fromMaybe (error "Missing expected prefix") . s8_stripPrefix prefix $
+             line
     findPrefix :: [ByteString] -> ByteString
     findPrefix = takePrefix False . findSmallestPrefix . dropNewlines
     dropNewlines :: [ByteString] -> [ByteString]
     dropNewlines = filter (not . S.null . S8.dropWhile (== '\n'))
     takePrefix :: Bool -> ByteString -> ByteString
     takePrefix bracketUsed txt =
-        case S8.uncons txt of
-            Nothing -> ""
-            Just ('>', txt') ->
-                if not bracketUsed
-                    then S8.cons '>' (takePrefix True txt')
-                    else ""
-            Just (c, txt') ->
-                if c == ' ' || c == '\t'
-                    then S8.cons c (takePrefix bracketUsed txt')
-                    else ""
+      case S8.uncons txt of
+        Nothing -> ""
+        Just ('>', txt') ->
+          if not bracketUsed
+            then S8.cons '>' (takePrefix True txt')
+            else ""
+        Just (c, txt') ->
+          if c == ' ' || c == '\t'
+            then S8.cons c (takePrefix bracketUsed txt')
+            else ""
     findSmallestPrefix :: [ByteString] -> ByteString
     findSmallestPrefix [] = ""
     findSmallestPrefix ("":_) = ""
     findSmallestPrefix (p:ps) =
-        let first = S8.head p
-            startsWithChar c x = S8.length x > 0 && S8.head x == c
-        in if all (startsWithChar first) ps
-               then S8.cons
-                        first
-                        (findSmallestPrefix (S.tail p : map S.tail ps))
-               else ""
+      let first = S8.head p
+          startsWithChar c x = S8.length x > 0 && S8.head x == c
+      in if all (startsWithChar first) ps
+           then S8.cons first (findSmallestPrefix (S.tail p : map S.tail ps))
+           else ""
     mode' =
-        let m = case mexts of
-                  Just exts ->
-                    parseMode
-                    { extensions = exts
-                    }
-                  Nothing -> parseMode
-        in m { parseFilename = fromMaybe "<interactive>" mfilepath }
+      let m =
+            case mexts of
+              Just exts -> parseMode {extensions = exts}
+              Nothing -> parseMode
+      in m {parseFilename = fromMaybe "<interactive>" mfilepath}
     preserveTrailingNewline f x =
-        if S8.null x || S8.all isSpace x
-            then return mempty
-            else if hasTrailingLine x || configTrailingNewline config
-                     then fmap
-                              (\x' ->
-                                    if hasTrailingLine
-                                           (L.toStrict (S.toLazyByteString x'))
-                                        then x'
-                                        else x' <> "\n")
-                              (f x)
-                     else f x
+      if S8.null x || S8.all isSpace x
+        then return mempty
+        else if hasTrailingLine x || configTrailingNewline config
+               then fmap
+                      (\x' ->
+                         if hasTrailingLine (L.toStrict (S.toLazyByteString x'))
+                           then x'
+                           else x' <> "\n")
+                      (f x)
+               else f x
 
 -- | Does the strict bytestring have a trailing newline?
 hasTrailingLine :: ByteString -> Bool
 hasTrailingLine xs =
-    if S8.null xs
-        then False
-        else S8.last xs == '\n'
+  if S8.null xs
+    then False
+    else S8.last xs == '\n'
 
 -- | Break a Haskell code string into chunks, using CPP as a delimiter.
 -- Lines that start with '#if', '#end', or '#else' are their own chunks, and
@@ -176,7 +180,16 @@ cppSplitBlocks inp =
     cppLine src =
       any
         (`S8.isPrefixOf` src)
-        ["#if", "#end", "#else", "#define", "#undef", "#elif", "#include", "#error", "#warning"]
+        [ "#if"
+        , "#end"
+        , "#else"
+        , "#define"
+        , "#undef"
+        , "#elif"
+        , "#include"
+        , "#error"
+        , "#warning"
+        ]
         -- Note: #ifdef and #ifndef are handled by #if
     unlines' :: [(Int, ByteString)] -> (Int, ByteString)
     unlines' [] = (0, S.empty)
@@ -203,17 +216,12 @@ cppSplitBlocks inp =
     inBlock f (HaskellSource line txt) = HaskellSource line (f txt)
     inBlock _ dir = dir
 
-
 -- | Print the module.
-prettyPrint :: Config
-            -> Module SrcSpanInfo
-            -> [Comment]
-            -> Either a Builder
+prettyPrint :: Config -> Module SrcSpanInfo -> [Comment] -> Either a Builder
 prettyPrint config m comments =
   let ast =
         evalState
-          (collectAllComments
-             (fromMaybe m (applyFixities baseFixities m)))
+          (collectAllComments (fromMaybe m (applyFixities baseFixities m)))
           comments
   in Right (runPrinterStyle config (pretty ast))
 
@@ -241,21 +249,19 @@ runPrinterStyle config m =
 
 -- | Parse mode, includes all extensions, doesn't assume any fixities.
 parseMode :: ParseMode
-parseMode =
-  defaultParseMode {extensions = allExtensions
-                   ,fixities = Nothing}
-  where allExtensions =
-          filter isDisabledExtension knownExtensions
-        isDisabledExtension (DisableExtension _) = False
-        isDisabledExtension _ = True
+parseMode = defaultParseMode {extensions = allExtensions, fixities = Nothing}
+  where
+    allExtensions = filter isDisabledExtension knownExtensions
+    isDisabledExtension (DisableExtension _) = False
+    isDisabledExtension _ = True
 
 -- | Test the given file.
 testFile :: FilePath -> IO ()
-testFile fp  = S.readFile fp >>= test
+testFile fp = S.readFile fp >>= test
 
 -- | Test the given file.
 testFileAst :: FilePath -> IO ()
-testFileAst fp  = S.readFile fp >>= print . testAst
+testFileAst fp = S.readFile fp >>= print . testAst
 
 -- | Test with the given style, prints to stdout.
 test :: ByteString -> IO ()
@@ -267,7 +273,7 @@ test =
 testAst :: ByteString -> Either String (Module NodeInfo)
 testAst x =
   case parseModuleWithComments parseMode (UTF8.toString x) of
-    ParseOk (m,comments) ->
+    ParseOk (m, comments) ->
       Right
         (let ast =
                evalState
@@ -280,68 +286,68 @@ testAst x =
 -- | Default extensions.
 defaultExtensions :: [Extension]
 defaultExtensions =
-  [ e
-  | e@EnableExtension {} <- knownExtensions ] \\
+  [e | e@EnableExtension {} <- knownExtensions] \\
   map EnableExtension badExtensions
 
 -- | Extensions which steal too much syntax.
 badExtensions :: [KnownExtension]
 badExtensions =
-    [Arrows -- steals proc
-    ,TransformListComp -- steals the group keyword
-    ,XmlSyntax, RegularPatterns -- steals a-b
-    ,UnboxedTuples -- breaks (#) lens operator
+  [ Arrows -- steals proc
+  , TransformListComp -- steals the group keyword
+  , XmlSyntax
+  , RegularPatterns -- steals a-b
+  , UnboxedTuples -- breaks (#) lens operator
     -- ,QuasiQuotes -- breaks [x| ...], making whitespace free list comps break
-    ,PatternSynonyms -- steals the pattern keyword
-    ,RecursiveDo -- steals the rec keyword
-    ,DoRec -- same
-    ,TypeApplications -- since GHC 8 and haskell-src-exts-1.19
-    ]
-
+  , PatternSynonyms -- steals the pattern keyword
+  , RecursiveDo -- steals the rec keyword
+  , DoRec -- same
+  , TypeApplications -- since GHC 8 and haskell-src-exts-1.19
+  ]
 
 s8_stripPrefix :: ByteString -> ByteString -> Maybe ByteString
 s8_stripPrefix bs1@(S.PS _ _ l1) bs2
-   | bs1 `S.isPrefixOf` bs2 = Just (S.unsafeDrop l1 bs2)
-   | otherwise = Nothing
+  | bs1 `S.isPrefixOf` bs2 = Just (S.unsafeDrop l1 bs2)
+  | otherwise = Nothing
 
 --------------------------------------------------------------------------------
 -- Extensions stuff stolen from hlint
-
 -- | Consume an extensions list from arguments.
 getExtensions :: [Text] -> [Extension]
 getExtensions = foldl f defaultExtensions . map T.unpack
-  where f _ "Haskell98" = []
-        f a ('N':'o':x)
-          | Just x' <- readExtension x =
-            delete x' a
-        f a x
-          | Just x' <- readExtension x =
-            x' :
-            delete x' a
-        f _ x = error $ "Unknown extension: " ++ x
+  where
+    f _ "Haskell98" = []
+    f a ('N':'o':x)
+      | Just x' <- readExtension x = delete x' a
+    f a x
+      | Just x' <- readExtension x = x' : delete x' a
+    f _ x = error $ "Unknown extension: " ++ x
 
 -- | Parse an extension.
 readExtension :: String -> Maybe Extension
 readExtension x =
   case classifyExtension x -- Foo
-       of
+        of
     UnknownExtension _ -> Nothing
     x' -> Just x'
 
 --------------------------------------------------------------------------------
 -- Comments
-
 -- | Traverse the structure backwards.
-traverseInOrder
-  :: (Monad m, Traversable t, Functor m)
-  => (b -> b -> Ordering) -> (b -> m b) -> t b -> m (t b)
+traverseInOrder ::
+     (Monad m, Traversable t, Functor m)
+  => (b -> b -> Ordering)
+  -> (b -> m b)
+  -> t b
+  -> m (t b)
 traverseInOrder cmp f ast = do
   indexed <-
-    fmap (zip [0 :: Integer ..] . reverse) (execStateT (traverse (modify . (:)) ast) [])
-  let sorted = sortBy (\(_,x) (_,y) -> cmp x y) indexed
+    fmap
+      (zip [0 :: Integer ..] . reverse)
+      (execStateT (traverse (modify . (:)) ast) [])
+  let sorted = sortBy (\(_, x) (_, y) -> cmp x y) indexed
   results <-
     mapM
-      (\(i,m) -> do
+      (\(i, m) -> do
          v <- f m
          return (i, v))
       sorted
@@ -367,7 +373,7 @@ collectAllComments =
           (<>)
           CommentAfterLine
           (\nodeSpan commentSpan ->
-              fst (srcSpanStart commentSpan) >= fst (srcSpanEnd nodeSpan)))) <=<
+             fst (srcSpanStart commentSpan) >= fst (srcSpanEnd nodeSpan)))) <=<
   shortCircuit
     (traverse
      -- Collect forwards comments which start at the end line of a
@@ -377,7 +383,7 @@ collectAllComments =
           (<>)
           CommentSameLine
           (\nodeSpan commentSpan ->
-              fst (srcSpanStart commentSpan) == fst (srcSpanEnd nodeSpan)))) <=<
+             fst (srcSpanStart commentSpan) == fst (srcSpanEnd nodeSpan)))) <=<
   shortCircuit
     (traverseBackwards
      -- Collect backwards comments which are on the same line as a
@@ -387,8 +393,8 @@ collectAllComments =
           (<>)
           CommentSameLine
           (\nodeSpan commentSpan ->
-              fst (srcSpanStart commentSpan) == fst (srcSpanStart nodeSpan) &&
-              fst (srcSpanStart commentSpan) == fst (srcSpanEnd nodeSpan)))) <=<
+             fst (srcSpanStart commentSpan) == fst (srcSpanStart nodeSpan) &&
+             fst (srcSpanStart commentSpan) == fst (srcSpanEnd nodeSpan)))) <=<
   shortCircuit
     (traverse
      -- First, collect forwards comments for declarations which both
@@ -397,9 +403,9 @@ collectAllComments =
           (<>)
           CommentBeforeLine
           (\nodeSpan commentSpan ->
-              (snd (srcSpanStart nodeSpan) == 1 &&
-               snd (srcSpanStart commentSpan) == 1) &&
-              fst (srcSpanStart commentSpan) < fst (srcSpanStart nodeSpan)))) .
+             (snd (srcSpanStart nodeSpan) == 1 &&
+              snd (srcSpanStart commentSpan) == 1) &&
+             fst (srcSpanStart commentSpan) < fst (srcSpanStart nodeSpan)))) .
   fmap nodify
   where
     nodify s = NodeInfo s mempty
@@ -417,8 +423,8 @@ collectAllComments =
 -- | Collect comments by satisfying the given predicate, to collect a
 -- comment means to remove it from the pool of available comments in
 -- the State. This allows for a multiple pass approach.
-collectCommentsBy
-  :: ([NodeComment] -> [NodeComment] -> [NodeComment])
+collectCommentsBy ::
+     ([NodeComment] -> [NodeComment] -> [NodeComment])
   -> (SrcSpan -> SomeComment -> NodeComment)
   -> (SrcSpan -> SrcSpan -> Bool)
   -> NodeInfo
@@ -429,23 +435,17 @@ collectCommentsBy append cons predicate nodeInfo@(NodeInfo (SrcSpanInfo nodeSpan
         partitionEithers
           (map
              (\comment@(Comment multiLine commentSpan commentString) ->
-                 if predicate nodeSpan (setFilename commentString commentSpan)
-                   then Right
-                          (cons
-                             commentSpan
-                             ((if multiLine
-                                 then MultiLine
-                                 else EndOfLine)
-                                commentString))
-                   else Left comment)
+                if predicate nodeSpan (setFilename commentString commentSpan)
+                  then Right
+                         (cons
+                            commentSpan
+                            ((if multiLine
+                                then MultiLine
+                                else EndOfLine)
+                               commentString))
+                  else Left comment)
              comments)
   put others
-  return
-    (nodeInfo
-     { nodeInfoComments = append (nodeInfoComments nodeInfo) mine
-     })
+  return (nodeInfo {nodeInfoComments = append (nodeInfoComments nodeInfo) mine})
   where
-    setFilename cs sp =
-      sp
-      { srcSpanFilename = cs
-      }
+    setFilename cs sp = sp {srcSpanFilename = cs}

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TupleSections        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 -- | Pretty printing.
 
@@ -14,19 +14,19 @@ module HIndent.Pretty
   where
 
 import           Control.Applicative
-import           Control.Monad.State.Strict hiding (state)
-import qualified Data.ByteString.Builder as S
-import           Data.Foldable (for_, traverse_)
+import           Control.Monad.State.Strict   hiding (state)
+import qualified Data.ByteString.Builder      as S
+import           Data.Foldable                (for_, traverse_)
 import           Data.Int
 import           Data.List
 import           Data.Maybe
-import           Data.Monoid ((<>))
+import           Data.Monoid                  ((<>))
 import           Data.Typeable
 import           HIndent.Types
-import qualified Language.Haskell.Exts as P
+import qualified Language.Haskell.Exts        as P
 import           Language.Haskell.Exts.SrcLoc
 import           Language.Haskell.Exts.Syntax
-import           Prelude hiding (exp)
+import           Prelude                      hiding (exp)
 
 --------------------------------------------------------------------------------
 -- * Pretty printing class
@@ -360,11 +360,11 @@ instance Pretty Pat where
       PTuple _ boxed pats ->
         depend (write (case boxed of
                          Unboxed -> "(# "
-                         Boxed -> "("))
+                         Boxed   -> "("))
                (do commas (map pretty pats)
                    write (case boxed of
                             Unboxed -> " #)"
-                            Boxed -> ")"))
+                            Boxed   -> ")"))
       PList _ ps ->
         brackets (commas (map pretty ps))
       PParen _ e -> parens (pretty e)
@@ -417,7 +417,7 @@ instance Pretty Pat where
 
 -- | Pretty infix application of a name (identifier or symbol).
 prettyInfixName :: Name NodeInfo -> Printer ()
-prettyInfixName (Ident _ n) = do write "`"; string n; write "`";
+prettyInfixName (Ident _ n)  = do write "`"; string n; write "`";
 prettyInfixName (Symbol _ s) = string s
 
 -- | Pretty print a name for being an infix operator.
@@ -426,7 +426,7 @@ prettyInfixOp x =
   case x of
     Qual _ mn n ->
       case n of
-        Ident _ i -> do write "`"; pretty mn; write "."; string i; write "`";
+        Ident _ i  -> do write "`"; pretty mn; write "."; string i; write "`";
         Symbol _ s -> do pretty mn; write "."; string s;
     UnQual _ n -> prettyInfixName n
     Special _ s -> pretty s
@@ -434,7 +434,7 @@ prettyInfixOp x =
 prettyQuoteName :: Name NodeInfo -> Printer ()
 prettyQuoteName x =
   case x of
-    Ident _ i -> string i
+    Ident _ i  -> string i
     Symbol _ s -> string ("(" ++ s ++ ")")
 
 prettyQuoteQName :: QName NodeInfo -> Printer ()
@@ -442,11 +442,11 @@ prettyQuoteQName x =
   case x of
     Qual _ mn n ->
       case n of
-        Ident _ i -> do pretty mn; write "."; string i;
+        Ident _ i  -> do pretty mn; write "."; string i;
         Symbol _ s -> do write "("; pretty mn; write "."; string s; write ")";
     UnQual _ n ->
       case n of
-        Ident _ i -> string i
+        Ident _ i  -> string i
         Symbol _ s -> do write "("; string s; write ")";
     Special _ s -> pretty s
 
@@ -483,9 +483,9 @@ exp (Tuple _ boxed exps) = do
     Nothing -> verVariant
     Just st -> put st
   where
-    parensHorB Boxed = parens
+    parensHorB Boxed   = parens
     parensHorB Unboxed = wrap "(# " " #)"
-    parensVerB Boxed = parens
+    parensVerB Boxed   = parens
     parensVerB Unboxed = wrap "(#" "#)"
 -- | Space out tuples.
 exp (TupleSection _ boxed mexps) = do
@@ -497,9 +497,9 @@ exp (TupleSection _ boxed mexps) = do
     Nothing -> verVariant
     Just st -> put st
   where
-    parensHorB Boxed = parens
+    parensHorB Boxed   = parens
     parensHorB Unboxed = wrap "(# " " #)"
-    parensVerB Boxed = parens
+    parensVerB Boxed   = parens
     parensVerB Unboxed = wrap "(#" "#)"
 -- | Infix apps, same algorithm as ChrisDone at the moment.
 exp e@(InfixApp _ a op b) =
@@ -614,9 +614,9 @@ exp (NegApp _ e) =
 exp (Lambda _ ps e) = do
   write "\\"
   spaced [ do case (i, x) of
-                (0, PIrrPat {}) -> space
+                (0, PIrrPat {})  -> space
                 (0, PBangPat {}) -> space
-                _ -> return ()
+                _                -> return ()
               pretty x
          | (i, x) <- zip [0 :: Int ..] ps
          ]
@@ -711,16 +711,16 @@ exp (MultiIf _ alts) =
       swing (write " " >> rhsSeparator) (pretty e)
 exp (Lit _ lit) = prettyInternal lit
 exp (Var _ q) = case q of
-                  Special _ Cons{} -> parens (pretty q)
+                  Special _ Cons{}      -> parens (pretty q)
                   Qual _ _ (Symbol _ _) -> parens (pretty q)
                   UnQual _ (Symbol _ _) -> parens (pretty q)
-                  _ -> pretty q
+                  _                     -> pretty q
 exp (IPVar _ q) = pretty q
 exp (Con _ q) = case q of
-                  Special _ Cons{} -> parens (pretty q)
+                  Special _ Cons{}      -> parens (pretty q)
                   Qual _ _ (Symbol _ _) -> parens (pretty q)
                   UnQual _ (Symbol _ _) -> parens (pretty q)
-                  _ -> pretty q
+                  _                     -> pretty q
 
 exp x@XTag{} = pretty' x
 exp x@XETag{} = pretty' x
@@ -822,7 +822,7 @@ decl (TypeFamDecl _ declhead result injectivity) = do
     Just r -> do
       space
       let sep = case r of
-                  KindSig _ _ -> "::"
+                  KindSig _ _  -> "::"
                   TyVarSig _ _ -> "="
       write sep
       space
@@ -839,7 +839,7 @@ decl (ClosedTypeFamDecl _ declhead result injectivity instances) = do
   for_ result $ \r -> do
     space
     let sep = case r of
-                KindSig _ _ -> "::"
+                KindSig _ _  -> "::"
                 TyVarSig _ _ -> "="
     write sep
     space
@@ -857,9 +857,9 @@ decl (DataDecl _ dataornew ctx dhead condecls mderivs) =
             (withCtx ctx
                      (do pretty dhead
                          case condecls of
-                           [] -> return ()
+                           []  -> return ()
                            [x] -> singleCons x
-                           xs -> multiCons xs))
+                           xs  -> multiCons xs))
      indentSpaces <- getIndentSpaces
      case mderivs of
        Nothing -> return ()
@@ -907,8 +907,8 @@ decl (InlineSig _ inline active name) = do
   unless inline $ write "NO"
   write "INLINE "
   case active of
-    Nothing -> return ()
-    Just (ActiveFrom _ x) -> write ("[" ++ show x ++ "] ")
+    Nothing                -> return ()
+    Just (ActiveFrom _ x)  -> write ("[" ++ show x ++ "] ")
     Just (ActiveUntil _ x) -> write ("[~" ++ show x ++ "] ")
   prettyQuoteQName name
 
@@ -957,11 +957,11 @@ instance Pretty Deriving where
               else heads
       maybeDerives <- fitsOnOneLine $ parens (commas (map pretty heads'))
       case maybeDerives of
-        Nothing -> formatMultiLine heads'
+        Nothing      -> formatMultiLine heads'
         Just derives -> put derives
     where
       stripParens (IParen _ iRule) = stripParens iRule
-      stripParens x = x
+      stripParens x                = x
       formatMultiLine derives = do
         depend (write "( ") $ prefixedLined ", " (map pretty derives)
         newline
@@ -1014,13 +1014,13 @@ instance Pretty Asst where
 instance Pretty BangType where
   prettyInternal x =
     case x of
-      BangedTy _ -> write "!"
-      LazyTy _ -> write "~"
+      BangedTy _      -> write "!"
+      LazyTy _        -> write "~"
       NoStrictAnnot _ -> return ()
 
 instance Pretty Unpackedness where
-  prettyInternal (Unpack _) = write "{-# UNPACK #-}"
-  prettyInternal (NoUnpack _) = write "{-# NOUNPACK #-}"
+  prettyInternal (Unpack _)         = write "{-# UNPACK #-}"
+  prettyInternal (NoUnpack _)       = write "{-# NOUNPACK #-}"
   prettyInternal (NoUnpackPragma _) = return ()
 
 instance Pretty Binds where
@@ -1239,8 +1239,8 @@ instance Pretty DeclHead where
                    pretty var)
 
 instance Pretty Overlap where
-  prettyInternal (Overlap _) = write "{-# OVERLAP #-}"
-  prettyInternal (NoOverlap _) = write "{-# NO_OVERLAP #-}"
+  prettyInternal (Overlap _)    = write "{-# OVERLAP #-}"
+  prettyInternal (NoOverlap _)  = write "{-# NO_OVERLAP #-}"
   prettyInternal (Incoherent _) = write "{-# INCOHERENT #-}"
 
 instance Pretty Sign where
@@ -1262,7 +1262,7 @@ instance Pretty Module where
                                  else Just r)
                            [(null pragmas,inter newline (map pretty pragmas))
                            ,(case mayModHead of
-                               Nothing -> (True,return ())
+                               Nothing      -> (True,return ())
                                Just modHead -> (False,pretty modHead))
                            ,(null imps,formatImports imps)
                            ,(null decls
@@ -1433,12 +1433,12 @@ instance Pretty BooleanFormula where
   prettyInternal (AndFormula _ fs) = do
       maybeFormulas <- fitsOnOneLine $ inter (write ", ") $ map pretty fs
       case maybeFormulas of
-        Nothing -> prefixedLined ", " (map pretty fs)
+        Nothing       -> prefixedLined ", " (map pretty fs)
         Just formulas -> put formulas
   prettyInternal (OrFormula _ fs) = do
       maybeFormulas <- fitsOnOneLine $ inter (write " | ") $ map pretty fs
       case maybeFormulas of
-        Nothing -> prefixedLined "| " (map pretty fs)
+        Nothing       -> prefixedLined "| " (map pretty fs)
         Just formulas -> put formulas
   prettyInternal (ParenFormula _ f) = parens $ pretty f
 
@@ -1455,7 +1455,7 @@ instance Pretty Kind where
   prettyInternal = pretty'
 
 instance Pretty ResultSig where
-  prettyInternal (KindSig _ kind) = pretty kind
+  prettyInternal (KindSig _ kind)       = pretty kind
   prettyInternal (TyVarSig _ tyVarBind) = pretty tyVarBind
 
 instance Pretty Literal where
@@ -1485,7 +1485,7 @@ instance Pretty Literal where
 
 instance Pretty Name where
   prettyInternal x = case x of
-                          Ident _ _ -> pretty' x -- Identifiers.
+                          Ident _ _  -> pretty' x -- Identifiers.
                           Symbol _ s -> string s -- Symbols
 
 instance Pretty QName where
@@ -1673,7 +1673,7 @@ guardedRhs (GuardedRhs _ stmts e) = do
                 pretty e)
         case mst' of
           Just st' -> put st'
-          Nothing -> swingIt
+          Nothing  -> swingIt
       Nothing -> do
         printStmts
         swingIt
@@ -1756,16 +1756,16 @@ typ (TyCon _ p) =
   case p of
     Qual _ _ name ->
       case name of
-        Ident _ _ -> pretty p
+        Ident _ _  -> pretty p
         Symbol _ _ -> parens (pretty p)
     UnQual _ name ->
       case name of
-        Ident _ _ -> pretty p
+        Ident _ _  -> pretty p
         Symbol _ _ -> parens (pretty p)
     Special _ con ->
       case con of
         FunCon _ -> parens (pretty p)
-        _ -> pretty p
+        _        -> pretty p
 typ (TyParen _ e) = parens (pretty e)
 typ (TyInfix _ a op b) = do
   -- Apply special rules to line-break operators.
@@ -1821,7 +1821,7 @@ typ (TyQuasiQuote _ n s) =
                        write "|"))
 
 prettyTopName :: Name NodeInfo -> Printer ()
-prettyTopName x@Ident{} = pretty x
+prettyTopName x@Ident{}  = pretty x
 prettyTopName x@Symbol{} = parens $ pretty x
 
 -- | Specially format records. Indent where clauses only 2 spaces.
@@ -1849,7 +1849,7 @@ decl' (TypeSig _ names ty') = do
         else (depend (write " :: ") (declTy ty'))
     Just st -> put st
   where
-    nameLength (Ident _ s) = length s
+    nameLength (Ident _ s)  = length s
     nameLength (Symbol _ s) = length s + 2
     allNamesLength = fromIntegral $ sum (map nameLength names) + 2 * (length names - 1)
 
@@ -1868,7 +1868,7 @@ decl' (DataDecl _ dataornew ctx dhead [con] mderivs)
                        (do pretty dhead
                            singleCons con))
        case mderivs of
-         Nothing -> return ()
+         Nothing     -> return ()
          Just derivs -> space >> pretty derivs
   where singleCons x =
           depend (write " =")
@@ -1919,19 +1919,19 @@ declTy dty =
     _ -> prettyTy False dty
   where
     collapseFaps (TyFun _ arg result) = arg : collapseFaps result
-    collapseFaps e = [e]
+    collapseFaps e                    = [e]
     prettyTy breakLine ty = do
       if breakLine
         then
           case collapseFaps ty of
-            [] -> pretty ty
+            []  -> pretty ty
             tys -> prefixedLined "-> " (map pretty tys)
         else do
           mst <- fitsOnOneLine (pretty ty)
           case mst of
             Nothing ->
               case collapseFaps ty of
-                [] -> pretty ty
+                []  -> pretty ty
                 tys -> prefixedLined "-> " (map pretty tys)
             Just st -> put st
 
@@ -1999,7 +1999,7 @@ recUpdateExpr expWriter updates = do
 -- | Is the decl a record?
 isRecord :: QualConDecl t -> Bool
 isRecord (QualConDecl _ _ _ RecDecl{}) = True
-isRecord _ = False
+isRecord _                             = False
 
 -- | If the given operator is an element of line breaks in configuration.
 isLineBreak :: QName NodeInfo -> Printer Bool
@@ -2054,7 +2054,7 @@ infixApp e a op b indent =
     hor =
       spaced
         [ case link of
-          OpChainExp e' -> pretty e'
+          OpChainExp e'   -> pretty e'
           OpChainLink qop -> pretty qop
         | link <- flattenOpChain e
         ]
@@ -2080,7 +2080,7 @@ infixApp e a op b indent =
     prettyWithIndent e' =
       case e' of
         InfixApp _ a' op' b' -> infixApp e' a' op' b' indent
-        _ -> pretty e'
+        _                    -> pretty e'
 
 -- | A link in a chain of operator applications.
 data OpChainLink l

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -6,33 +6,38 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- | All types.
-
 module HIndent.Types
-  (Printer(..)
-  ,PrintState(..)
-  ,Config(..)
-  ,defaultConfig
-  ,NodeInfo(..)
-  ,NodeComment(..)
-  ,SomeComment(..)
+  ( Printer(..)
+  , PrintState(..)
+  , Config(..)
+  , defaultConfig
+  , NodeInfo(..)
+  , NodeComment(..)
+  , SomeComment(..)
   ) where
 
-import           Control.Applicative
-import           Control.Monad
-import           Control.Monad.State.Strict (MonadState(..),StateT)
-import           Control.Monad.Trans.Maybe
-import           Data.ByteString.Builder
-import           Data.Functor.Identity
-import           Data.Int (Int64)
-import           Data.Maybe
-import           Data.Yaml (FromJSON(..))
+import Control.Applicative
+import Control.Monad
+import Control.Monad.State.Strict (MonadState(..), StateT)
+import Control.Monad.Trans.Maybe
+import Data.ByteString.Builder
+import Data.Functor.Identity
+import Data.Int (Int64)
+import Data.Maybe
+import Data.Yaml (FromJSON(..))
 import qualified Data.Yaml as Y
-import           Language.Haskell.Exts.SrcLoc
+import Language.Haskell.Exts.SrcLoc
 
 -- | A pretty printing monad.
-newtype Printer a =
-  Printer {runPrinter :: StateT PrintState (MaybeT Identity) a}
-  deriving (Applicative,Monad,Functor,MonadState PrintState,MonadPlus,Alternative)
+newtype Printer a = Printer
+  { runPrinter :: StateT PrintState (MaybeT Identity) a
+  } deriving ( Applicative
+             , Monad
+             , Functor
+             , MonadState PrintState
+             , MonadPlus
+             , Alternative
+             )
 
 -- | The state of the pretty printer.
 data PrintState = PrintState
@@ -59,43 +64,37 @@ data PrintState = PrintState
 -- | Configurations shared among the different styles. Styles may pay
 -- attention to or completely disregard this configuration.
 data Config = Config
-    { configMaxColumns :: !Int64 -- ^ Maximum columns to fit code into ideally.
-    , configIndentSpaces :: !Int64 -- ^ How many spaces to indent?
-    , configTrailingNewline :: !Bool -- ^ End with a newline.
-    , configSortImports :: !Bool -- ^ Sort imports in groups.
-    , configLineBreaks :: [String] -- ^ Break line when meets these operators.
-    }
+  { configMaxColumns :: !Int64 -- ^ Maximum columns to fit code into ideally.
+  , configIndentSpaces :: !Int64 -- ^ How many spaces to indent?
+  , configTrailingNewline :: !Bool -- ^ End with a newline.
+  , configSortImports :: !Bool -- ^ Sort imports in groups.
+  , configLineBreaks :: [String] -- ^ Break line when meets these operators.
+  }
 
 instance FromJSON Config where
   parseJSON (Y.Object v) =
     Config <$>
-      fmap
-        (fromMaybe (configMaxColumns defaultConfig))
-        (v Y..:? "line-length") <*>
-      fmap
-        (fromMaybe (configIndentSpaces defaultConfig))
-        (v Y..:? "indent-size" <|> v Y..:? "tab-size") <*>
-      fmap
-        (fromMaybe (configTrailingNewline defaultConfig))
-        (v Y..:? "force-trailing-newline") <*>
-      fmap
-        (fromMaybe (configSortImports defaultConfig))
-        (v Y..:? "sort-imports") <*>
-      fmap
-        (fromMaybe (configLineBreaks defaultConfig))
-        (v Y..:? "line-breaks")
+    fmap (fromMaybe (configMaxColumns defaultConfig)) (v Y..:? "line-length") <*>
+    fmap
+      (fromMaybe (configIndentSpaces defaultConfig))
+      (v Y..:? "indent-size" <|> v Y..:? "tab-size") <*>
+    fmap
+      (fromMaybe (configTrailingNewline defaultConfig))
+      (v Y..:? "force-trailing-newline") <*>
+    fmap (fromMaybe (configSortImports defaultConfig)) (v Y..:? "sort-imports") <*>
+    fmap (fromMaybe (configLineBreaks defaultConfig)) (v Y..:? "line-breaks")
   parseJSON _ = fail "Expected Object for Config value"
 
 -- | Default style configuration.
 defaultConfig :: Config
 defaultConfig =
-    Config
-    { configMaxColumns = 80
-    , configIndentSpaces = 2
-    , configTrailingNewline = True
-    , configSortImports = True
-    , configLineBreaks = []
-    }
+  Config
+  { configMaxColumns = 80
+  , configIndentSpaces = 2
+  , configTrailingNewline = True
+  , configSortImports = True
+  , configLineBreaks = []
+  }
 
 -- | Some comment to print.
 data SomeComment
@@ -106,9 +105,12 @@ data SomeComment
 -- | Comment associated with a node.
 -- 'SrcSpan' is the original source span of the comment.
 data NodeComment
-  = CommentSameLine SrcSpan SomeComment
-  | CommentAfterLine SrcSpan SomeComment
-  | CommentBeforeLine SrcSpan SomeComment
+  = CommentSameLine SrcSpan
+                    SomeComment
+  | CommentAfterLine SrcSpan
+                     SomeComment
+  | CommentBeforeLine SrcSpan
+                      SomeComment
   deriving (Show, Ord, Eq)
 
 -- | Information for each node in the AST.
@@ -116,7 +118,7 @@ data NodeInfo = NodeInfo
   { nodeInfoSpan :: !SrcSpanInfo -- ^ Location info from the parser.
   , nodeInfoComments :: ![NodeComment] -- ^ Comments attached to this node.
   }
+
 instance Show NodeInfo where
   show (NodeInfo _ []) = ""
-  show (NodeInfo _ s) =
-    "{- " ++ show s ++ " -}"
+  show (NodeInfo _ s) = "{- " ++ show s ++ " -}"

--- a/src/main/Benchmark.hs
+++ b/src/main/Benchmark.hs
@@ -2,27 +2,26 @@
 {-# LANGUAGE BangPatterns #-}
 
 -- | Benchmark the pretty printer.
-
 module Main where
 
-import           Control.DeepSeq
-import           Criterion
-import           Criterion.Main
+import Control.DeepSeq
+import Criterion
+import Criterion.Main
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy.Builder as L
 import qualified Data.ByteString.Lazy.UTF8 as LUTF8
 import qualified Data.ByteString.UTF8 as UTF8
-import           HIndent
-import           HIndent.Types
-import           Markdone
+import HIndent
+import HIndent.Types
+import Markdone
 
 -- | Main benchmarks.
 main :: IO ()
 main = do
-    bytes <- S.readFile "BENCHMARKS.md"
-    !forest <- fmap force (parse (tokenize bytes))
-    defaultMain (toCriterion forest)
+  bytes <- S.readFile "BENCHMARKS.md"
+  !forest <- fmap force (parse (tokenize bytes))
+  defaultMain (toCriterion forest)
 
 -- | Convert the Markdone document to Criterion benchmarks.
 toCriterion :: [Markdone] -> [Benchmark]

--- a/src/main/Path/Find.hs
+++ b/src/main/Path/Find.hs
@@ -1,58 +1,61 @@
 {-# LANGUAGE DataKinds #-}
 
 -- | Finding files.
-
 -- Lifted from Stack.
-
 module Path.Find
-  (findFileUp
-  ,findDirUp
-  ,findFiles
-  ,findInParents)
-  where
+  ( findFileUp
+  , findDirUp
+  , findFiles
+  , findInParents
+  ) where
 
-import Control.Exception (evaluate)
 import Control.DeepSeq (force)
+import Control.Exception (evaluate)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
-import System.IO.Error (isPermissionError)
 import Data.List
 import Path
 import Path.IO hiding (findFiles)
-import System.PosixCompat.Files (getSymbolicLinkStatus, isSymbolicLink)
+import System.IO.Error (isPermissionError)
+import System.PosixCompat.Files
+       (getSymbolicLinkStatus, isSymbolicLink)
 
 -- | Find the location of a file matching the given predicate.
-findFileUp :: (MonadIO m,MonadThrow m)
-           => Path Abs Dir                -- ^ Start here.
-           -> (Path Abs File -> Bool)     -- ^ Predicate to match the file.
-           -> Maybe (Path Abs Dir)        -- ^ Do not ascend above this directory.
-           -> m (Maybe (Path Abs File))  -- ^ Absolute file path.
+findFileUp ::
+     (MonadIO m, MonadThrow m)
+  => Path Abs Dir -- ^ Start here.
+  -> (Path Abs File -> Bool) -- ^ Predicate to match the file.
+  -> Maybe (Path Abs Dir) -- ^ Do not ascend above this directory.
+  -> m (Maybe (Path Abs File)) -- ^ Absolute file path.
 findFileUp = findPathUp snd
 
 -- | Find the location of a directory matching the given predicate.
-findDirUp :: (MonadIO m,MonadThrow m)
-          => Path Abs Dir                -- ^ Start here.
-          -> (Path Abs Dir -> Bool)      -- ^ Predicate to match the directory.
-          -> Maybe (Path Abs Dir)        -- ^ Do not ascend above this directory.
-          -> m (Maybe (Path Abs Dir))   -- ^ Absolute directory path.
+findDirUp ::
+     (MonadIO m, MonadThrow m)
+  => Path Abs Dir -- ^ Start here.
+  -> (Path Abs Dir -> Bool) -- ^ Predicate to match the directory.
+  -> Maybe (Path Abs Dir) -- ^ Do not ascend above this directory.
+  -> m (Maybe (Path Abs Dir)) -- ^ Absolute directory path.
 findDirUp = findPathUp fst
 
 -- | Find the location of a path matching the given predicate.
-findPathUp :: (MonadIO m,MonadThrow m)
-           => (([Path Abs Dir],[Path Abs File]) -> [Path Abs t])
+findPathUp ::
+     (MonadIO m, MonadThrow m)
+  => (([Path Abs Dir], [Path Abs File]) -> [Path Abs t])
               -- ^ Choose path type from pair.
-           -> Path Abs Dir                     -- ^ Start here.
-           -> (Path Abs t -> Bool)             -- ^ Predicate to match the path.
-           -> Maybe (Path Abs Dir)             -- ^ Do not ascend above this directory.
-           -> m (Maybe (Path Abs t))           -- ^ Absolute path.
-findPathUp pathType dir p upperBound =
-  do entries <- listDir dir
-     case find p (pathType entries) of
-       Just path -> return (Just path)
-       Nothing | Just dir == upperBound -> return Nothing
-               | parent dir == dir -> return Nothing
-               | otherwise -> findPathUp pathType (parent dir) p upperBound
+  -> Path Abs Dir -- ^ Start here.
+  -> (Path Abs t -> Bool) -- ^ Predicate to match the path.
+  -> Maybe (Path Abs Dir) -- ^ Do not ascend above this directory.
+  -> m (Maybe (Path Abs t)) -- ^ Absolute path.
+findPathUp pathType dir p upperBound = do
+  entries <- listDir dir
+  case find p (pathType entries) of
+    Just path -> return (Just path)
+    Nothing
+      | Just dir == upperBound -> return Nothing
+      | parent dir == dir -> return Nothing
+      | otherwise -> findPathUp pathType (parent dir) p upperBound
 
 -- | Find files matching predicate below a root directory.
 --
@@ -61,38 +64,44 @@ findPathUp pathType dir p upperBound =
 --
 -- TODO: write one of these that traverses symbolic links but
 -- efficiently ignores loops.
-findFiles :: Path Abs Dir            -- ^ Root directory to begin with.
-          -> (Path Abs File -> Bool) -- ^ Predicate to match files.
-          -> (Path Abs Dir -> Bool)  -- ^ Predicate for which directories to traverse.
-          -> IO [Path Abs File]      -- ^ List of matching files.
-findFiles dir p traversep =
-  do (dirs,files) <- catchJust (\ e -> if isPermissionError e
-                                         then Just ()
-                                         else Nothing)
-                               (listDir dir)
-                               (\ _ -> return ([], []))
-     filteredFiles <- evaluate $ force (filter p files)
-     filteredDirs <- filterM (fmap not . isSymLink) dirs
-     subResults <-
-       forM filteredDirs
-            (\entry ->
-               if traversep entry
-                  then findFiles entry p traversep
-                  else return [])
-     return (concat (filteredFiles : subResults))
+findFiles ::
+     Path Abs Dir -- ^ Root directory to begin with.
+  -> (Path Abs File -> Bool) -- ^ Predicate to match files.
+  -> (Path Abs Dir -> Bool) -- ^ Predicate for which directories to traverse.
+  -> IO [Path Abs File] -- ^ List of matching files.
+findFiles dir p traversep = do
+  (dirs, files) <-
+    catchJust
+      (\e ->
+         if isPermissionError e
+           then Just ()
+           else Nothing)
+      (listDir dir)
+      (\_ -> return ([], []))
+  filteredFiles <- evaluate $ force (filter p files)
+  filteredDirs <- filterM (fmap not . isSymLink) dirs
+  subResults <-
+    forM
+      filteredDirs
+      (\entry ->
+         if traversep entry
+           then findFiles entry p traversep
+           else return [])
+  return (concat (filteredFiles : subResults))
 
 isSymLink :: Path Abs t -> IO Bool
 isSymLink = fmap isSymbolicLink . getSymbolicLinkStatus . toFilePath
 
 -- | @findInParents f path@ applies @f@ to @path@ and its 'parent's until
 -- it finds a 'Just' or reaches the root directory.
-findInParents :: MonadIO m => (Path Abs Dir -> m (Maybe a)) -> Path Abs Dir -> m (Maybe a)
+findInParents ::
+     MonadIO m => (Path Abs Dir -> m (Maybe a)) -> Path Abs Dir -> m (Maybe a)
 findInParents f path = do
-    mres <- f path
-    case mres of
-        Just res -> return (Just res)
-        Nothing -> do
-            let next = parent path
-            if next == path
-                then return Nothing
-                else findInParents f next
+  mres <- f path
+  case mres of
+    Just res -> return (Just res)
+    Nothing -> do
+      let next = parent path
+      if next == path
+        then return Nothing
+        else findInParents f next

--- a/src/main/Test.hs
+++ b/src/main/Test.hs
@@ -3,29 +3,29 @@
 -- | Test the pretty printer.
 module Main where
 
-import           Data.Algorithm.Diff
-import           Data.Algorithm.DiffOutput
+import Data.Algorithm.Diff
+import Data.Algorithm.DiffOutput
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
-import           Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Builder as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Data.ByteString.Lazy.UTF8 as LUTF8
 import qualified Data.ByteString.UTF8 as UTF8
-import           Data.Function
-import           Data.Monoid
+import Data.Function
+import Data.Monoid
 import qualified HIndent
-import           HIndent.Types
-import           Markdone
-import           Test.Hspec
+import HIndent.Types
+import Markdone
+import Test.Hspec
 
 -- | Main benchmarks.
 main :: IO ()
 main = do
-    bytes <- S.readFile "TESTS.md"
-    forest <- parse (tokenize bytes)
-    hspec (toSpec forest)
+  bytes <- S.readFile "TESTS.md"
+  forest <- parse (tokenize bytes)
+  hspec (toSpec forest)
 
 reformat :: Config -> S.ByteString -> ByteString
 reformat cfg code =

--- a/src/main/TestGenerate.hs
+++ b/src/main/TestGenerate.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import qualified HIndent
 

--- a/src/main/Tests.hs
+++ b/src/main/Tests.hs
@@ -1,7 +1,10 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import qualified HIndent
 
 main :: IO ()
-main = do tests <- readFile "tests.hs"
-          undefined
+main = do
+  tests <- readFile "tests.hs"
+  undefined


### PR DESCRIPTION
See #432. Initial pass running hindent on all files under `src`, the result of running:

```bash
for f in `fd .hs src`; do hindent "$f"; done
```

Unfortunately, this is partly blocked by bug #383, which causes hindent to fail on Pretty.hs:

```bash
$ hindent src/HIndent/Pretty.hs
hindent: src/HIndent/Pretty.hs:998:12: Parse error: EOF
```

Additionally, someone mentioned writing pre-commit hooks for consistency but I am unaware of a way to make that present across cloned repos without messing up personal commit hooks, but I could be wrong. See [here](https://stackoverflow.com/questions/3462955/putting-git-hooks-into-repository/3464399#3464399). 

That said, if I am wrong about the pre-commit hook, I'm more than happy to write the script to automate the process and include it in this PR (unless it's preferred to have it separate).

Thanks for the hard work on `hindent`! :+1: 