### PR TITLE
Improve testing of C preprocessor parser

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1554,3 +1554,23 @@ exp = [name|exp|]
 
 f [qq|pattern|] = ()
 ```
+
+# C preprocessor
+
+Conditionals (`#if`)
+
+```haskell
+isDebug :: Bool
+#if DEBUG
+isDebug = True
+#else
+isDebug = False
+#endif
+```
+
+Macro definitions (`#define`)
+
+```haskell
+#define STRINGIFY(x) #x
+f = STRINGIFY (y)
+```

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -105,3 +105,4 @@ benchmark hindent-bench
                    , criterion
                    , deepseq
                    , exceptions
+                   , mtl

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -33,6 +33,7 @@ library
                      HIndent.Types
                      HIndent.Pretty
                      HIndent.CabalFile
+                     HIndent.CodeBlock
   build-depends:     base >= 4.7 && <5
                    , containers
                    , Cabal

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -41,19 +41,12 @@ import           Data.Monoid
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Traversable hiding (mapM)
+import           HIndent.CodeBlock
 import           HIndent.Pretty
 import           HIndent.Types
 import qualified Language.Haskell.Exts as Exts
 import           Language.Haskell.Exts hiding (Style, prettyPrint, Pretty, style, parse)
 import           Prelude
-
--- | A block of code.
-data CodeBlock
-    = Shebang ByteString
-    | HaskellSource Int ByteString
-    -- ^ Includes the starting line (indexed from 0) for error reporting
-    | CPPDirectives ByteString
-     deriving (Show, Eq)
 
 -- | Format the given source.
 reformat :: Config -> Maybe [Extension] -> Maybe FilePath -> ByteString -> Either String Builder
@@ -147,62 +140,6 @@ hasTrailingLine xs =
     if S8.null xs
         then False
         else S8.last xs == '\n'
-
--- | Break a Haskell code string into chunks, using CPP as a delimiter.
--- Lines that start with '#if', '#end', or '#else' are their own chunks, and
--- also act as chunk separators. For example, the code
---
--- > #ifdef X
--- > x = X
--- > y = Y
--- > #else
--- > x = Y
--- > y = X
--- > #endif
---
--- will become five blocks, one for each CPP line and one for each pair of declarations.
-cppSplitBlocks :: ByteString -> [CodeBlock]
-cppSplitBlocks inp =
-  modifyLast (inBlock (<> trailing)) .
-  map (classify . unlines') .
-  groupBy ((==) `on` nonHaskellLine) . zip [0 ..] . S8.lines $
-  inp
-  where
-    nonHaskellLine :: (Int, ByteString) -> Bool
-    nonHaskellLine (_, src) = cppLine src || shebangLine src
-    shebangLine :: ByteString -> Bool
-    shebangLine = S8.isPrefixOf "#!"
-    cppLine :: ByteString -> Bool
-    cppLine src =
-      any
-        (`S8.isPrefixOf` src)
-        ["#if", "#end", "#else", "#define", "#undef", "#elif", "#include", "#error", "#warning"]
-        -- Note: #ifdef and #ifndef are handled by #if
-    unlines' :: [(Int, ByteString)] -> (Int, ByteString)
-    unlines' [] = (0, S.empty)
-    unlines' srcs@((line, _):_) =
-      (line, mconcat . intersperse "\n" $ map snd srcs)
-    classify :: (Int, ByteString) -> CodeBlock
-    classify (line, text)
-      | shebangLine text = Shebang text
-      | cppLine text = CPPDirectives text
-      | otherwise = HaskellSource line text
-    -- Hack to work around some parser issues in haskell-src-exts: Some pragmas
-    -- need to have a newline following them in order to parse properly, so we include
-    -- the trailing newline in the code block if it existed.
-    trailing :: ByteString
-    trailing =
-      if S8.isSuffixOf "\n" inp
-        then "\n"
-        else ""
-    modifyLast :: (a -> a) -> [a] -> [a]
-    modifyLast _ [] = []
-    modifyLast f [x] = [f x]
-    modifyLast f (x:xs) = x : modifyLast f xs
-    inBlock :: (ByteString -> ByteString) -> CodeBlock -> CodeBlock
-    inBlock f (HaskellSource line txt) = HaskellSource line (f txt)
-    inBlock _ dir = dir
-
 
 -- | Print the module.
 prettyPrint :: Config

--- a/src/HIndent/CodeBlock.hs
+++ b/src/HIndent/CodeBlock.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module HIndent.CodeBlock
+  ( CodeBlock(..)
+  , cppSplitBlocks
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Char8 as S8
+import Data.Function
+import Data.List
+import Data.Monoid
+
+-- | A block of code.
+data CodeBlock
+    = Shebang ByteString
+    | HaskellSource Int ByteString
+    -- ^ Includes the starting line (indexed from 0) for error reporting
+    | CPPDirectives ByteString
+     deriving (Show, Eq)
+
+-- | Break a Haskell code string into chunks, using CPP as a delimiter.
+-- Lines that start with '#if', '#end', or '#else' are their own chunks, and
+-- also act as chunk separators. For example, the code
+--
+-- > #ifdef X
+-- > x = X
+-- > y = Y
+-- > #else
+-- > x = Y
+-- > y = X
+-- > #endif
+--
+-- will become five blocks, one for each CPP line and one for each pair of declarations.
+cppSplitBlocks :: ByteString -> [CodeBlock]
+cppSplitBlocks inp =
+  modifyLast (inBlock (<> trailing)) .
+  map (classify . unlines') .
+  groupBy ((==) `on` nonHaskellLine) . zip [0 ..] . S8.lines $
+  inp
+  where
+    nonHaskellLine :: (Int, ByteString) -> Bool
+    nonHaskellLine (_, src) = cppLine src || shebangLine src
+    shebangLine :: ByteString -> Bool
+    shebangLine = S8.isPrefixOf "#!"
+    cppLine :: ByteString -> Bool
+    cppLine src =
+      any
+        (`S8.isPrefixOf` src)
+        ["#if", "#end", "#else", "#define", "#undef", "#elif", "#include", "#error", "#warning"]
+        -- Note: #ifdef and #ifndef are handled by #if
+    unlines' :: [(Int, ByteString)] -> (Int, ByteString)
+    unlines' [] = (0, S.empty)
+    unlines' srcs@((line, _):_) =
+      (line, mconcat . intersperse "\n" $ map snd srcs)
+    classify :: (Int, ByteString) -> CodeBlock
+    classify (line, text)
+      | shebangLine text = Shebang text
+      | cppLine text = CPPDirectives text
+      | otherwise = HaskellSource line text
+    -- Hack to work around some parser issues in haskell-src-exts: Some pragmas
+    -- need to have a newline following them in order to parse properly, so we include
+    -- the trailing newline in the code block if it existed.
+    trailing :: ByteString
+    trailing =
+      if S8.isSuffixOf "\n" inp
+        then "\n"
+        else ""
+    modifyLast :: (a -> a) -> [a] -> [a]
+    modifyLast _ [] = []
+    modifyLast f [x] = [f x]
+    modifyLast f (x:xs) = x : modifyLast f xs
+    inBlock :: (ByteString -> ByteString) -> CodeBlock -> CodeBlock
+    inBlock f (HaskellSource line txt) = HaskellSource line (f txt)
+    inBlock _ dir = dir

--- a/src/main/Markdone.hs
+++ b/src/main/Markdone.hs
@@ -26,7 +26,7 @@ data Token
   | PlainLine !ByteString
   | BeginFence !ByteString
   | EndFence
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- | A markdone document.
 data Markdone
@@ -35,7 +35,7 @@ data Markdone
   | CodeFence !ByteString
               !ByteString
   | PlainText !ByteString
-  deriving (Show,Generic)
+  deriving (Eq,Show,Generic)
 instance NFData Markdone
 
 -- | Parse error.

--- a/src/main/Test.hs
+++ b/src/main/Test.hs
@@ -122,6 +122,11 @@ markdoneSpec = do
     it "should tokenize full code fences" $ do
       tokenize "```haskell\ncode goes here\n```" `shouldBe`
         [BeginFence "haskell", PlainLine "code goes here", EndFence]
+    it "should tokenize lines inside code fences as plain text" $ do
+      tokenize "```haskell\n#!/usr/bin/env stack\n```" `shouldBe`
+        [BeginFence "haskell", PlainLine "#!/usr/bin/env stack", EndFence]
+      tokenize "```haskell\n# not a heading\n```" `shouldBe`
+        [BeginFence "haskell", PlainLine "# not a heading", EndFence]
   describe "markdown parser" $ do
     it "should parse a heading followed by text as a section" $ do
       let input =


### PR DESCRIPTION
HIndent doesn't support line continuations in C preprocessor directives. I want to implement support for this syntax. Prepare for this feature by adding tests for [a subset of] the currently-supported syntax.

(I will implement line continuation support in a future pull request.)

This set of commits should not change behavior.
