### PR TITLE
Fix pretty printing of '(:)

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -382,6 +382,12 @@ Type brackets
 foo :: $([t|Bool|]) -> a
 ```
 
+Quoted data constructors
+
+```haskell
+cons = '(:)
+```
+
 # Type signatures
 
 Long argument list should line break

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -445,6 +445,7 @@ prettyQuoteQName x =
       case n of
         Ident _ i -> string i
         Symbol _ s -> do write "("; string s; write ")";
+    Special _ s@Cons{} -> parens (pretty s)
     Special _ s -> pretty s
 
 instance Pretty Type where


### PR DESCRIPTION
HIndent pretty-prints quoted list cons incorrectly, resulting in illegal Haskell output:

    '(:)  -- Input
    ':    -- Output (invalid Haskell syntax)

Force parentheses for quoted list cons so HIndent emits valid code.