### PR TITLE
Fix dependency issues and compatibility with cabal 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 
 # Choose a lightweight base image; we provide our own build tools.
 language: c
+compiler: gcc
 
 # Caching so the next build will be fast too.
 cache:
@@ -27,30 +28,19 @@ cache:
 matrix:
   include:
 
-  - env: BUILD=stack ARGS="--resolver lts-5" BUILDARGS=""
-    compiler: ": #stack 7.10.3"
-    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+  - env: BUILD=stack ARGS="--resolver lts-5" GHC="7.10.3" BUILDARGS=""
 
-  - env: BUILD=stack ARGS="--resolver lts-7" BUILDARGS=""
-    compiler: ": #stack 8.0.1"
-    addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+  - env: BUILD=stack ARGS="--resolver lts-7" GHC="8.0.1" BUILDARGS=""
 
-  - env: BUILD=stack ARGS="--resolver lts-9" BUILDARGS="--pedantic"
-    compiler: ": #stack 8.0.2"
-    addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
+  - env: BUILD=stack ARGS="--resolver lts-9" GHC="8.0.2" BUILDARGS="--pedantic"
 
-  - env: BUILD=stack ARGS="--resolver lts-10" BUILDARGS="--pedantic"
-    compiler: ": #stack 8.2.2"
-    addons: {apt: {packages: [ghc-8.2.2], sources: [hvr-ghc]}}
+  - env: BUILD=stack ARGS="--resolver lts-10" GHC="8.2.2" BUILDARGS="--pedantic"
 
   # Build on OS X in addition to Linux
   - env: BUILD=stack ARGS="" BUILDARGS=""
-    compiler: ": #stack default osx"
     os: osx
 
 before_install:
-# Using compiler above sets CC to an invalid value, so unset it
-- unset CC
 
 # We want to always allow newer versions of packages when building on GHC HEAD
 - CABALARGS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ before_install:
 
 install:
 - stack --no-terminal --install-ghc $ARGS install hsc2hs
+# Fix dependency issue for vector-algoritms for lts-3 and lts-5
+- stack --no-terminal --install-ghc $ARGS install mtl mwc-random
 - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ compiler: gcc
 # Caching so the next build will be fast too.
 cache:
   directories:
-  - $HOME/.ghc
-  - $HOME/.cabal
   - $HOME/.stack
 
 # The different configurations we want to test. We have BUILD=cabal which uses
@@ -28,26 +26,19 @@ cache:
 matrix:
   include:
 
-  - env: BUILD=stack ARGS="--resolver lts-5" GHC="7.10.3" BUILDARGS=""
+  - env: ARGS="--resolver lts-5" GHC="7.10.3" BUILDARGS=""
 
-  - env: BUILD=stack ARGS="--resolver lts-7" GHC="8.0.1" BUILDARGS=""
+  - env: ARGS="--resolver lts-7" GHC="8.0.1" BUILDARGS=""
 
-  - env: BUILD=stack ARGS="--resolver lts-9" GHC="8.0.2" BUILDARGS="--pedantic"
+  - env: ARGS="--resolver lts-9" GHC="8.0.2" BUILDARGS="--pedantic"
 
-  - env: BUILD=stack ARGS="--resolver lts-10" GHC="8.2.2" BUILDARGS="--pedantic"
+  - env: ARGS="--resolver lts-10" GHC="8.2.2" BUILDARGS="--pedantic"
 
   # Build on OS X in addition to Linux
-  - env: BUILD=stack ARGS="" BUILDARGS=""
+  - env: ARGS="" GHC="" BUILDARGS=""
     os: osx
 
 before_install:
-
-# We want to always allow newer versions of packages when building on GHC HEAD
-- CABALARGS=""
-- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
-
-# Download and unpack the stack executable
-- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
 - mkdir -p ~/.local/bin
 - |
   if [ `uname` = "Darwin" ]
@@ -57,54 +48,11 @@ before_install:
     travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   fi
 
-  # Use the more reliable S3 mirror of Hackage
-  mkdir -p $HOME/.cabal
-  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
-  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
-
-  if [ "$CABALVER" != "1.16" ]
-  then
-    echo 'jobs: $ncpus' >> $HOME/.cabal/config
   fi
 
 install:
-- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-- if [ -f configure.ac ]; then autoreconf -i; fi
-- |
-  set -ex
-  case "$BUILD" in
-    stack)
-      stack --no-terminal --install-ghc $ARGS install hsc2hs
-      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
-      ;;
-    cabal)
-      cabal --version
-      travis_retry cabal update
-      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-      ;;
-  esac
-  set +ex
+- stack --no-terminal --install-ghc $ARGS install hsc2hs
+- stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:
-- |
-  set -ex
-  case "$BUILD" in
-    stack)
-      stack --no-terminal $ARGS test $BUILDARGS --bench --no-run-benchmarks --haddock --no-haddock-deps
-      ;;
-    cabal)
-      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-
-      ORIGDIR=$(pwd)
-      for dir in $PACKAGES
-      do
-        cd $dir
-        cabal check || [ "$CABALVER" == "1.16" ]
-        cabal sdist
-        SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz && \
-          (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
-        cd $ORIGDIR
-      done
-      ;;
-  esac
-  set +ex
+- stack --no-terminal $ARGS test $BUILDARGS --bench --no-run-benchmarks --haddock --no-haddock-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ matrix:
 before_install:
 - mkdir -p ~/.local/bin
 - |
-  if [ `uname` = "Darwin" ]
+  if [[ "${TRAVIS_OS_NAME}" = "osx" ]]
   then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+      | tar xz --strip-components=1 -C ~/.local/bin --include   '*/stack'
   else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-  fi
-
+    travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+      | tar xz --strip-components=1 -C ~/.local/bin --wildcards '*/stack'
   fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,6 @@ before_install:
     echo 'jobs: $ncpus' >> $HOME/.cabal/config
   fi
 
-# Get the list of packages from the stack.yaml file
-- PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 - if [ -f configure.ac ]; then autoreconf -i; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ install:
 - stack --no-terminal --install-ghc $ARGS install hsc2hs
 # Fix dependency issue for vector-algoritms for lts-3 and lts-5
 - stack --no-terminal --install-ghc $ARGS install mtl mwc-random
+# Fix dependency issue for haskell-src-exts for lts-10
+- stack --no-terminal --install-ghc $ARGS install happy
 - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1101cc89ad4e9842c65c89e38b946f772ed0c36cc20fc57ed40c3ad87eef8603
+-- hash: 8b8d19f80d5727084e4baf52df76b91d3d65c621ce7c750bdc1fbb780fd887f2
 
 name:           hindent
 version:        5.2.4.1
@@ -90,6 +90,7 @@ executable hindent
     , yaml
   other-modules:
       Path.Find
+      Paths_hindent
   default-language: Haskell2010
 
 test-suite hindent-test

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -1,107 +1,136 @@
-name:                hindent
-version:             5.2.4.1
-synopsis:            Extensible Haskell pretty printer
-description:         Extensible Haskell pretty printer. Both a library and an executable.
-                     .
-                     See the Github page for usage\/explanation: <https://github.com/commercialhaskell/hindent>
-license:             BSD3
-stability:           Unstable
-license-file:        LICENSE.md
-author:              Chris Done, Andrew Gibiansky, Tobias Pflug, Pierre Radermecker
-maintainer:          chrisdone@gmail.com
-copyright:           2014 Chris Done, 2015 Andrew Gibiansky
-category:            Development
-build-type:          Simple
-cabal-version:       >=1.8
-homepage:            https://github.com/commercialhaskell/hindent
-bug-reports:         https://github.com/commercialhaskell/hindent/issues
-data-files:          elisp/hindent.el
+-- This file has been generated from package.yaml by hpack version 0.20.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 1101cc89ad4e9842c65c89e38b946f772ed0c36cc20fc57ed40c3ad87eef8603
+
+name:           hindent
+version:        5.2.4.1
+synopsis:       Extensible Haskell pretty printer
+description:    Extensible Haskell pretty printer. Both a library and an executable.
+                .
+                See the Github page for usage\/explanation: <https://github.com/commercialhaskell/hindent>
+category:       Development
+homepage:       https://github.com/commercialhaskell/hindent#readme
+bug-reports:    https://github.com/commercialhaskell/hindent/issues
+author:         Chris Done,
+                Andrew Gibiansky,
+                Tobias Pflug,
+                Pierre Radermecker
+maintainer:     chrisdone@gmail.com
+copyright:      2014 Chris Done,
+                2015 Andrew Gibiansky
+license:        BSD3
+license-file:   LICENSE.md
+build-type:     Simple
+cabal-version:  >= 1.10
+
 extra-source-files:
- README.md
- CHANGELOG.md
- BENCHMARKS.md
- TESTS.md
+    BENCHMARKS.md
+    CHANGELOG.md
+    README.md
+    TESTS.md
+
+data-files:
+    elisp/hindent.el
 
 source-repository head
-    type:           git
-    location:       https://github.com/commercialhaskell/hindent
+  type: git
+  location: https://github.com/commercialhaskell/hindent
 
 library
-  hs-source-dirs:    src/
-  ghc-options:       -Wall -O2
-  exposed-modules:   HIndent
-                     HIndent.Types
-                     HIndent.Pretty
-                     HIndent.CabalFile
-  build-depends:     base >= 4.7 && <5
-                   , containers
-                   , Cabal
-                   , filepath
-                   , directory
-                   , haskell-src-exts >= 1.20
-                   , monad-loops
-                   , mtl
-                   , bytestring
-                   , utf8-string
-                   , transformers
-                   , exceptions
-                   , text
-                   , yaml
+  hs-source-dirs:
+      src/
+  ghc-options: -Wall -O2
+  build-depends:
+      Cabal
+    , base >=4.7 && <5
+    , bytestring
+    , containers
+    , directory
+    , exceptions
+    , filepath
+    , haskell-src-exts >=1.20
+    , monad-loops
+    , mtl
+    , text
+    , transformers
+    , utf8-string
+    , yaml
+  exposed-modules:
+      HIndent
+      HIndent.Types
+      HIndent.Pretty
+      HIndent.CabalFile
+  other-modules:
+      Paths_hindent
+  default-language: Haskell2010
 
 executable hindent
-  hs-source-dirs:    src/main
-  ghc-options:       -Wall -O2
-  main-is:           Main.hs
-  other-modules: Path.Find
-  build-depends:     base >= 4 && < 5
-                   , hindent
-                   , bytestring
-                   , utf8-string
-                   , descriptive >= 0.7 && < 0.10
-                   , haskell-src-exts
-                   , ghc-prim
-                   , directory
-                   , text
-                   , yaml
-                   , unix-compat
-                   , deepseq
-                   , path
-                   , path-io
-                   , transformers
-                   , exceptions
+  main-is: Main.hs
+  hs-source-dirs:
+      src/main
+  ghc-options: -Wall -O2
+  build-depends:
+      base >=4 && <5
+    , bytestring
+    , deepseq
+    , descriptive >=0.7 && <0.10
+    , directory
+    , exceptions
+    , ghc-prim
+    , haskell-src-exts
+    , hindent
+    , path
+    , path-io
+    , text
+    , transformers
+    , unix-compat
+    , utf8-string
+    , yaml
+  other-modules:
+      Path.Find
+  default-language: Haskell2010
 
 test-suite hindent-test
   type: exitcode-stdio-1.0
-  hs-source-dirs: src/main/
   main-is: Test.hs
-  other-modules: Markdone
-  build-depends:     base >= 4 && <5
-                   , hindent
-                   , haskell-src-exts
-                   , monad-loops
-                   , mtl
-                   , bytestring
-                   , utf8-string
-                   , hspec
-                   , directory
-                   , deepseq
-                   , exceptions
-                   , utf8-string
-                   , Diff
+  hs-source-dirs:
+      src/main/
+  build-depends:
+      Diff
+    , base >=4 && <5
+    , bytestring
+    , deepseq
+    , directory
+    , exceptions
+    , haskell-src-exts
+    , hindent
+    , hspec
+    , monad-loops
+    , mtl
+    , utf8-string
+  other-modules:
+      Markdone
+  default-language: Haskell2010
 
 benchmark hindent-bench
   type: exitcode-stdio-1.0
-  hs-source-dirs:    src/main
-  ghc-options:       -Wall -O2 -rtsopts
-  main-is:           Benchmark.hs
-  other-modules: Markdone
-  build-depends:     base >= 4 && < 5
-                   , hindent
-                   , bytestring
-                   , utf8-string
-                   , haskell-src-exts
-                   , ghc-prim
-                   , directory
-                   , criterion
-                   , deepseq
-                   , exceptions
+  main-is: Benchmark.hs
+  hs-source-dirs:
+      src/main
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+      base >=4 && <5
+    , bytestring
+    , criterion
+    , deepseq
+    , directory
+    , exceptions
+    , ghc-prim
+    , haskell-src-exts
+    , hindent
+    , utf8-string
+  other-modules:
+      Markdone
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,109 @@
+name: hindent
+version: '5.2.4.1'
+synopsis: Extensible Haskell pretty printer
+description: ! 'Extensible Haskell pretty printer. Both a library and an executable.
+
+
+  See the Github page for usage\/explanation: <https://github.com/commercialhaskell/hindent>'
+category: Development
+author:
+  - Chris Done
+  - Andrew Gibiansky
+  - Tobias Pflug
+  - Pierre Radermecker
+maintainer: chrisdone@gmail.com
+copyright:
+  - 2014 Chris Done
+  - 2015 Andrew Gibiansky
+license: BSD3
+license-file: LICENSE.md
+github: commercialhaskell/hindent
+extra-source-files:
+  - README.md
+  - CHANGELOG.md
+  - BENCHMARKS.md
+  - TESTS.md
+dependencies:
+  - directory
+  - bytestring
+  - utf8-string
+  - exceptions
+
+library:
+  source-dirs: src/
+  ghc-options:
+    - -Wall
+    - -O2
+  exposed-modules:
+    - HIndent
+    - HIndent.Types
+    - HIndent.Pretty
+    - HIndent.CabalFile
+  dependencies:
+    - base >=4.7 && <5
+    - containers
+    - Cabal
+    - filepath
+    - haskell-src-exts >=1.20
+    - monad-loops
+    - mtl
+    - transformers
+    - text
+    - yaml
+
+executables:
+  hindent:
+    main: Main.hs
+    source-dirs: src/main
+    ghc-options:
+      - -Wall
+      - -O2
+    dependencies:
+      - base >=4 && <5
+      - hindent
+      - descriptive >=0.7 && <0.10
+      - haskell-src-exts
+      - ghc-prim
+      - text
+      - yaml
+      - unix-compat
+      - deepseq
+      - path
+      - path-io
+      - transformers
+    other-modules: Path.Find
+
+tests:
+  hindent-test:
+    main: Test.hs
+    source-dirs: src/main/
+    dependencies:
+      - base >=4 && <5
+      - hindent
+      - haskell-src-exts
+      - monad-loops
+      - mtl
+      - hspec
+      - deepseq
+      - Diff
+    other-modules: Markdone
+
+benchmarks:
+  hindent-bench:
+    main: Benchmark.hs
+    source-dirs: src/main
+    ghc-options:
+      - -Wall
+      - -O2
+      - -rtsopts
+    dependencies:
+      - base >=4 && <5
+      - hindent
+      - haskell-src-exts
+      - ghc-prim
+      - criterion
+      - deepseq
+    other-modules: Markdone
+
+data-files:
+  - elisp/hindent.el

--- a/package.yaml
+++ b/package.yaml
@@ -71,7 +71,9 @@ executables:
       - path
       - path-io
       - transformers
-    other-modules: Path.Find
+    other-modules:
+      - Path.Find
+      - Paths_hindent
 
 tests:
   hindent-test:

--- a/src/HIndent/CabalFile.hs
+++ b/src/HIndent/CabalFile.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module HIndent.CabalFile
   ( getCabalExtensionsForSourcePath
   ) where
@@ -19,6 +21,13 @@ data Stanza = MkStanza
   { _stanzaBuildInfo :: BuildInfo
   , stanzaIsSourceFilePath :: FilePath -> Bool
   }
+
+parsePackageDesc :: String -> ParseResult GenericPackageDescription
+#if MIN_VERSION_Cabal(2,0,0)
+parsePackageDesc = parseGenericPackageDescription
+#else
+parsePackageDesc = parsePackageDescription
+#endif
 
 -- | Find the relative path of a child path in a parent, if it is a child
 toRelative :: FilePath -> FilePath -> Maybe FilePath
@@ -92,7 +101,7 @@ getCabalStanza srcpath = do
       stanzass <-
         for cabalpaths $ \cabalpath -> do
           cabaltext <- readFile cabalpath
-          case parsePackageDescription cabaltext of
+          case parsePackageDesc cabaltext of
             ParseFailed _ -> return []
             ParseOk _ gpd -> do
               return $ packageStanzas $ flattenPackageDescription gpd

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
-resolver: lts-9.12
+flags: {}
 packages:
-- '.'
+- .
 extra-deps:
 - haskell-src-exts-1.20.1
 - path-0.5.9
 - path-io-1.2.2
+resolver: lts-9.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,5 @@ packages:
 - '.'
 extra-deps:
 - haskell-src-exts-1.20.1
-- descriptive-0.9.4
 - path-0.5.9
-- path-io-1.2.0
+- path-io-1.2.2


### PR DESCRIPTION
- Use [hpack](https://github.com/sol/hpack) to manage `hindent.cabal` file
  - Remove redundancies 
  - Keep it nice and compatible
- Huge cleanup in `.travis.yml` 
  - Remove what is not used
  - Install of 1 GHC instead of 3
- Fix failing build of
  - LTS-5 - dependencies problem with `vector-algorithms` (required for `--bench`)
  - LTS-10
    - cabal 2 deprecation of `parsePackageDescription`
    - dependency problem with `haskell-src-exts`
Update stack LTS-9.12 to last LTS-9.21 

  