### PR TITLE
Specify default extensions in configuration file

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -72,10 +72,16 @@ reformat config mexts mfilepath =
             mode'' = case exts of
                        Nothing -> mode'
                        Just (Nothing, exts') ->
-                         mode' { extensions = exts' ++ extensions mode' }
+                         mode' { extensions =
+                                   exts'
+                                   ++ configExtensions config
+                                   ++ extensions mode' }
                        Just (Just lang, exts') ->
                          mode' { baseLanguage = lang
-                               , extensions = exts' ++ extensions mode' }
+                               , extensions =
+                                   exts'
+                                   ++ configExtensions config
+                                   ++ extensions mode' }
         in case parseModuleWithComments mode'' (UTF8.toString code) of
                ParseOk (m, comments) ->
                    fmap
@@ -319,14 +325,6 @@ getExtensions = foldl f defaultExtensions . map T.unpack
             x' :
             delete x' a
         f _ x = error $ "Unknown extension: " ++ x
-
--- | Parse an extension.
-readExtension :: String -> Maybe Extension
-readExtension x =
-  case classifyExtension x -- Foo
-       of
-    UnknownExtension _ -> Nothing
-    x' -> Just x'
 
 --------------------------------------------------------------------------------
 -- Comments


### PR DESCRIPTION
The configuration file is extended to include the field `extensions` listing the
language extensions to enable, in addition to the default extensions and
extensions specified on the command-line.