### PR TITLE
Fix associated type families, close #528.

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1558,6 +1558,14 @@ cdsmith Quotes are dropped from package imports #480
 import qualified "base" Prelude as P
 ```
 
+alexwl Hindent breaks associated type families annotated with injectivity information #528
+
+```haskell
+-- https://github.com/commercialhaskell/hindent/issues/528
+class C a where
+  type F a = b | b -> a
+```
+
 # MINIMAL pragma
 
 Monad example


### PR DESCRIPTION
The PR fixes this:

Input haskell
```haskell
class C a where type F a = b | b -> a
```

Expected output haskell
```haskell
class C a where
  type F a = b | b -> a
```

Actual output haskell
```haskell
class C a where
  type F a :: b| b -> a
```