### PR TITLE
Reorganize tests related to type signature declarations

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -466,6 +466,13 @@ Tuples
 fun :: (a, b, c) -> (a, b)
 ```
 
+Infix operator
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/301
+(+) :: ()
+```
+
 #### Promoted types
 
 Promoted infix type constructor
@@ -1623,13 +1630,6 @@ ys = (++) [] []
 
 cons :: V.Vector a -> V.Vector a -> V.Vector a
 cons = (V.++)
-```
-
-ivan-timokhin breaks operators type signatures #301
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/301
-(+) :: ()
 ```
 
 cdepillabout Long deriving clauses are not reformatted #289

--- a/TESTS.md
+++ b/TESTS.md
@@ -476,6 +476,17 @@ Tuples
 fun :: (a, b, c) -> (a, b)
 ```
 
+Promoted list (issue #348)
+
+```haskell
+a :: A '[ 'True]
+a = undefined
+
+-- nested promoted list with multiple elements.
+b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
+b = undefined
+```
+
 #### Symbol type constructors
 
 Infix
@@ -969,17 +980,6 @@ g =
 ```
 
 ## Type signatures
-
-Promoted list (issue #348)
-
-```haskell
-a :: A '[ 'True]
-a = undefined
-
--- nested promoted list with multiple elements.
-b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
-b = undefined
-```
 
 Promoted list with a tuple (issue #348)
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -486,7 +486,7 @@ fun :: [a|bc|]
 
 Tuples
 
-``` haskell
+```haskell
 fun :: (a, b, c) -> (a, b)
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -458,6 +458,12 @@ fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
 fun2 = undefined
 ```
 
+Quasiquotes in types
+
+```haskell
+fun :: [a|bc|]
+```
+
 Tuples
 
 ``` haskell
@@ -943,12 +949,6 @@ g =
 ```
 
 ## Type signatures
-
-Quasiquotes in types
-
-```haskell
-fun :: [a|bc|]
-```
 
 Implicit parameters
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -500,6 +500,15 @@ b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
 b = undefined
 ```
 
+Prefix promoted symbol type constructor
+
+```haskell
+a :: '(T.:->) 'True 'False
+b :: (T.:->) 'True 'False
+c :: '(:->) 'True 'False
+d :: (:->) 'True 'False
+```
+
 #### Symbol type constructors
 
 Infix
@@ -990,17 +999,6 @@ g =
   case x of
     $(mkPat y z) -> True
     _ -> False
-```
-
-## Type signatures
-
-Prefix promoted symbol type constructor
-
-```haskell
-a :: '(T.:->) 'True 'False
-b :: (T.:->) 'True 'False
-c :: '(:->) 'True 'False
-d :: (:->) 'True 'False
 ```
 
 ## Function declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -489,6 +489,17 @@ b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
 b = undefined
 ```
 
+Promoted list with a tuple (issue #348)
+
+```haskell
+a :: A '[ '( a, b, c, d)]
+a = undefined
+
+-- nested promoted tuples.
+b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
+b = undefined
+```
+
 #### Symbol type constructors
 
 Infix
@@ -982,17 +993,6 @@ g =
 ```
 
 ## Type signatures
-
-Promoted list with a tuple (issue #348)
-
-```haskell
-a :: A '[ '( a, b, c, d)]
-a = undefined
-
--- nested promoted tuples.
-b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
-b = undefined
-```
 
 Prefix promoted symbol type constructor
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -458,6 +458,12 @@ fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
 fun2 = undefined
 ```
 
+Implicit parameters
+
+```haskell
+f :: (?x :: Int) => Int
+```
+
 Quasiquotes in types
 
 ```haskell
@@ -949,12 +955,6 @@ g =
 ```
 
 ## Type signatures
-
-Implicit parameters
-
-```haskell
-f :: (?x :: Int) => Int
-```
 
 Symbol type constructor
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -477,6 +477,13 @@ fun ::
   -> c
 ```
 
+Symbol class constructor in class constraint
+
+```haskell
+f :: (a :?: b) => (a, b)
+f' :: ((:?:) a b) => (a, b)
+```
+
 ### Type synonym declarations
 
 Short
@@ -930,13 +937,6 @@ g =
 ```
 
 ## Type signatures
-
-Symbol class constructor in class constraint
-
-```haskell
-f :: (a :?: b) => (a, b)
-f' :: ((:?:) a b) => (a, b)
-```
 
 Tuples
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -440,14 +440,6 @@ type family Closed (a :: k) :: Bool where
 
 ### Type signature declarations
 
-Long argument list should line break
-
-```haskell
-longLongFunction ::
-     ReaderT r (WriterT w (StateT s m)) a
-  -> StateT s (WriterT w (ReaderT r m)) a
-```
-
 Always break after `::` on overlong signatures
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -458,6 +458,12 @@ fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
 fun2 = undefined
 ```
 
+Tuples
+
+``` haskell
+fun :: (a, b, c) -> (a, b)
+```
+
 #### Type signature with class constraints
 
 Short
@@ -937,12 +943,6 @@ g =
 ```
 
 ## Type signatures
-
-Tuples
-
-``` haskell
-fun :: (a, b, c) -> (a, b)
-```
 
 Quasiquotes in types
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,6 +448,12 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
+Class constraints
+
+```haskell
+fun :: (Class a, Class b) => a -> b -> c
+```
+
 Class constraints should leave `::` on same line
 
 ```haskell
@@ -922,12 +928,6 @@ g =
 ```
 
 ## Type signatures
-
-Class constraints
-
-``` haskell
-fun :: (Class a, Class b) => a -> b -> c
-```
 
 Symbol class constructor in class constraint
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -464,6 +464,13 @@ Implicit parameters
 f :: (?x :: Int) => Int
 ```
 
+Symbol type constructor
+
+```haskell
+f :: a :?: b
+f' :: (:?:) a b
+```
+
 Quasiquotes in types
 
 ```haskell
@@ -955,13 +962,6 @@ g =
 ```
 
 ## Type signatures
-
-Symbol type constructor
-
-```haskell
-f :: a :?: b
-f' :: (:?:) a b
-```
 
 Promoted list (issue #348)
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -440,13 +440,18 @@ type family Closed (a :: k) :: Bool where
 
 ### Type signature declarations
 
-Always break after `::` on overlong signatures
+Short
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/390
 fun :: Is => Short
 fun = undefined
+```
 
+Always break after `::` on overlong signatures
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/390
 someFunctionSignature ::
      Wiiiiiiiiiiiiiiiiith
   -> Enough
@@ -538,7 +543,15 @@ f' :: (:?:) a b
 
 #### Type signature with class constraints
 
-Short
+Single
+
+```haskell
+-- https://github.com/commercialhaskell/hindent/issues/244
+x :: Num a => a
+x = undefined
+```
+
+Multiple
 
 ```haskell
 fun :: (Class a, Class b) => a -> b -> c
@@ -1696,14 +1709,6 @@ RecursiveDo `rec` and `mdo` keyword #328
 rec = undefined
 
 mdo = undefined
-```
-
-tfausak Class constraints cause too many newlines #244
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/244
-x :: Num a => a
-x = undefined
 ```
 
 ocharles Type application differs from function application (leading to long lines) #359

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,16 +448,6 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
-With infix promoted type constructor
-
-```haskell
-fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
-fun1 = undefined
-
-fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
-fun2 = undefined
-```
-
 Implicit parameters
 
 ```haskell
@@ -474,6 +464,18 @@ Tuples
 
 ``` haskell
 fun :: (a, b, c) -> (a, b)
+```
+
+#### Promoted types
+
+Promoted infix type constructor
+
+```haskell
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 = undefined
+
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 = undefined
 ```
 
 Promoted list (issue #348)

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,7 +448,19 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
-Class constraints
+with infix promoted type constructor
+
+```haskell
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 = undefined
+
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 = undefined
+```
+
+#### Type signature with class constraints
+
+Short
 
 ```haskell
 fun :: (Class a, Class b) => a -> b -> c
@@ -463,16 +475,6 @@ fun ::
   => fooooooooooo bar mu zot
   -> fooooooooooo bar mu zot
   -> c
-```
-
-with infix promoted type constructor
-
-```haskell
-fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
-fun1 = undefined
-
-fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
-fun2 = undefined
 ```
 
 ### Type synonym declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,6 +448,20 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
+Always break before `::` on overlong signatures
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/390
+fun :: Is => Short
+fun = undefined
+
+someFunctionSignature ::
+     Wiiiiiiiiiiiiiiiiith
+  -> Enough
+  -> (Arguments -> To ())
+  -> Overflow (The Line Limit)
+```
+
 Implicit parameters
 
 ```haskell
@@ -1698,20 +1712,6 @@ tfausak Class constraints cause too many newlines #244
 -- https://github.com/commercialhaskell/hindent/issues/244
 x :: Num a => a
 x = undefined
-```
-
-expipiplus1 Always break before `::` on overlong signatures #390
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/390
-fun :: Is => Short
-fun = undefined
-
-someFunctionSignature ::
-     Wiiiiiiiiiiiiiiiiith
-  -> Enough
-  -> (Arguments -> To ())
-  -> Overflow (The Line Limit)
 ```
 
 ocharles Type application differs from function application (leading to long lines) #359

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,6 +448,17 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
+Class constraints should leave `::` on same line
+
+```haskell
+-- see https://github.com/mihaimaruseac/hindent/pull/266#issuecomment-244182805
+fun ::
+     (Class a, Class b)
+  => fooooooooooo bar mu zot
+  -> fooooooooooo bar mu zot
+  -> c
+```
+
 with infix promoted type constructor
 
 ```haskell
@@ -911,17 +922,6 @@ g =
 ```
 
 ## Type signatures
-
-Class constraints should leave `::` on same line
-
-``` haskell
--- see https://github.com/chrisdone/hindent/pull/266#issuecomment-244182805
-fun ::
-     (Class a, Class b)
-  => fooooooooooo bar mu zot
-  -> fooooooooooo bar mu zot
-  -> c
-```
 
 Class constraints
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,6 +448,7 @@ type family Closed (a :: k) :: Bool where
   Closed x = 'True
 ```
 
+### Type signature declarations
 ### Type synonym declarations
 
 Short

--- a/TESTS.md
+++ b/TESTS.md
@@ -132,16 +132,6 @@ import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 
 ## Declarations
 
-Type declaration with infix promoted type constructor
-
-```haskell
-fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
-fun1 = undefined
-
-fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
-fun2 = undefined
-```
-
 ### Class declarations
 
 Default signatures
@@ -449,6 +439,17 @@ type family Closed (a :: k) :: Bool where
 ```
 
 ### Type signature declarations
+
+with infix promoted type constructor
+
+```haskell
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 = undefined
+
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 = undefined
+```
+
 ### Type synonym declarations
 
 Short

--- a/TESTS.md
+++ b/TESTS.md
@@ -440,6 +440,14 @@ type family Closed (a :: k) :: Bool where
 
 ### Type signature declarations
 
+Long argument list should line break
+
+```haskell
+longLongFunction ::
+     ReaderT r (WriterT w (StateT s m)) a
+  -> StateT s (WriterT w (ReaderT r m)) a
+```
+
 with infix promoted type constructor
 
 ```haskell
@@ -903,14 +911,6 @@ g =
 ```
 
 ## Type signatures
-
-Long argument list should line break
-
-```haskell
-longLongFunction ::
-     ReaderT r (WriterT w (StateT s m)) a
-  -> StateT s (WriterT w (ReaderT r m)) a
-```
 
 Class constraints should leave `::` on same line
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -464,13 +464,6 @@ Implicit parameters
 f :: (?x :: Int) => Int
 ```
 
-Symbol type constructor
-
-```haskell
-f :: a :?: b
-f' :: (:?:) a b
-```
-
 Quasiquotes in types
 
 ```haskell
@@ -481,6 +474,20 @@ Tuples
 
 ``` haskell
 fun :: (a, b, c) -> (a, b)
+```
+
+#### Symbol type constructors
+
+Infix
+
+```haskell
+f :: a :?: b
+```
+
+Prefix
+
+```haskell
+f' :: (:?:) a b
 ```
 
 #### Type signature with class constraints

--- a/TESTS.md
+++ b/TESTS.md
@@ -459,6 +459,19 @@ someFunctionSignature ::
   -> Overflow (The Line Limit)
 ```
 
+A long type is broken into lines
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/359
+thing ::
+     ( ResB.BomEx
+     , Maybe [( Entity BomSnapshot
+              , ( [ResBS.OrderSubstituteAggr]
+                , ( Maybe (Entity BomSnapshotHistory)
+                  , Maybe (Entity BomSnapshotHistory))))])
+  -> [(ResB.BomEx, Maybe ResBS.BomSnapshotAggr)]
+```
+
 Implicit parameters
 
 ```haskell
@@ -1709,19 +1722,6 @@ RecursiveDo `rec` and `mdo` keyword #328
 rec = undefined
 
 mdo = undefined
-```
-
-ocharles Type application differs from function application (leading to long lines) #359
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/359
-thing ::
-     ( ResB.BomEx
-     , Maybe [( Entity BomSnapshot
-              , ( [ResBS.OrderSubstituteAggr]
-                , ( Maybe (Entity BomSnapshotHistory)
-                  , Maybe (Entity BomSnapshotHistory))))])
-  -> [(ResB.BomEx, Maybe ResBS.BomSnapshotAggr)]
 ```
 
 NorfairKing Do as left-hand side of an infix operation #296

--- a/TESTS.md
+++ b/TESTS.md
@@ -444,7 +444,7 @@ Short
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/390
-fun :: Is => Short
+fun :: Short
 fun = undefined
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,7 +448,7 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
-Always break before `::` on overlong signatures
+Always break after `::` on overlong signatures
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/390

--- a/TESTS.md
+++ b/TESTS.md
@@ -448,7 +448,7 @@ longLongFunction ::
   -> StateT s (WriterT w (ReaderT r m)) a
 ```
 
-with infix promoted type constructor
+With infix promoted type constructor
 
 ```haskell
 fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)


### PR DESCRIPTION
This PR creates the "Type signature declarations" section and a few subsections. It moves tests related to type signature declarations inside them, breaks large tests, fixes issue URLs, and removes duplicated or unnecessary lines.

This is a part of #610.
