### PR TITLE
Reorganize tests related to lambda expressions

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -769,14 +769,14 @@ type family Closed (a :: k) :: Bool where
 
 Lazy patterns
 
-``` haskell
+```haskell
 f = \ ~a -> undefined
 -- \~a yields parse error on input ‘\~’
 ```
 
 Bang patterns
 
-``` haskell
+```haskell
 f = \ !a -> undefined
 -- \!a yields parse error on input ‘\!’
 ```


### PR DESCRIPTION
This PR creates the "Lambda expressions" section in `TESTS.md`, moves tests related to lambda expressions inside it, and removes duplicated tests.

This is a part of #610.
