### PR TITLE
Support $p pattern splices

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -388,6 +388,17 @@ Quoted data constructors
 cons = '(:)
 ```
 
+Pattern splices
+
+```haskell
+f $pat = ()
+
+g =
+  case x of
+    $(mkPat y z) -> True
+    _ -> False
+```
+
 # Type signatures
 
 Long argument list should line break

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -411,6 +411,7 @@ instance Pretty Pat where
       PXPatTag{} -> pretty' x
       PXRPats{} -> pretty' x
       PVar{} -> pretty' x
+      PSplice _ s -> pretty s
 
 -- | Pretty infix application of a name (identifier or symbol).
 prettyInfixName :: Name NodeInfo -> Printer ()


### PR DESCRIPTION
hindent fails with a PatternMatchFail exception when given source with a Template Haskell pattern splice:

    f $pat = ()

    > uncaught exception: PatternMatchFail (src/HIndent/Pretty.hs:(338,5)-(413,25): Non-exhaustive patterns in case)

Teach hindent how to pretty-print this syntax, fixing the crash.