### PR TITLE
Add missing initial value for hindent-extra-args

### DIFF
--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -60,7 +60,7 @@ For hindent versions lower than 5, you must set this to a non-nil string."
   :type 'string
   :safe #'stringp)
 
-(defcustom hindent-extra-args
+(defcustom hindent-extra-args nil
   :group 'hindent
   :type 'sexp
   :safe #'listp)

--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -61,6 +61,7 @@ For hindent versions lower than 5, you must set this to a non-nil string."
   :safe #'stringp)
 
 (defcustom hindent-extra-args nil
+  "Extra arguments to pass to hindent."
   :group 'hindent
   :type 'sexp
   :safe #'listp)


### PR DESCRIPTION
This var was getting defaulted to `:group`, which obviously broke things in certain circumstances.

/cc @bigs