### PR TITLE
Prefer strOption for -X option, so that quotes are not required

### DIFF
--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -30,6 +30,7 @@ import           System.Exit (exitWith)
 import qualified System.IO as IO
 import           Options.Applicative hiding (action, style)
 import           Data.Monoid ((<>))
+import qualified Data.Text as T
 
 data Action = Validate | Reformat
 
@@ -103,7 +104,7 @@ options config =
       ) <*
       optional (strOption
            (long "style" <> help "Style to print with (historical, now ignored)" <> metavar "STYLE") :: Parser String)
-    exts = fmap getExtensions (many (option auto (short 'X' <> help "Language extension" <> metavar "GHCEXT")))
+    exts = fmap getExtensions (many (T.pack <$> strOption (short 'X' <> help "Language extension" <> metavar "GHCEXT")))
     indentSpaces =
         option auto
            (long "indent-size" <> help "Indentation size in spaces" <> value (configIndentSpaces config) <> showDefault) <|>


### PR DESCRIPTION
Hey @chrisdone, I don't think you actually changed "option auto" to "strOption", re. your comment in #508, so here's a PR for that fix. IIRC I had started with `strOption` in #508 and switched to `option auto` because `strOption` didn't support `Text` in an older version of `optparse-applicative` used by the Travis build. I'll let the build run for this, then fix it with a `T.pack` if that's the case.