### PR TITLE
Switch from descriptive to optparse-applicative

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -57,7 +57,6 @@ executable hindent
                    , hindent
                    , bytestring
                    , utf8-string
-                   , descriptive >= 0.7 && < 0.10
                    , haskell-src-exts
                    , ghc-prim
                    , directory
@@ -69,6 +68,7 @@ executable hindent
                    , path-io
                    , transformers
                    , exceptions
+                   , optparse-applicative
 
 test-suite hindent-test
   type: exitcode-stdio-1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,6 @@ packages:
 - '.'
 extra-deps:
 - haskell-src-exts-1.20.2
-- git: https://github.com/robertjlooby/descriptive
-  commit: 9419a51e272d6f6738cd3e81c652790e8b4bd11b
 - path-0.5.9
 - path-io-1.2.0
 


### PR DESCRIPTION
Aiming to get hindent back into Stackage Nightly (and, soon, LTS with GHC 8.4), I contacted @chrisdone via Twitter to see if I could help. Chris indicated he planned to switch `hindent` from `descriptive` to `optparse-applicative`. This is that change, though I'm not 100% sure it's perfect yet as I haven't exhaustively tested it. Hope this helps.