### PR TITLE
Exclude haskell-src-exts 1.20

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -38,7 +38,7 @@ library
                    , Cabal
                    , filepath
                    , directory
-                   , haskell-src-exts >= 1.19
+                   , haskell-src-exts >= 1.19 && < 1.20
                    , monad-loops
                    , mtl
                    , bytestring


### PR DESCRIPTION
Builds started failing after incompatible version 1.20 was released