### PR TITLE
Add parens around symbols (:|) when required

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -144,6 +144,14 @@ instance C a where
     k p
 ```
 
+Symbol class constructor in instance declaration
+
+```haskell
+instance Bool :?: Bool
+
+instance (:?:) Int Bool
+```
+
 GADT declarations
 
 ```haskell
@@ -247,6 +255,20 @@ commitToEvent gitFolderPath timezone commit =
     }
 ```
 
+Record with symbol constructor
+
+```haskell
+f = (:..?) {}
+```
+
+Record with symbol field
+
+```haskell
+f x = x {(..?) = wat}
+
+g x = Rec {(..?)}
+```
+
 Cases
 
 ``` haskell
@@ -297,6 +319,20 @@ Operator with lambda-case
 ```haskell
 for xs $ \case
   Left x -> x
+```
+
+Binary symbol data constructor in pattern
+
+```haskell
+f (x :| _) = x
+
+f' ((:|) x _) = x
+
+f'' ((Data.List.NonEmpty.:|) x _) = x
+
+g (x:xs) = x
+
+g' ((:) x _) = x
 ```
 
 Type application
@@ -415,6 +451,13 @@ Class constraints
 fun :: (Class a, Class b) => a -> b -> c
 ```
 
+Symbol class constructor in class constraint
+
+```haskell
+f :: (a :?: b) => (a, b)
+f' :: ((:?:) a b) => (a, b)
+```
+
 Tuples
 
 ``` haskell
@@ -444,6 +487,13 @@ Implicit parameters
 f :: (?x :: Int) => Int
 ```
 
+Symbol type constructor
+
+```haskell
+f :: a :?: b
+f' :: (:?:) a b
+```
+
 Promoted list (issue #348)
 
 ```haskell
@@ -464,6 +514,15 @@ a = undefined
 -- nested promoted tuples.
 b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
 b = undefined
+```
+
+Prefix promoted symbol type constructor
+
+```haskell
+a :: '(T.:->) 'True 'False
+b :: (T.:->) 'True 'False
+c :: '(:->) 'True 'False
+d :: (:->) 'True 'False
 ```
 
 # Function declarations
@@ -618,6 +677,37 @@ fun Rec { alpha = beta
         , lambda = mu
         } =
   beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
+```
+
+Symbol constructor, short
+
+```haskell
+fun ((:..?) {}) = undefined
+```
+
+Symbol constructor, long
+
+```
+fun (:..?) { alpha = beta
+           , gamma = delta
+           , epsilon = zeta
+           , eta = theta
+           , iota = kappa
+           , lambda = mu
+           } =
+  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
+```
+
+Symbol field
+
+```haskell
+f (X {(..?) = x}) = x
+```
+
+Punned symbol field
+
+```haskell
+f' (X {(..?)}) = (..?)
 ```
 
 # Johan Tibell compatibility checks

--- a/TESTS.md
+++ b/TESTS.md
@@ -321,6 +321,20 @@ for xs $ \case
   Left x -> x
 ```
 
+Operator in parentheses
+
+```haskell
+cat = (++)
+```
+
+Symbol data constructor in parentheses
+
+```haskell
+cons = (:)
+
+cons' = (:|)
+```
+
 Binary symbol data constructor in pattern
 
 ```haskell

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -446,6 +446,7 @@ prettyQuoteQName x =
         Ident _ i -> string i
         Symbol _ s -> do write "("; string s; write ")";
     Special _ s@Cons{} -> parens (pretty s)
+    Special _ s@FunCon{} -> parens (pretty s)
     Special _ s -> pretty s
 
 instance Pretty Type where
@@ -702,17 +703,9 @@ exp (MultiIf _ alts) =
                          (zip [1..] stmts))))
       swing (write " " >> rhsSeparator) (pretty e)
 exp (Lit _ lit) = prettyInternal lit
-exp (Var _ q) = case q of
-                  Special _ Cons{} -> parens (pretty q)
-                  Qual _ _ (Symbol _ _) -> parens (pretty q)
-                  UnQual _ (Symbol _ _) -> parens (pretty q)
-                  _ -> pretty q
+exp (Var _ q) = prettyQuoteQName q
 exp (IPVar _ q) = pretty q
-exp (Con _ q) = case q of
-                  Special _ Cons{} -> parens (pretty q)
-                  Qual _ _ (Symbol _ _) -> parens (pretty q)
-                  UnQual _ (Symbol _ _) -> parens (pretty q)
-                  _ -> pretty q
+exp (Con _ q) = prettyQuoteQName q
 
 exp x@XTag{} = pretty' x
 exp x@XETag{} = pretty' x
@@ -1785,20 +1778,7 @@ typ (TyParArray _ t) =
                write ":")
 typ (TyApp _ f a) = spaced [pretty f, pretty a]
 typ (TyVar _ n) = pretty n
-typ (TyCon _ p) =
-  case p of
-    Qual _ _ name ->
-      case name of
-        Ident _ _ -> pretty p
-        Symbol _ _ -> parens (pretty p)
-    UnQual _ name ->
-      case name of
-        Ident _ _ -> pretty p
-        Symbol _ _ -> parens (pretty p)
-    Special _ con ->
-      case con of
-        FunCon _ -> parens (pretty p)
-        _ -> pretty p
+typ (TyCon _ p) = prettyQuoteQName p
 typ (TyParen _ e) = parens (pretty e)
 typ (TyInfix _ a promotedop b) = do
   -- Apply special rules to line-break operators.

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -354,7 +354,7 @@ instance Pretty Pat where
                                space)
                            (pretty b))
       PApp _ f args ->
-        depend (do pretty f
+        depend (do prettyQuoteQName f
                    unless (null args) space)
                (spaced (map pretty args))
       PTuple _ boxed pats ->
@@ -370,11 +370,11 @@ instance Pretty Pat where
       PParen _ e -> parens (pretty e)
       PRec _ qname fields -> do
         let horVariant = do
-              pretty qname
+              prettyQuoteQName qname
               space
               braces $ commas $ map pretty fields
             verVariant =
-              depend (pretty qname >> space) $ do
+              depend (prettyQuoteQName qname >> space) $ do
                 case fields of
                   [] -> write "{}"
                   [field] -> braces $ pretty field
@@ -565,7 +565,7 @@ exp (List _ es) =
           brackets (inter (write ", ")
                           (map pretty es))
 exp (RecUpdate _ exp' updates) = recUpdateExpr (pretty exp') updates
-exp (RecConstr _ qname updates) = recUpdateExpr (pretty qname) updates
+exp (RecConstr _ qname updates) = recUpdateExpr (prettyQuoteQName qname) updates
 exp (Let _ binds e) =
   depend (write "let ")
          (do pretty binds
@@ -1000,7 +1000,7 @@ instance Pretty Alt where
 instance Pretty Asst where
   prettyInternal x =
     case x of
-      ClassA _ name types -> spaced (pretty name : map pretty types)
+      ClassA _ name types -> spaced (prettyQuoteQName name : map pretty types)
       i@InfixA {} -> pretty' i
       IParam _ name ty -> do
         pretty name
@@ -1081,10 +1081,10 @@ instance Pretty FieldUpdate where
   prettyInternal x =
     case x of
       FieldUpdate _ n e ->
-        swing (do pretty n
+        swing (do prettyQuoteQName n
                   write " =")
                (pretty e)
-      FieldPun _ n -> pretty n
+      FieldPun _ n -> prettyQuoteQName n
       FieldWildcard _ -> write ".."
 
 instance Pretty GuardedRhs where
@@ -1137,10 +1137,10 @@ instance Pretty PatField where
   prettyInternal x =
     case x of
       PFieldPat _ n p ->
-        depend (do pretty n
+        depend (do prettyQuoteQName n
                    write " = ")
                (pretty p)
-      PFieldPun _ n -> pretty n
+      PFieldPun _ n -> prettyQuoteQName n
       PFieldWildcard _ -> write ".."
 
 instance Pretty QualConDecl where
@@ -1220,7 +1220,7 @@ instance Pretty InstHead where
   prettyInternal x =
     case x of
       -- Base cases
-      IHCon _ name -> pretty name
+      IHCon _ name -> prettyQuoteQName name
       IHInfix _ typ' name ->
         depend (pretty typ')
                (do space
@@ -1846,7 +1846,7 @@ typ (TyPromoted _ (PromotedTuple _ ts)) =
      write ")"
 typ (TyPromoted _ (PromotedCon _ _ tname)) =
   do write "'"
-     pretty tname
+     prettyQuoteQName tname
 typ (TyPromoted _ (PromotedString _ _ raw)) = do
   do write "\""
      string raw


### PR DESCRIPTION
In many cases, if a symbol is used in the prefix position, HIndent strips its surrounding parentheses. This produces invalid code; the parentheses are required:

```haskell
f' ((:|) x _) = x  -- Input
f' (:| x _) = x    -- Output (invalid Haskell syntax)
```

Fix these cases by using a function which parenthesizes symbols (prettyQuoteQName) instead of one which doesn't (pretty).