### PR TITLE
Parse C preprocessor line continuations

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1574,3 +1574,15 @@ Macro definitions (`#define`)
 #define STRINGIFY(x) #x
 f = STRINGIFY (y)
 ```
+
+Escaped newlines
+
+```haskell
+#define LONG_MACRO_DEFINITION \
+  data Pair a b = Pair \
+    { first :: a \
+    , second :: b \
+    }
+#define SHORT_MACRO_DEFINITION \
+  x
+```

--- a/src/main/Test.hs
+++ b/src/main/Test.hs
@@ -123,9 +123,17 @@ codeBlocksSpec =
         [ Shebang "#!/usr/bin/env runhaskell"
         , HaskellSource 1 "{-# LANGUAGE OverloadedStrings #-}\n"
         ]
-    it "should put adjacent #define lines into a single block" $ do
-      cppSplitBlocks "#define A\n#define B\n#define C\n" `shouldBe`
-        [CPPDirectives "#define A\n#define B\n#define C"]
+    it "should put a multi-line #define into its own block" $ do
+      let input = "#define A \\\n  macro contents \\\n  go here\nhaskell code\n"
+      cppSplitBlocks input `shouldBe`
+        [ CPPDirectives "#define A \\\n  macro contents \\\n  go here"
+        , HaskellSource 3 "haskell code\n"
+        ]
+    it "should put an unterminated multi-line #define into its own block" $ do
+      cppSplitBlocks "#define A \\" `shouldBe` [CPPDirectives "#define A \\"]
+      cppSplitBlocks "#define A \\\n" `shouldBe` [CPPDirectives "#define A \\"]
+      cppSplitBlocks "#define A \\\n.\\" `shouldBe`
+        [CPPDirectives "#define A \\\n.\\"]
 
 markdoneSpec :: Spec
 markdoneSpec = do


### PR DESCRIPTION
 Parse C preprocessor line continuations

C preprocessor directives can span multiple lines if the line break is escaped with a backslash:

    #define LONG_MACRO_DEFINITION \
      data Pair a b = Pair \
        { first :: a \
        , second :: b \
        }

HIndent ignores these line continuations, thus often incorrectly formats code which uses them. Fix this bug by teaching HIndent's C preprocessor parser to consume multiple lines if necessary (instead of always consuming exactly one line).