### PR TITLE
Define `ModuleWarning` in replacement for `WarningTxt`

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -44,6 +44,7 @@ library
       HIndent.Ast.Module
       HIndent.Ast.Module.Declaration
       HIndent.Ast.Module.Name
+      HIndent.Ast.Module.Warning
       HIndent.Ast.NodeComments
       HIndent.Ast.WithComments
       HIndent.ByteString

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -45,6 +45,7 @@ library
       HIndent.Ast.Module.Declaration
       HIndent.Ast.Module.Name
       HIndent.Ast.Module.Warning
+      HIndent.Ast.Module.Warning.Kind
       HIndent.Ast.NodeComments
       HIndent.Ast.WithComments
       HIndent.ByteString

--- a/src/HIndent/Ast/Module/Declaration.hs
+++ b/src/HIndent/Ast/Module/Declaration.hs
@@ -5,20 +5,19 @@ module HIndent.Ast.Module.Declaration
   , mkModuleDeclaration
   ) where
 
-import HIndent.Applicative
-import HIndent.Ast.Module.Name
-import HIndent.Ast.NodeComments
-import HIndent.Ast.WithComments
+import           HIndent.Applicative
+import           HIndent.Ast.Module.Name
+import           HIndent.Ast.Module.Warning
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import qualified HIndent.GhcLibParserWrapper.GHC.Unit.Module.Warnings as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.Types
+import           HIndent.Pretty
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data ModuleDeclaration = ModuleDeclaration
-  { name :: WithComments ModuleName
-  , warning :: Maybe (GHC.LocatedP GHC.WarningTxt')
+  { name    :: WithComments ModuleName
+  , warning :: Maybe ModuleWarning
   , exports :: Maybe (GHC.LocatedL [GHC.LIE GHC.GhcPs])
   }
 
@@ -30,11 +29,10 @@ instance Pretty ModuleDeclaration where
     pretty name
     whenJust warning $ \x -> do
       space
-      pretty $ fmap ModuleDeprecatedPragma x
+      pretty x
     whenJust exports $ \xs -> do
       newline
-      indentedBlock $ do
-        printCommentsAnd xs (vTuple . fmap pretty)
+      indentedBlock $ do printCommentsAnd xs (vTuple . fmap pretty)
     string " where"
 
 mkModuleDeclaration :: GHC.HsModule' -> Maybe ModuleDeclaration
@@ -43,5 +41,5 @@ mkModuleDeclaration m =
     Nothing -> Nothing
     Just name' -> Just ModuleDeclaration {..}
       where name = mkModuleName <$> fromGenLocated name'
-            warning = GHC.getDeprecMessage m
+            warning = mkModuleWarning m
             exports = GHC.hsmodExports m

--- a/src/HIndent/Ast/Module/Declaration.hs
+++ b/src/HIndent/Ast/Module/Declaration.hs
@@ -17,7 +17,7 @@ import           HIndent.Pretty.NodeComments
 
 data ModuleDeclaration = ModuleDeclaration
   { name    :: WithComments ModuleName
-  , warning :: Maybe ModuleWarning
+  , warning :: Maybe (WithComments ModuleWarning)
   , exports :: Maybe (GHC.LocatedL [GHC.LIE GHC.GhcPs])
   }
 

--- a/src/HIndent/Ast/Module/Declaration.hs
+++ b/src/HIndent/Ast/Module/Declaration.hs
@@ -5,18 +5,18 @@ module HIndent.Ast.Module.Declaration
   , mkModuleDeclaration
   ) where
 
-import           HIndent.Applicative
-import           HIndent.Ast.Module.Name
-import           HIndent.Ast.Module.Warning
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.WithComments
+import HIndent.Applicative
+import HIndent.Ast.Module.Name
+import HIndent.Ast.Module.Warning
+import HIndent.Ast.NodeComments
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 data ModuleDeclaration = ModuleDeclaration
-  { name    :: WithComments ModuleName
+  { name :: WithComments ModuleName
   , warning :: Maybe (WithComments ModuleWarning)
   , exports :: Maybe (GHC.LocatedL [GHC.LIE GHC.GhcPs])
   }
@@ -32,7 +32,8 @@ instance Pretty ModuleDeclaration where
       pretty x
     whenJust exports $ \xs -> do
       newline
-      indentedBlock $ do printCommentsAnd xs (vTuple . fmap pretty)
+      indentedBlock $ do
+        printCommentsAnd xs (vTuple . fmap pretty)
     string " where"
 
 mkModuleDeclaration :: GHC.HsModule' -> Maybe ModuleDeclaration

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -5,6 +5,7 @@ module HIndent.Ast.Module.Warning
   , mkModuleWarning
   ) where
 
+import           HIndent.Ast.Module.Warning.Kind
 import           HIndent.Ast.NodeComments
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs                   as GHC
@@ -18,19 +19,8 @@ data ModuleWarning = ModuleWarning
   , kind     :: Kind
   }
 
-data Kind
-  = Warning
-  | Deprecated
-
 instance CommentExtraction ModuleWarning where
   nodeComments _ = NodeComments [] [] []
-
-instance CommentExtraction Kind where
-  nodeComments _ = NodeComments [] [] []
-
-instance Pretty Kind where
-  pretty' Warning    = string "WARNING"
-  pretty' Deprecated = string "DEPRECATED"
 
 instance Pretty ModuleWarning where
   pretty' ModuleWarning {..} = do

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -41,7 +41,7 @@ mkModuleWarning =
   fmap (fromGenLocated . fmap fromWarningTxt) . GHC.getDeprecMessage
 
 fromWarningTxt :: GHC.WarningTxt' -> ModuleWarning
-#if MIN_VERSION_ghc_lib_parser(9, 4, 0)
+#if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 fromWarningTxt (GHC.WarningTxt _ _ s) = ModuleWarning {..}
   where
     messages = fmap showOutputable s

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -33,18 +33,17 @@ instance Pretty Kind where
   pretty' Deprecated = string "DEPRECATED"
 
 instance Pretty ModuleWarning where
-  pretty' ModuleWarning {messages = [msg], ..} = do
-    string "{-# "
-    pretty kind
-    space
-    string msg
-    string " #-}"
   pretty' ModuleWarning {..} = do
     string "{-# "
     pretty kind
     space
-    hList $ fmap string messages
+    prettyMsgs
     string " #-}"
+    where
+      prettyMsgs =
+        case messages of
+          [x] -> string x
+          xs  -> hList $ fmap string xs
 
 mkModuleWarning :: GHC.HsModule' -> Maybe (WithComments ModuleWarning)
 mkModuleWarning =

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -25,20 +25,23 @@ data Kind
 instance CommentExtraction ModuleWarning where
   nodeComments _ = NodeComments [] [] []
 
+instance CommentExtraction Kind where
+  nodeComments _ = NodeComments [] [] []
+
+instance Pretty Kind where
+  pretty' Warning    = string "WARNING"
+  pretty' Deprecated = string "DEPRECATED"
+
 instance Pretty ModuleWarning where
   pretty' ModuleWarning {messages = [msg], ..} = do
     string "{-# "
-    case kind of
-      Warning    -> string "WARNING"
-      Deprecated -> string "DEPRECATED"
+    pretty kind
     space
     string msg
     string " #-}"
   pretty' ModuleWarning {..} = do
     string "{-# "
-    case kind of
-      Warning    -> string "WARNING"
-      Deprecated -> string "DEPRECATED"
+    pretty kind
     space
     hList $ fmap string messages
     string " #-}"

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -41,7 +41,7 @@ mkModuleWarning =
   fmap (fromGenLocated . fmap fromWarningTxt) . GHC.getDeprecMessage
 
 fromWarningTxt :: GHC.WarningTxt' -> ModuleWarning
-#if MIN_VERSION_ghc_lib_parser(9, 6, 1)
+#if MIN_VERSION_ghc_lib_parser(9, 8, 1)
 fromWarningTxt (GHC.WarningTxt _ _ s) = ModuleWarning {..}
   where
     messages = fmap showOutputable s

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -3,8 +3,8 @@ module HIndent.Ast.Module.Warning
   , mkModuleWarning
   ) where
 
-import qualified GHC.Hs                                               as GHC
 import           HIndent.Ast.NodeComments
+import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs                   as GHC
 import qualified HIndent.GhcLibParserWrapper.GHC.Unit.Module.Warnings as GHC
 import           HIndent.Pretty
@@ -12,13 +12,14 @@ import           HIndent.Pretty.NodeComments
 import           HIndent.Pretty.Types
 
 newtype ModuleWarning =
-  ModuleWarning (GHC.LocatedP GHC.WarningTxt')
+  ModuleWarning GHC.WarningTxt'
 
 instance CommentExtraction ModuleWarning where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty ModuleWarning where
-  pretty' (ModuleWarning x) = pretty' $ fmap ModuleDeprecatedPragma x
+  pretty' (ModuleWarning x) = pretty' $ ModuleDeprecatedPragma x
 
-mkModuleWarning :: GHC.HsModule' -> Maybe ModuleWarning
-mkModuleWarning = fmap ModuleWarning . GHC.getDeprecMessage
+mkModuleWarning :: GHC.HsModule' -> Maybe (WithComments ModuleWarning)
+mkModuleWarning =
+  fmap (fromGenLocated . fmap ModuleWarning) . GHC.getDeprecMessage

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -1,0 +1,24 @@
+module HIndent.Ast.Module.Warning
+  ( ModuleWarning
+  , mkModuleWarning
+  ) where
+
+import qualified GHC.Hs                                               as GHC
+import           HIndent.Ast.NodeComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs                   as GHC
+import qualified HIndent.GhcLibParserWrapper.GHC.Unit.Module.Warnings as GHC
+import           HIndent.Pretty
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.Types
+
+newtype ModuleWarning =
+  ModuleWarning (GHC.LocatedP GHC.WarningTxt')
+
+instance CommentExtraction ModuleWarning where
+  nodeComments _ = NodeComments [] [] []
+
+instance Pretty ModuleWarning where
+  pretty' (ModuleWarning x) = pretty' $ fmap ModuleDeprecatedPragma x
+
+mkModuleWarning :: GHC.HsModule' -> Maybe ModuleWarning
+mkModuleWarning = fmap ModuleWarning . GHC.getDeprecMessage

--- a/src/HIndent/Ast/Module/Warning/Kind.hs
+++ b/src/HIndent/Ast/Module/Warning/Kind.hs
@@ -1,0 +1,19 @@
+module HIndent.Ast.Module.Warning.Kind
+  ( Kind(..)
+  ) where
+
+import           HIndent.Ast.NodeComments
+import           HIndent.Pretty
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+
+data Kind
+  = Warning
+  | Deprecated
+
+instance CommentExtraction Kind where
+  nodeComments _ = NodeComments [] [] []
+
+instance Pretty Kind where
+  pretty' Warning    = string "WARNING"
+  pretty' Deprecated = string "DEPRECATED"

--- a/src/HIndent/Ast/Module/Warning/Kind.hs
+++ b/src/HIndent/Ast/Module/Warning/Kind.hs
@@ -2,10 +2,10 @@ module HIndent.Ast.Module.Warning.Kind
   ( Kind(..)
   ) where
 
-import           HIndent.Ast.NodeComments
-import           HIndent.Pretty
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import HIndent.Ast.NodeComments
+import HIndent.Pretty
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 data Kind
   = Warning
@@ -15,5 +15,5 @@ instance CommentExtraction Kind where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Kind where
-  pretty' Warning    = string "WARNING"
+  pretty' Warning = string "WARNING"
   pretty' Deprecated = string "DEPRECATED"

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 -- | Pretty printing.
 --
@@ -21,45 +21,45 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import Data.Maybe
-import Data.Void
-import GHC.Core.Coercion
-import GHC.Core.InstEnv
-import GHC.Data.Bag
-import GHC.Data.BooleanFormula
-import GHC.Data.FastString
-import GHC.Hs
-import GHC.Stack
-import GHC.Types.Basic
-import GHC.Types.Fixity
-import GHC.Types.ForeignCall
-import GHC.Types.Name
-import GHC.Types.Name.Reader
-import GHC.Types.SourceText
-import GHC.Types.SrcLoc
-import GHC.Unit.Module.Warnings
-import HIndent.Applicative
-import HIndent.Ast.NodeComments
-import HIndent.Config
-import HIndent.Fixity
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
-import HIndent.Printer
-import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
-import Text.Show.Unicode
+import           Control.Monad
+import           Control.Monad.RWS
+import           Data.Maybe
+import           Data.Void
+import           GHC.Core.Coercion
+import           GHC.Core.InstEnv
+import           GHC.Data.Bag
+import           GHC.Data.BooleanFormula
+import           GHC.Data.FastString
+import           GHC.Hs
+import           GHC.Stack
+import           GHC.Types.Basic
+import           GHC.Types.Fixity
+import           GHC.Types.ForeignCall
+import           GHC.Types.Name
+import           GHC.Types.Name.Reader
+import           GHC.Types.SourceText
+import           GHC.Types.SrcLoc
+import           GHC.Unit.Module.Warnings
+import           HIndent.Applicative
+import           HIndent.Ast.NodeComments
+import           HIndent.Config
+import           HIndent.Fixity
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
+import           HIndent.Printer
+import           Language.Haskell.GhclibParserEx.GHC.Hs.Expr
+import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable as NonEmpty
-import GHC.Core.DataCon
+import qualified Data.Foldable                               as NonEmpty
+import           GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import GHC.Unit
+import           GHC.Unit
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-import GHC.Types.PkgQual
+import           GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -93,10 +93,8 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
+           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c) $
+         spaced $ fmap pretty $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -132,19 +130,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
 instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d) = pretty d
-  pretty' (InstD _ inst) = pretty inst
-  pretty' (DerivD _ x) = pretty x
-  pretty' (ValD _ bind) = pretty bind
-  pretty' (SigD _ s) = pretty s
-  pretty' (KindSigD _ x) = pretty x
-  pretty' (DefD _ x) = pretty x
-  pretty' (ForD _ x) = pretty x
-  pretty' (WarningD _ x) = pretty x
-  pretty' (AnnD _ x) = pretty x
-  pretty' (RuleD _ x) = pretty x
-  pretty' (SpliceD _ sp) = pretty sp
-  pretty' DocD {} = docNode
+  pretty' (TyClD _ d)      = pretty d
+  pretty' (InstD _ inst)   = pretty inst
+  pretty' (DerivD _ x)     = pretty x
+  pretty' (ValD _ bind)    = pretty bind
+  pretty' (SigD _ s)       = pretty s
+  pretty' (KindSigD _ x)   = pretty x
+  pretty' (DefD _ x)       = pretty x
+  pretty' (ForD _ x)       = pretty x
+  pretty' (WarningD _ x)   = pretty x
+  pretty' (AnnD _ x)       = pretty x
+  pretty' (RuleD _ x)      = pretty x
+  pretty' (SpliceD _ sp)   = pretty sp
+  pretty' DocD {}          = docNode
   pretty' (RoleAnnotD _ x) = pretty x
 
 instance Pretty (TyClDecl GhcPs) where
@@ -182,7 +180,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_cons tcdDataDefn of
         DataTypeCons {} -> string "data "
-        NewTypeCon {} -> string "newtype "
+        NewTypeCon {}   -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -197,7 +195,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -212,7 +210,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #endif
 prettyTyClDecl ClassDecl {..} = do
   if isJust tcdCtxt
@@ -233,21 +231,20 @@ prettyTyClDecl ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            [] -> string "()"
+            []  -> string "()"
             [x] -> pretty x
-            xs -> hvTuple $ fmap pretty xs
+            xs  -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock
-          $ string "| "
-              |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
-                       printCommentsAnd x $ \(FunDep _ from to) ->
-                         spaced
-                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock $
+          string "| " |=>
+          vCommaSep
+            (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
+               printCommentsAnd x $ \(FunDep _ from to) ->
+                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -258,27 +255,27 @@ prettyTyClDecl ClassDecl {..} = do
         Infix ->
           case hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens
-                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens $
+                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..} = pretty cid_inst
+  pretty' ClsInstD {..}     = pretty cid_inst
   pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (HsBind GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..} = pretty fun_matches
-prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {} = notGeneratedByParser
+prettyHsBind FunBind {..}     = pretty fun_matches
+prettyHsBind PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind VarBind {}       = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {} = notGeneratedByParser
+prettyHsBind AbsBinds {}      = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -298,10 +295,9 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -321,9 +317,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -366,10 +362,9 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -389,9 +384,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' IdSig {} = notGeneratedByParser
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
@@ -450,12 +445,12 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       cons =
         case dd_cons of
-          NewTypeCon x -> [x]
+          NewTypeCon x      -> [x]
           DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
-          _ -> False
+          _                                       -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -491,7 +486,7 @@ instance Pretty (HsDataDefn GhcPs) where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
-          _ -> False
+          _                      -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -502,8 +497,8 @@ instance Pretty (ClsInstDecl GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
+        unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -549,18 +544,17 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              [] -> error "Invalid function application."
+              []         -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col'
-              - col
-              - if col == 0
-                  then spaces
-                  else 0
+            col' - col -
+            if col == 0
+              then spaces
+              else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -598,11 +592,11 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens
-        $ prefixedLined ","
-        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens $
+      prefixedLined "," $
+      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
-    isMissing _ = False
+    isMissing _          = False
 prettyHsExpr (ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -627,9 +621,9 @@ prettyHsExpr (HsIf _ cond t f) = do
     branch :: String -> LHsExpr GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ (DoExpr m) xs)) -> doStmt (QualifiedDo m Do) xs
+        (L _ (HsDo _ (DoExpr m) xs))  -> doStmt (QualifiedDo m Do) xs
         (L _ (HsDo _ (MDoExpr m) xs)) -> doStmt (QualifiedDo m Mdo) xs
-        _ -> string str |=> pretty e
+        _                             -> string str |=> pretty e
       where
         doStmt qDo stmts = do
           string str
@@ -637,8 +631,8 @@ prettyHsExpr (HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (HsMultiIf _ guards) =
-  string "if "
-    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if " |=>
+  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -701,9 +695,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsFieldBind a b)]
@@ -731,9 +725,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsRecField' a b)]
@@ -760,11 +754,10 @@ prettyHsExpr (HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr HsProjection {..} =
-  parens
-    $ forM_ proj_flds
-    $ \x -> do
-        string "."
-        pretty x
+  parens $
+  forM_ proj_flds $ \x -> do
+    string "."
+    pretty x
 prettyHsExpr (ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -776,8 +769,8 @@ prettyHsExpr (HsSpliceE _ x) = pretty x
 prettyHsExpr (HsProc _ pat x@(L _ (HsCmdTop _ (L _ (HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock
-    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock $
+    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -811,7 +804,7 @@ prettyHsExpr (HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case -> string "\\case"
+      Case  -> string "\\case"
       Cases -> string "\\cases"
     if null $ unLoc $ mg_alts matches
       then string " {}"
@@ -838,12 +831,10 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do
-                    hor <-|> ver
-                    newline
-                    prefixed "=> "
-                      $ prefixedLined "-> "
-                      $ pretty <$> flatten hst_body
+               in do hor <-|> ver
+                     newline
+                     prefixed "=> " $
+                       prefixedLined "-> " $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -853,7 +844,7 @@ instance Pretty HsSigType' where
     where
       flatten :: LHsType GhcPs -> [LHsType GhcPs]
       flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x = [x]
+      flatten x                       = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
     case sig_bndrs of
       HsOuterExplicit _ xs -> do
@@ -862,8 +853,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt))
-              <-|> (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
+              (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -893,10 +884,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -907,19 +898,19 @@ prettyConDecl ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     forallNeeded =
@@ -937,10 +928,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -951,52 +942,52 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt))
-        <-|> (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt)) <-|>
+        (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
-        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-    
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
+      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
+
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -1004,30 +995,26 @@ prettyConDecl ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \c -> do
-             pretty $ Context c
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \c -> do
+        pretty $ Context c
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #else
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \_ -> do
-             pretty $ Context con_mb_cxt
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \_ -> do
+        pretty $ Context con_mb_cxt
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #endif
 prettyConDecl ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1043,11 +1030,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
 prettyMatchExpr :: Match GhcPs (LHsExpr GhcPs) -> Printer ()
 prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case unLoc $ head m_pats of
-        LazyPat {} -> space
-        BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case unLoc $ head m_pats of
+      LazyPat {} -> space
+      BangPat {} -> space
+      _          -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
@@ -1067,9 +1054,8 @@ prettyMatchExpr Match {..} =
     Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, FunRhs {..}) -> do
-          spaced
-            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
-                ++ fmap pretty xs
+          spaced $
+            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1079,11 +1065,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
 prettyMatchProc :: Match GhcPs (LHsCmd GhcPs) -> Printer ()
 prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case unLoc $ head m_pats of
-        LazyPat {} -> space
-        BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case unLoc $ head m_pats of
+      LazyPat {} -> space
+      BangPat {} -> space
+      _          -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1143,7 +1129,7 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
     where
       horizontal =
         case rec_dotdot of
-          Just _ -> braces $ string ".."
+          Just _  -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1152,8 +1138,8 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) wher
   pretty' HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (HsType GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1258,7 +1244,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hvPromotedList $ fmap pretty xs
+    _  -> hvPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"
@@ -1276,11 +1262,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (HsValBinds epa lr, _) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
@@ -1288,31 +1274,31 @@ instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (HsValBinds epa lr) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty (HsMatchContext GhcPs) where
   pretty' = prettyHsMatchContext
 
 prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr = return ()
-prettyHsMatchContext CaseAlt = return ()
-prettyHsMatchContext IfAlt {} = notGeneratedByParser
+prettyHsMatchContext FunRhs {..}       = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext LambdaExpr        = return ()
+prettyHsMatchContext CaseAlt           = return ()
+prettyHsMatchContext IfAlt {}          = notGeneratedByParser
 prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
-prettyHsMatchContext RecUpd {} = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
-prettyHsMatchContext PatSyn {} = notGeneratedByParser
+prettyHsMatchContext PatBindRhs {}     = notGeneratedByParser
+prettyHsMatchContext PatBindGuards {}  = notGeneratedByParser
+prettyHsMatchContext RecUpd {}         = notGeneratedByParser
+prettyHsMatchContext StmtCtxt {}       = notGeneratedByParser
+prettyHsMatchContext ThPatSplice {}    = notGeneratedByParser
+prettyHsMatchContext ThPatQuote {}     = notGeneratedByParser
+prettyHsMatchContext PatSyn {}         = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
+prettyHsMatchContext LamCaseAlt {}     = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
   pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
@@ -1421,11 +1407,8 @@ instance Pretty (HsSplice GhcPs) where
   pretty' (HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars
-        $ indentedWithFixedLevel 0
-        $ sequence_
-        $ printers [] ""
-        $ unpackFS r
+      wrapWithBars $
+        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1489,13 +1472,13 @@ prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat HsRecFields {..}) =
     case fieldPrinters of
-      [] -> string "{}"
+      []  -> string "{}"
       [x] -> braces x
-      xs -> hvFields xs
+      xs  -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsBracket GhcPs) where
   pretty' (ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1509,10 +1492,10 @@ instance Pretty (HsBracket GhcPs) where
   pretty' (TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x) = pretty x
-  pretty' (Bind x) = pretty x
-  pretty' (TypeFamily x) = pretty x
-  pretty' (TyFamInst x) = pretty x
+  pretty' (Sig x)         = pretty x
+  pretty' (Bind x)        = pretty x
+  pretty' (TypeFamily x)  = pretty x
+  pretty' (TyFamInst x)   = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty EpaComment where
@@ -1534,7 +1517,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
-  pretty' Missing {} = pure () -- This appears in a tuple section.
+  pretty' Missing {}    = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1632,7 +1615,7 @@ instance Pretty (ConDeclField GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x) = pretty' x
+  pretty' (InfixExpr x)                    = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1692,9 +1675,9 @@ instance Pretty InfixApp where
       Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x) = pretty x
-  pretty' (And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs) = hvBarSep $ fmap pretty xs
+  pretty' (Var x)    = pretty x
+  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
 instance Pretty (FieldLabelStrings GhcPs) where
@@ -1702,7 +1685,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name) = pretty name
+  pretty' (Ambiguous _ name)   = pretty name
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1719,9 +1702,8 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclImportList $ \(x, ps) -> do
       when (x == EverythingBut) (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
-        <-|> (newline
-                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
+        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #else
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1738,9 +1720,8 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclHiding $ \(x, ps) -> do
       when x (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
-        <-|> (newline
-                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
+        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #endif
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1763,14 +1744,14 @@ instance Pretty (HsDerivingClause GhcPs) where
 
 instance Pretty (DerivClauseTys GhcPs) where
   pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
+  pretty' (DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {} = notUsedInParsedStage
+  pretty' NoOverlap {}    = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1778,13 +1759,13 @@ instance Pretty StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (FamilyDecl GhcPs) where
   pretty' FamilyDecl {..} = do
-    string
-      $ case fdInfo of
-          DataFamily -> "data"
-          OpenTypeFamily -> "type"
-          ClosedTypeFamily {} -> "type"
+    string $
+      case fdInfo of
+        DataFamily          -> "data"
+        OpenTypeFamily      -> "type"
+        ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel -> string " family "
+      TopLevel    -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
@@ -1807,8 +1788,8 @@ instance Pretty (FamilyDecl GhcPs) where
       _ -> pure ()
 
 instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {} = pure ()
-  pretty' (KindSig _ x) = string ":: " >> pretty x
+  pretty' NoSig {}       = pure ()
+  pretty' (KindSig _ x)  = string ":: " >> pretty x
   pretty' (TyVarSig _ x) = pretty x
 
 instance Pretty (HsTyVarBndr a GhcPs) where
@@ -1827,8 +1808,8 @@ instance Pretty (ArithSeqInfo GhcPs) where
   pretty' (FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (FromThenTo from next to) =
-    brackets
-      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets $
+    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (HsForAllTelescope GhcPs) where
   pretty' HsForAllVis {..} = do
@@ -1874,9 +1855,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ []) -> parens
+          (L _ [])  -> parens
           (L _ [_]) -> id
-          _ -> parens
+          _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1891,10 +1872,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing -> id
-          Just (L _ []) -> parens
+          Nothing        -> id
+          Just (L _ [])  -> parens
           Just (L _ [_]) -> id
-          Just _ -> parens
+          Just _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1952,7 +1933,7 @@ instance Pretty FamEqn' where
     where
       prefix =
         case famEqnFor of
-          DataFamInstDeclForTopLevel -> "data instance"
+          DataFamInstDeclForTopLevel        -> "data instance"
           DataFamInstDeclForInsideClassInst -> "data"
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
@@ -1961,17 +1942,17 @@ instance Pretty
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
+  pretty' (HsValArg x)    = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+  pretty' HsArgPar {}     = notUsedInParsedStage
 #else
 instance Pretty
            (HsArg
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
+  pretty' (HsValArg x)    = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+  pretty' HsArgPar {}     = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
@@ -1996,7 +1977,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2010,7 +1991,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2028,15 +2009,15 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
-  pretty' (IEName _ name) = pretty name
+  pretty' (IEName _ name)    = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+  pretty' (IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name) = pretty name
+  pretty' (IEName name)      = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+  pretty' (IEType _ name)    = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -2165,23 +2146,23 @@ instance Pretty ForeignImport where
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, output s]
-  pretty' (CExport _ conv) = pretty conv
+  pretty' (CExport _ conv)                    = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv) = pretty conv
+  pretty' (CExport _ conv)                    = pretty conv
 #else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _) = pretty conv
+  pretty' (CExport conv _)                    = pretty conv
 #endif
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe = string "safe"
+  pretty' PlaySafe          = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky = string "unsafe"
+  pretty' PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2201,14 +2182,14 @@ instance Pretty (AnnDecl GhcPs) where
 #endif
 instance Pretty (RoleAnnotDecl GhcPs) where
   pretty' (RoleAnnotDecl _ name roles) =
-    spaced
-      $ [string "type role", pretty name]
-          ++ fmap (maybe (string "_") pretty . unLoc) roles
+    spaced $
+    [string "type role", pretty name] ++
+    fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal = string "nominal"
+  pretty' Nominal          = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom = string "phantom"
+  pretty' Phantom          = string "phantom"
 
 instance Pretty (TyFamInstDecl GhcPs) where
   pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2267,8 +2248,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x -> space >> brackets (string $ show x)
-      _ -> pure ()
+      ActiveAfter _ x  -> space >> brackets (string $ show x)
+      _                -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -2284,25 +2265,25 @@ prettyInlineSpec NoUserInlinePrag =
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional = string "<-"
-  pretty' ImplicitBidirectional = string "="
+  pretty' Unidirectional           = string "<-"
+  pretty' ImplicitBidirectional    = string "="
   pretty' ExplicitBidirectional {} = string "<-"
 
 instance Pretty (HsOverLit GhcPs) where
   pretty' OverLit {..} = pretty ol_val
 
 instance Pretty OverLitVal where
-  pretty' (HsIntegral x) = pretty x
+  pretty' (HsIntegral x)   = pretty x
   pretty' (HsFractional x) = pretty x
   pretty' (HsIsString _ x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 #else
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 #endif
 instance Pretty FractionalLit where
   pretty' = output
@@ -2321,7 +2302,7 @@ instance Pretty (HsLit GhcPs) where
   pretty' HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {} -> prettyString
+      HsString {}     -> prettyString
       HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2332,9 +2313,8 @@ instance Pretty (HsLit GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1)
-                $ lined
-                $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1) $
+                lined $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
@@ -2346,13 +2326,13 @@ instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsNumTy _ x)  = string $ show x
+  pretty' (HsStrTy _ x)  = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
 instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsNumTy _ x)  = string $ show x
+  pretty' (HsStrTy _ x)  = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (HsPatSigType GhcPs) where
@@ -2374,10 +2354,10 @@ prettyIPBind (IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {} = string "stock"
+  pretty' StockStrategy {}    = string "stock"
   pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {} = string "newtype"
-  pretty' (ViaStrategy x) = string "via " >> pretty x
+  pretty' NewtypeStrategy {}  = string "newtype"
+  pretty' (ViaStrategy x)     = string "via " >> pretty x
 
 instance Pretty XViaStrategyPs where
   pretty' (XViaStrategyPs _ ty) = pretty ty
@@ -2445,12 +2425,9 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets
-          $ spaced
-              [ pretty listCompLhs
-              , string "|"
-              , hCommaSep $ fmap pretty listCompRhs
-              ]
+        brackets $
+        spaced
+          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2468,7 +2445,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do = string "do"
+  pretty' Do  = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2488,32 +2465,12 @@ instance Pretty (RuleBndr GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv = string "ccall"
-  pretty' CApiConv = string "capi"
-  pretty' StdCallConv = string "stdcall"
-  pretty' PrimCallConv = string "prim"
+  pretty' CCallConv          = string "ccall"
+  pretty' CApiConv           = string "capi"
+  pretty' StdCallConv        = string "stdcall"
+  pretty' PrimCallConv       = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
-#if MIN_VERSION_ghc_lib_parser(9, 8, 1)
-instance Pretty ModuleDeprecatedPragma where
-  pretty' (ModuleDeprecatedPragma (WarningTxt _ _ [msg])) =
-    spaced [string "{-# WARNING", pretty msg, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (WarningTxt _ _ msgs)) =
-    spaced [string "{-# WARNING", hList $ fmap pretty msgs, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ [msg])) =
-    spaced [string "{-# DEPRECATED", pretty msg, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ msgs)) =
-    spaced [string "{-# DEPRECATED", hList $ fmap pretty msgs, string "#-}"]
-#else
-instance Pretty ModuleDeprecatedPragma where
-  pretty' (ModuleDeprecatedPragma (WarningTxt _ [msg])) =
-    spaced [string "{-# WARNING", pretty msg, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (WarningTxt _ msgs)) =
-    spaced [string "{-# WARNING", hList $ fmap pretty msgs, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ [msg])) =
-    spaced [string "{-# DEPRECATED", pretty msg, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ msgs)) =
-    spaced [string "{-# DEPRECATED", hList $ fmap pretty msgs, string "#-}"]
-#endif
+
 instance Pretty HsSrcBang where
   pretty' (HsSrcBang _ unpack strictness) = do
     pretty unpack
@@ -2521,13 +2478,13 @@ instance Pretty HsSrcBang where
     pretty strictness
 
 instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack = string "{-# UNPACK #-}"
+  pretty' SrcUnpack   = string "{-# UNPACK #-}"
   pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' NoSrcUnpack = pure ()
 
 instance Pretty SrcStrictness where
-  pretty' SrcLazy = string "~"
-  pretty' SrcStrict = string "!"
+  pretty' SrcLazy     = string "~"
+  pretty' SrcStrict   = string "!"
   pretty' NoSrcStrict = pure ()
 
 instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
@@ -2551,11 +2508,8 @@ instance Pretty (HsUntypedSplice GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars
-           . indentedWithFixedLevel 0
-           . sequence_
-           . printers [] ""
-           . unpackFS)
+        (wrapWithBars .
+         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Pretty printing.
 --
@@ -21,45 +21,45 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
-import           Data.Maybe
-import           Data.Void
-import           GHC.Core.Coercion
-import           GHC.Core.InstEnv
-import           GHC.Data.Bag
-import           GHC.Data.BooleanFormula
-import           GHC.Data.FastString
-import           GHC.Hs
-import           GHC.Stack
-import           GHC.Types.Basic
-import           GHC.Types.Fixity
-import           GHC.Types.ForeignCall
-import           GHC.Types.Name
-import           GHC.Types.Name.Reader
-import           GHC.Types.SourceText
-import           GHC.Types.SrcLoc
-import           GHC.Unit.Module.Warnings
-import           HIndent.Applicative
-import           HIndent.Ast.NodeComments
-import           HIndent.Config
-import           HIndent.Fixity
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
-import           HIndent.Pretty.SigBindFamily
-import           HIndent.Pretty.Types
-import           HIndent.Printer
-import           Language.Haskell.GhclibParserEx.GHC.Hs.Expr
-import           Text.Show.Unicode
+import Control.Monad
+import Control.Monad.RWS
+import Data.Maybe
+import Data.Void
+import GHC.Core.Coercion
+import GHC.Core.InstEnv
+import GHC.Data.Bag
+import GHC.Data.BooleanFormula
+import GHC.Data.FastString
+import GHC.Hs
+import GHC.Stack
+import GHC.Types.Basic
+import GHC.Types.Fixity
+import GHC.Types.ForeignCall
+import GHC.Types.Name
+import GHC.Types.Name.Reader
+import GHC.Types.SourceText
+import GHC.Types.SrcLoc
+import GHC.Unit.Module.Warnings
+import HIndent.Applicative
+import HIndent.Ast.NodeComments
+import HIndent.Config
+import HIndent.Fixity
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+import HIndent.Pretty.SigBindFamily
+import HIndent.Pretty.Types
+import HIndent.Printer
+import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
+import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable                               as NonEmpty
-import           GHC.Core.DataCon
+import qualified Data.Foldable as NonEmpty
+import GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import           GHC.Unit
+import GHC.Unit
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-import           GHC.Types.PkgQual
+import GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -93,8 +93,10 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -130,19 +132,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
 instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d)      = pretty d
-  pretty' (InstD _ inst)   = pretty inst
-  pretty' (DerivD _ x)     = pretty x
-  pretty' (ValD _ bind)    = pretty bind
-  pretty' (SigD _ s)       = pretty s
-  pretty' (KindSigD _ x)   = pretty x
-  pretty' (DefD _ x)       = pretty x
-  pretty' (ForD _ x)       = pretty x
-  pretty' (WarningD _ x)   = pretty x
-  pretty' (AnnD _ x)       = pretty x
-  pretty' (RuleD _ x)      = pretty x
-  pretty' (SpliceD _ sp)   = pretty sp
-  pretty' DocD {}          = docNode
+  pretty' (TyClD _ d) = pretty d
+  pretty' (InstD _ inst) = pretty inst
+  pretty' (DerivD _ x) = pretty x
+  pretty' (ValD _ bind) = pretty bind
+  pretty' (SigD _ s) = pretty s
+  pretty' (KindSigD _ x) = pretty x
+  pretty' (DefD _ x) = pretty x
+  pretty' (ForD _ x) = pretty x
+  pretty' (WarningD _ x) = pretty x
+  pretty' (AnnD _ x) = pretty x
+  pretty' (RuleD _ x) = pretty x
+  pretty' (SpliceD _ sp) = pretty sp
+  pretty' DocD {} = docNode
   pretty' (RoleAnnotD _ x) = pretty x
 
 instance Pretty (TyClDecl GhcPs) where
@@ -180,7 +182,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_cons tcdDataDefn of
         DataTypeCons {} -> string "data "
-        NewTypeCon {}   -> string "newtype "
+        NewTypeCon {} -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -195,7 +197,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType  -> string "newtype "
+        NewType -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -210,7 +212,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType  -> string "newtype "
+        NewType -> string "newtype "
 #endif
 prettyTyClDecl ClassDecl {..} = do
   if isJust tcdCtxt
@@ -231,20 +233,21 @@ prettyTyClDecl ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            []  -> string "()"
+            [] -> string "()"
             [x] -> pretty x
-            xs  -> hvTuple $ fmap pretty xs
+            xs -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock $
-          string "| " |=>
-          vCommaSep
-            (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
-               printCommentsAnd x $ \(FunDep _ from to) ->
-                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock
+          $ string "| "
+              |=> vCommaSep
+                    (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
+                       printCommentsAnd x $ \(FunDep _ from to) ->
+                         spaced
+                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -255,27 +258,27 @@ prettyTyClDecl ClassDecl {..} = do
         Infix ->
           case hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens $
-                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens
+                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..}     = pretty cid_inst
+  pretty' ClsInstD {..} = pretty cid_inst
   pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (HsBind GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..}     = pretty fun_matches
-prettyHsBind PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {}       = notGeneratedByParser
+prettyHsBind FunBind {..} = pretty fun_matches
+prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {}      = notGeneratedByParser
+prettyHsBind AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -295,9 +298,10 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -317,9 +321,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -362,9 +366,10 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -384,9 +389,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' IdSig {} = notGeneratedByParser
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
@@ -445,12 +450,12 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       cons =
         case dd_cons of
-          NewTypeCon x      -> [x]
+          NewTypeCon x -> [x]
           DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
-          _                                       -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -486,7 +491,7 @@ instance Pretty (HsDataDefn GhcPs) where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
-          _                      -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -497,8 +502,8 @@ instance Pretty (ClsInstDecl GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -544,17 +549,18 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              []         -> error "Invalid function application."
+              [] -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col' - col -
-            if col == 0
-              then spaces
-              else 0
+            col'
+              - col
+              - if col == 0
+                  then spaces
+                  else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -592,11 +598,11 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens $
-      prefixedLined "," $
-      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens
+        $ prefixedLined ","
+        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
-    isMissing _          = False
+    isMissing _ = False
 prettyHsExpr (ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -621,9 +627,9 @@ prettyHsExpr (HsIf _ cond t f) = do
     branch :: String -> LHsExpr GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ (DoExpr m) xs))  -> doStmt (QualifiedDo m Do) xs
+        (L _ (HsDo _ (DoExpr m) xs)) -> doStmt (QualifiedDo m Do) xs
         (L _ (HsDo _ (MDoExpr m) xs)) -> doStmt (QualifiedDo m Mdo) xs
-        _                             -> string str |=> pretty e
+        _ -> string str |=> pretty e
       where
         doStmt qDo stmts = do
           string str
@@ -631,8 +637,8 @@ prettyHsExpr (HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (HsMultiIf _ guards) =
-  string "if " |=>
-  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if "
+    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -695,9 +701,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsFieldBind a b)]
@@ -725,9 +731,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsRecField' a b)]
@@ -754,10 +760,11 @@ prettyHsExpr (HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr HsProjection {..} =
-  parens $
-  forM_ proj_flds $ \x -> do
-    string "."
-    pretty x
+  parens
+    $ forM_ proj_flds
+    $ \x -> do
+        string "."
+        pretty x
 prettyHsExpr (ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -769,8 +776,8 @@ prettyHsExpr (HsSpliceE _ x) = pretty x
 prettyHsExpr (HsProc _ pat x@(L _ (HsCmdTop _ (L _ (HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock $
-    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock
+    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -804,7 +811,7 @@ prettyHsExpr (HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case  -> string "\\case"
+      Case -> string "\\case"
       Cases -> string "\\cases"
     if null $ unLoc $ mg_alts matches
       then string " {}"
@@ -831,10 +838,12 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do hor <-|> ver
-                     newline
-                     prefixed "=> " $
-                       prefixedLined "-> " $ pretty <$> flatten hst_body
+               in do
+                    hor <-|> ver
+                    newline
+                    prefixed "=> "
+                      $ prefixedLined "-> "
+                      $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -844,7 +853,7 @@ instance Pretty HsSigType' where
     where
       flatten :: LHsType GhcPs -> [LHsType GhcPs]
       flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x                       = [x]
+      flatten x = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
     case sig_bndrs of
       HsOuterExplicit _ xs -> do
@@ -853,8 +862,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
-              (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt))
+              <-|> (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -884,10 +893,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -898,19 +907,19 @@ prettyConDecl ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     forallNeeded =
@@ -928,10 +937,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -942,52 +951,52 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
-
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt)) <-|>
-        (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt))
+        <-|> (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
-      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
+        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-
+    
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -995,26 +1004,30 @@ prettyConDecl ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \c -> do
-        pretty $ Context c
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \c -> do
+             pretty $ Context c
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #else
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \_ -> do
-        pretty $ Context con_mb_cxt
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \_ -> do
+             pretty $ Context con_mb_cxt
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #endif
 prettyConDecl ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1030,11 +1043,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
 prettyMatchExpr :: Match GhcPs (LHsExpr GhcPs) -> Printer ()
 prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case unLoc $ head m_pats of
-      LazyPat {} -> space
-      BangPat {} -> space
-      _          -> return ()
+  unless (null m_pats)
+    $ case unLoc $ head m_pats of
+        LazyPat {} -> space
+        BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
@@ -1054,8 +1067,9 @@ prettyMatchExpr Match {..} =
     Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, FunRhs {..}) -> do
-          spaced $
-            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
+          spaced
+            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
+                ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1065,11 +1079,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
 prettyMatchProc :: Match GhcPs (LHsCmd GhcPs) -> Printer ()
 prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case unLoc $ head m_pats of
-      LazyPat {} -> space
-      BangPat {} -> space
-      _          -> return ()
+  unless (null m_pats)
+    $ case unLoc $ head m_pats of
+        LazyPat {} -> space
+        BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1129,7 +1143,7 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
     where
       horizontal =
         case rec_dotdot of
-          Just _  -> braces $ string ".."
+          Just _ -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1138,8 +1152,8 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) wher
   pretty' HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (HsType GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1244,7 +1258,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _  -> hvPromotedList $ fmap pretty xs
+    _ -> hvPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"
@@ -1262,11 +1276,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (HsValBinds epa lr, _) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
@@ -1274,31 +1288,31 @@ instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (HsValBinds epa lr) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (HsMatchContext GhcPs) where
   pretty' = prettyHsMatchContext
 
 prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..}       = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr        = return ()
-prettyHsMatchContext CaseAlt           = return ()
-prettyHsMatchContext IfAlt {}          = notGeneratedByParser
+prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext LambdaExpr = return ()
+prettyHsMatchContext CaseAlt = return ()
+prettyHsMatchContext IfAlt {} = notGeneratedByParser
 prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {}     = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {}  = notGeneratedByParser
-prettyHsMatchContext RecUpd {}         = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {}       = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {}    = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {}     = notGeneratedByParser
-prettyHsMatchContext PatSyn {}         = notGeneratedByParser
+prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
+prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
+prettyHsMatchContext RecUpd {} = notGeneratedByParser
+prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
+prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
+prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
+prettyHsMatchContext PatSyn {} = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsMatchContext LamCaseAlt {}     = notUsedInParsedStage
+prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
   pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
@@ -1407,8 +1421,11 @@ instance Pretty (HsSplice GhcPs) where
   pretty' (HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars $
-        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ unpackFS r
+      wrapWithBars
+        $ indentedWithFixedLevel 0
+        $ sequence_
+        $ printers [] ""
+        $ unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1472,13 +1489,13 @@ prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat HsRecFields {..}) =
     case fieldPrinters of
-      []  -> string "{}"
+      [] -> string "{}"
       [x] -> braces x
-      xs  -> hvFields xs
+      xs -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsBracket GhcPs) where
   pretty' (ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1492,10 +1509,10 @@ instance Pretty (HsBracket GhcPs) where
   pretty' (TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x)         = pretty x
-  pretty' (Bind x)        = pretty x
-  pretty' (TypeFamily x)  = pretty x
-  pretty' (TyFamInst x)   = pretty x
+  pretty' (Sig x) = pretty x
+  pretty' (Bind x) = pretty x
+  pretty' (TypeFamily x) = pretty x
+  pretty' (TyFamInst x) = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty EpaComment where
@@ -1517,7 +1534,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
-  pretty' Missing {}    = pure () -- This appears in a tuple section.
+  pretty' Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1615,7 +1632,7 @@ instance Pretty (ConDeclField GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x)                    = pretty' x
+  pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1675,9 +1692,9 @@ instance Pretty InfixApp where
       Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x)    = pretty x
-  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (Var x) = pretty x
+  pretty' (And xs) = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs) = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
 instance Pretty (FieldLabelStrings GhcPs) where
@@ -1685,7 +1702,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name)   = pretty name
+  pretty' (Ambiguous _ name) = pretty name
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1702,8 +1719,9 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclImportList $ \(x, ps) -> do
       when (x == EverythingBut) (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
-        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
+        <-|> (newline
+                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #else
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1720,8 +1738,9 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclHiding $ \(x, ps) -> do
       when x (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
-        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
+        <-|> (newline
+                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #endif
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1744,14 +1763,14 @@ instance Pretty (HsDerivingClause GhcPs) where
 
 instance Pretty (DerivClauseTys GhcPs) where
   pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts)  = hvTuple $ fmap pretty ts
+  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {}    = notUsedInParsedStage
+  pretty' NoOverlap {} = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1759,13 +1778,13 @@ instance Pretty StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (FamilyDecl GhcPs) where
   pretty' FamilyDecl {..} = do
-    string $
-      case fdInfo of
-        DataFamily          -> "data"
-        OpenTypeFamily      -> "type"
-        ClosedTypeFamily {} -> "type"
+    string
+      $ case fdInfo of
+          DataFamily -> "data"
+          OpenTypeFamily -> "type"
+          ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel    -> string " family "
+      TopLevel -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
@@ -1788,8 +1807,8 @@ instance Pretty (FamilyDecl GhcPs) where
       _ -> pure ()
 
 instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {}       = pure ()
-  pretty' (KindSig _ x)  = string ":: " >> pretty x
+  pretty' NoSig {} = pure ()
+  pretty' (KindSig _ x) = string ":: " >> pretty x
   pretty' (TyVarSig _ x) = pretty x
 
 instance Pretty (HsTyVarBndr a GhcPs) where
@@ -1808,8 +1827,8 @@ instance Pretty (ArithSeqInfo GhcPs) where
   pretty' (FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (FromThenTo from next to) =
-    brackets $
-    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets
+      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (HsForAllTelescope GhcPs) where
   pretty' HsForAllVis {..} = do
@@ -1855,9 +1874,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ [])  -> parens
+          (L _ []) -> parens
           (L _ [_]) -> id
-          _         -> parens
+          _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1872,10 +1891,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing        -> id
-          Just (L _ [])  -> parens
+          Nothing -> id
+          Just (L _ []) -> parens
           Just (L _ [_]) -> id
-          Just _         -> parens
+          Just _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1933,7 +1952,7 @@ instance Pretty FamEqn' where
     where
       prefix =
         case famEqnFor of
-          DataFamInstDeclForTopLevel        -> "data instance"
+          DataFamInstDeclForTopLevel -> "data instance"
           DataFamInstDeclForInsideClassInst -> "data"
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
@@ -1942,17 +1961,17 @@ instance Pretty
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x)    = pretty x
+  pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {}     = notUsedInParsedStage
+  pretty' HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
            (HsArg
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x)    = pretty x
+  pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {}     = notUsedInParsedStage
+  pretty' HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
@@ -1977,7 +1996,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -1991,7 +2010,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2009,15 +2028,15 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
-  pretty' (IEName _ name)    = pretty name
+  pretty' (IEName _ name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name)    = string "type " >> pretty name
+  pretty' (IEType _ name) = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name)      = pretty name
+  pretty' (IEName name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name)    = string "type " >> pretty name
+  pretty' (IEType _ name) = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -2146,23 +2165,23 @@ instance Pretty ForeignImport where
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, output s]
-  pretty' (CExport _ conv)                    = pretty conv
+  pretty' (CExport _ conv) = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv)                    = pretty conv
+  pretty' (CExport _ conv) = pretty conv
 #else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _)                    = pretty conv
+  pretty' (CExport conv _) = pretty conv
 #endif
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe          = string "safe"
+  pretty' PlaySafe = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky         = string "unsafe"
+  pretty' PlayRisky = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2182,14 +2201,14 @@ instance Pretty (AnnDecl GhcPs) where
 #endif
 instance Pretty (RoleAnnotDecl GhcPs) where
   pretty' (RoleAnnotDecl _ name roles) =
-    spaced $
-    [string "type role", pretty name] ++
-    fmap (maybe (string "_") pretty . unLoc) roles
+    spaced
+      $ [string "type role", pretty name]
+          ++ fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal          = string "nominal"
+  pretty' Nominal = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom          = string "phantom"
+  pretty' Phantom = string "phantom"
 
 instance Pretty (TyFamInstDecl GhcPs) where
   pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2248,8 +2267,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                -> pure ()
+      ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -2265,25 +2284,25 @@ prettyInlineSpec NoUserInlinePrag =
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional           = string "<-"
-  pretty' ImplicitBidirectional    = string "="
+  pretty' Unidirectional = string "<-"
+  pretty' ImplicitBidirectional = string "="
   pretty' ExplicitBidirectional {} = string "<-"
 
 instance Pretty (HsOverLit GhcPs) where
   pretty' OverLit {..} = pretty ol_val
 
 instance Pretty OverLitVal where
-  pretty' (HsIntegral x)   = pretty x
+  pretty' (HsIntegral x) = pretty x
   pretty' (HsFractional x) = pretty x
   pretty' (HsIsString _ x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
-  pretty' IL {..}                     = string $ show il_value
+  pretty' IL {..} = string $ show il_value
 #else
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..}                     = string $ show il_value
+  pretty' IL {..} = string $ show il_value
 #endif
 instance Pretty FractionalLit where
   pretty' = output
@@ -2302,7 +2321,7 @@ instance Pretty (HsLit GhcPs) where
   pretty' HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {}     -> prettyString
+      HsString {} -> prettyString
       HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2313,8 +2332,9 @@ instance Pretty (HsLit GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1) $
-                lined $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1)
+                $ lined
+                $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
@@ -2326,13 +2346,13 @@ instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
-  pretty' (HsNumTy _ x)  = string $ show x
-  pretty' (HsStrTy _ x)  = string $ ushow x
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
 instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x)  = string $ show x
-  pretty' (HsStrTy _ x)  = string $ ushow x
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (HsPatSigType GhcPs) where
@@ -2354,10 +2374,10 @@ prettyIPBind (IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {}    = string "stock"
+  pretty' StockStrategy {} = string "stock"
   pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {}  = string "newtype"
-  pretty' (ViaStrategy x)     = string "via " >> pretty x
+  pretty' NewtypeStrategy {} = string "newtype"
+  pretty' (ViaStrategy x) = string "via " >> pretty x
 
 instance Pretty XViaStrategyPs where
   pretty' (XViaStrategyPs _ ty) = pretty ty
@@ -2425,9 +2445,12 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets $
-        spaced
-          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
+        brackets
+          $ spaced
+              [ pretty listCompLhs
+              , string "|"
+              , hCommaSep $ fmap pretty listCompRhs
+              ]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2445,7 +2468,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do  = string "do"
+  pretty' Do = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2465,10 +2488,10 @@ instance Pretty (RuleBndr GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv          = string "ccall"
-  pretty' CApiConv           = string "capi"
-  pretty' StdCallConv        = string "stdcall"
-  pretty' PrimCallConv       = string "prim"
+  pretty' CCallConv = string "ccall"
+  pretty' CApiConv = string "capi"
+  pretty' StdCallConv = string "stdcall"
+  pretty' PrimCallConv = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 
 instance Pretty HsSrcBang where
@@ -2478,13 +2501,13 @@ instance Pretty HsSrcBang where
     pretty strictness
 
 instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' SrcUnpack = string "{-# UNPACK #-}"
   pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' NoSrcUnpack = pure ()
 
 instance Pretty SrcStrictness where
-  pretty' SrcLazy     = string "~"
-  pretty' SrcStrict   = string "!"
+  pretty' SrcLazy = string "~"
+  pretty' SrcStrict = string "!"
   pretty' NoSrcStrict = pure ()
 
 instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
@@ -2508,8 +2531,11 @@ instance Pretty (HsUntypedSplice GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars .
-         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
+        (wrapWithBars
+           . indentedWithFixedLevel 0
+           . sequence_
+           . printers [] ""
+           . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 -- | Comment handling around an AST node
 module HIndent.Pretty.NodeComments
@@ -8,27 +8,27 @@ module HIndent.Pretty.NodeComments
   , emptyNodeComments
   ) where
 
-import Data.Void
-import GHC.Core.Coercion
-import GHC.Data.BooleanFormula
-import GHC.Hs
-import GHC.Stack
-import GHC.Types.Basic
-import GHC.Types.Fixity
-import GHC.Types.ForeignCall
-import GHC.Types.Name
-import GHC.Types.Name.Reader
-import GHC.Types.SourceText
-import GHC.Types.SrcLoc
-import HIndent.Ast.NodeComments
-import HIndent.Pragma
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
+import           Data.Void
+import           GHC.Core.Coercion
+import           GHC.Data.BooleanFormula
+import           GHC.Hs
+import           GHC.Stack
+import           GHC.Types.Basic
+import           GHC.Types.Fixity
+import           GHC.Types.ForeignCall
+import           GHC.Types.Name
+import           GHC.Types.Name.Reader
+import           GHC.Types.SourceText
+import           GHC.Types.SrcLoc
+import           HIndent.Ast.NodeComments
+import           HIndent.Pragma
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import GHC.Core.DataCon
+import           GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import GHC.Unit
+import           GHC.Unit
 #endif
 -- | An interface to extract comments from an AST node.
 class CommentExtraction a where
@@ -88,64 +88,64 @@ instance CommentExtraction (HsDecl GhcPs) where
   nodeComments RoleAnnotD {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (TyClDecl GhcPs) where
-  nodeComments FamDecl {} = emptyNodeComments
-  nodeComments SynDecl {..} = nodeComments tcdSExt
-  nodeComments DataDecl {..} = nodeComments tcdDExt
+  nodeComments FamDecl {}                   = emptyNodeComments
+  nodeComments SynDecl {..}                 = nodeComments tcdSExt
+  nodeComments DataDecl {..}                = nodeComments tcdDExt
   nodeComments ClassDecl {tcdCExt = (x, _)} = nodeComments x
 #else
 instance CommentExtraction (TyClDecl GhcPs) where
-  nodeComments FamDecl {} = emptyNodeComments
-  nodeComments SynDecl {..} = nodeComments tcdSExt
-  nodeComments DataDecl {..} = nodeComments tcdDExt
+  nodeComments FamDecl {}                      = emptyNodeComments
+  nodeComments SynDecl {..}                    = nodeComments tcdSExt
+  nodeComments DataDecl {..}                   = nodeComments tcdDExt
   nodeComments ClassDecl {tcdCExt = (x, _, _)} = nodeComments x
 #endif
 instance CommentExtraction (InstDecl GhcPs) where
   nodeComments = nodeCommentsInstDecl
 
 nodeCommentsInstDecl :: InstDecl GhcPs -> NodeComments
-nodeCommentsInstDecl ClsInstD {} = emptyNodeComments
+nodeCommentsInstDecl ClsInstD {}       = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsInstDecl DataFamInstD {} = emptyNodeComments
+nodeCommentsInstDecl DataFamInstD {}   = emptyNodeComments
 #else
 nodeCommentsInstDecl DataFamInstD {..} = nodeComments dfid_ext
 #endif
-nodeCommentsInstDecl TyFamInstD {} = emptyNodeComments
+nodeCommentsInstDecl TyFamInstD {}     = emptyNodeComments
 
 instance CommentExtraction (HsBind GhcPs) where
   nodeComments = nodeCommentsHsBind
 
 nodeCommentsHsBind :: HsBind GhcPs -> NodeComments
-nodeCommentsHsBind FunBind {..} = nodeComments fun_id
-nodeCommentsHsBind PatBind {..} = nodeComments pat_ext
-nodeCommentsHsBind VarBind {} = emptyNodeComments
+nodeCommentsHsBind FunBind {..}  = nodeComments fun_id
+nodeCommentsHsBind PatBind {..}  = nodeComments pat_ext
+nodeCommentsHsBind VarBind {}    = emptyNodeComments
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsBind AbsBinds {} = emptyNodeComments
+nodeCommentsHsBind AbsBinds {}   = emptyNodeComments
 #endif
 nodeCommentsHsBind PatSynBind {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (Sig GhcPs) where
-  nodeComments (TypeSig x _ _) = nodeComments x
-  nodeComments (PatSynSig x _ _) = nodeComments x
-  nodeComments (ClassOpSig x _ _ _) = nodeComments x
-  nodeComments (FixSig x _) = nodeComments x
-  nodeComments (InlineSig x _ _) = nodeComments x
-  nodeComments (SpecSig x _ _ _) = nodeComments x
-  nodeComments (SpecInstSig x _) = nodeComments $ fst x
-  nodeComments (MinimalSig x _) = nodeComments $ fst x
-  nodeComments (SCCFunSig x _ _) = nodeComments $ fst x
+  nodeComments (TypeSig x _ _)          = nodeComments x
+  nodeComments (PatSynSig x _ _)        = nodeComments x
+  nodeComments (ClassOpSig x _ _ _)     = nodeComments x
+  nodeComments (FixSig x _)             = nodeComments x
+  nodeComments (InlineSig x _ _)        = nodeComments x
+  nodeComments (SpecSig x _ _ _)        = nodeComments x
+  nodeComments (SpecInstSig x _)        = nodeComments $ fst x
+  nodeComments (MinimalSig x _)         = nodeComments $ fst x
+  nodeComments (SCCFunSig x _ _)        = nodeComments $ fst x
   nodeComments (CompleteMatchSig x _ _) = nodeComments $ fst x
 #else
 instance CommentExtraction (Sig GhcPs) where
-  nodeComments (TypeSig x _ _) = nodeComments x
-  nodeComments (PatSynSig x _ _) = nodeComments x
-  nodeComments (ClassOpSig x _ _ _) = nodeComments x
-  nodeComments IdSig {} = emptyNodeComments
-  nodeComments (FixSig x _) = nodeComments x
-  nodeComments (InlineSig x _ _) = nodeComments x
-  nodeComments (SpecSig x _ _ _) = nodeComments x
-  nodeComments (SpecInstSig x _ _) = nodeComments x
-  nodeComments (MinimalSig x _ _) = nodeComments x
-  nodeComments (SCCFunSig x _ _ _) = nodeComments x
+  nodeComments (TypeSig x _ _)            = nodeComments x
+  nodeComments (PatSynSig x _ _)          = nodeComments x
+  nodeComments (ClassOpSig x _ _ _)       = nodeComments x
+  nodeComments IdSig {}                   = emptyNodeComments
+  nodeComments (FixSig x _)               = nodeComments x
+  nodeComments (InlineSig x _ _)          = nodeComments x
+  nodeComments (SpecSig x _ _ _)          = nodeComments x
+  nodeComments (SpecInstSig x _ _)        = nodeComments x
+  nodeComments (MinimalSig x _ _)         = nodeComments x
+  nodeComments (SCCFunSig x _ _ _)        = nodeComments x
   nodeComments (CompleteMatchSig x _ _ _) = nodeComments x
 #endif
 instance CommentExtraction (HsDataDefn GhcPs) where
@@ -170,78 +170,78 @@ instance CommentExtraction QualifiedDo where
   nodeComments = const emptyNodeComments
 
 nodeCommentsHsExpr :: HsExpr GhcPs -> NodeComments
-nodeCommentsHsExpr HsVar {} = emptyNodeComments
-nodeCommentsHsExpr (HsUnboundVar x _) = nodeComments x
+nodeCommentsHsExpr HsVar {}                 = emptyNodeComments
+nodeCommentsHsExpr (HsUnboundVar x _)       = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr HsConLikeOut {} = emptyNodeComments
-nodeCommentsHsExpr HsRecFld {} = emptyNodeComments
+nodeCommentsHsExpr HsConLikeOut {}          = emptyNodeComments
+nodeCommentsHsExpr HsRecFld {}              = emptyNodeComments
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsHsExpr (HsOverLabel x _ _) = nodeComments x
+nodeCommentsHsExpr (HsOverLabel x _ _)      = nodeComments x
 #else
-nodeCommentsHsExpr (HsOverLabel x _) = nodeComments x
+nodeCommentsHsExpr (HsOverLabel x _)        = nodeComments x
 #endif
-nodeCommentsHsExpr (HsIPVar x _) = nodeComments x
-nodeCommentsHsExpr (HsOverLit x _) = nodeComments x
-nodeCommentsHsExpr (HsLit x _) = nodeComments x
-nodeCommentsHsExpr HsLam {} = emptyNodeComments
+nodeCommentsHsExpr (HsIPVar x _)            = nodeComments x
+nodeCommentsHsExpr (HsOverLit x _)          = nodeComments x
+nodeCommentsHsExpr (HsLit x _)              = nodeComments x
+nodeCommentsHsExpr HsLam {}                 = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsLamCase x _ _) = nodeComments x
+nodeCommentsHsExpr (HsLamCase x _ _)        = nodeComments x
 #else
-nodeCommentsHsExpr (HsLamCase x _) = nodeComments x
+nodeCommentsHsExpr (HsLamCase x _)          = nodeComments x
 #endif
-nodeCommentsHsExpr (HsApp x _ _) = nodeComments x
-nodeCommentsHsExpr HsAppType {} = emptyNodeComments
-nodeCommentsHsExpr (OpApp x _ _ _) = nodeComments x
-nodeCommentsHsExpr (NegApp x _ _) = nodeComments x
+nodeCommentsHsExpr (HsApp x _ _)            = nodeComments x
+nodeCommentsHsExpr HsAppType {}             = emptyNodeComments
+nodeCommentsHsExpr (OpApp x _ _ _)          = nodeComments x
+nodeCommentsHsExpr (NegApp x _ _)           = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsPar x _ _ _) = nodeComments x
+nodeCommentsHsExpr (HsPar x _ _ _)          = nodeComments x
 #else
-nodeCommentsHsExpr (HsPar x _) = nodeComments x
+nodeCommentsHsExpr (HsPar x _)              = nodeComments x
 #endif
-nodeCommentsHsExpr (SectionL x _ _) = nodeComments x
-nodeCommentsHsExpr (SectionR x _ _) = nodeComments x
-nodeCommentsHsExpr (ExplicitTuple x _ _) = nodeComments x
-nodeCommentsHsExpr (ExplicitSum x _ _ _) = nodeComments x
-nodeCommentsHsExpr (HsCase x _ _) = nodeComments x
-nodeCommentsHsExpr (HsIf x _ _ _) = nodeComments x
-nodeCommentsHsExpr (HsMultiIf x _) = nodeComments x
+nodeCommentsHsExpr (SectionL x _ _)         = nodeComments x
+nodeCommentsHsExpr (SectionR x _ _)         = nodeComments x
+nodeCommentsHsExpr (ExplicitTuple x _ _)    = nodeComments x
+nodeCommentsHsExpr (ExplicitSum x _ _ _)    = nodeComments x
+nodeCommentsHsExpr (HsCase x _ _)           = nodeComments x
+nodeCommentsHsExpr (HsIf x _ _ _)           = nodeComments x
+nodeCommentsHsExpr (HsMultiIf x _)          = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsLet x _ _ _ _) = nodeComments x
+nodeCommentsHsExpr (HsLet x _ _ _ _)        = nodeComments x
 #else
-nodeCommentsHsExpr (HsLet x _ _) = nodeComments x
+nodeCommentsHsExpr (HsLet x _ _)            = nodeComments x
 #endif
-nodeCommentsHsExpr (HsDo x _ _) = nodeComments x
-nodeCommentsHsExpr (ExplicitList x _) = nodeComments x
-nodeCommentsHsExpr RecordCon {..} = nodeComments rcon_ext
-nodeCommentsHsExpr RecordUpd {..} = nodeComments rupd_ext
-nodeCommentsHsExpr HsGetField {..} = nodeComments gf_ext
-nodeCommentsHsExpr HsProjection {..} = nodeComments proj_ext
-nodeCommentsHsExpr (ExprWithTySig x _ _) = nodeComments x
-nodeCommentsHsExpr (ArithSeq x _ _) = nodeComments x
+nodeCommentsHsExpr (HsDo x _ _)             = nodeComments x
+nodeCommentsHsExpr (ExplicitList x _)       = nodeComments x
+nodeCommentsHsExpr RecordCon {..}           = nodeComments rcon_ext
+nodeCommentsHsExpr RecordUpd {..}           = nodeComments rupd_ext
+nodeCommentsHsExpr HsGetField {..}          = nodeComments gf_ext
+nodeCommentsHsExpr HsProjection {..}        = nodeComments proj_ext
+nodeCommentsHsExpr (ExprWithTySig x _ _)    = nodeComments x
+nodeCommentsHsExpr (ArithSeq x _ _)         = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsBracket x _) = nodeComments x
-nodeCommentsHsExpr HsRnBracketOut {} = notUsedInParsedStage
-nodeCommentsHsExpr HsTcBracketOut {} = notUsedInParsedStage
+nodeCommentsHsExpr (HsBracket x _)          = nodeComments x
+nodeCommentsHsExpr HsRnBracketOut {}        = notUsedInParsedStage
+nodeCommentsHsExpr HsTcBracketOut {}        = notUsedInParsedStage
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsHsExpr (HsSpliceE x _) = nodeComments x
+nodeCommentsHsExpr (HsSpliceE x _)          = nodeComments x
 #endif
-nodeCommentsHsExpr (HsProc x _ _) = nodeComments x
-nodeCommentsHsExpr (HsStatic x _) = nodeComments x
+nodeCommentsHsExpr (HsProc x _ _)           = nodeComments x
+nodeCommentsHsExpr (HsStatic x _)           = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr HsTick {} = emptyNodeComments
-nodeCommentsHsExpr HsBinTick {} = emptyNodeComments
+nodeCommentsHsExpr HsTick {}                = emptyNodeComments
+nodeCommentsHsExpr HsBinTick {}             = emptyNodeComments
 #endif
-nodeCommentsHsExpr HsPragE {} = emptyNodeComments
+nodeCommentsHsExpr HsPragE {}               = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr HsRecSel {} = emptyNodeComments
-nodeCommentsHsExpr (HsTypedBracket x _) = nodeComments x
-nodeCommentsHsExpr (HsUntypedBracket x _) = nodeComments x
+nodeCommentsHsExpr HsRecSel {}              = emptyNodeComments
+nodeCommentsHsExpr (HsTypedBracket x _)     = nodeComments x
+nodeCommentsHsExpr (HsUntypedBracket x _)   = nodeComments x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 nodeCommentsHsExpr (HsTypedSplice (x, y) _) = nodeComments x <> nodeComments y
-nodeCommentsHsExpr (HsUntypedSplice x _) = nodeComments x
+nodeCommentsHsExpr (HsUntypedSplice x _)    = nodeComments x
 #endif
 instance CommentExtraction (HsSigType GhcPs) where
   nodeComments HsSig {} = emptyNodeComments
@@ -251,32 +251,32 @@ instance CommentExtraction HsSigType' where
 
 instance CommentExtraction (ConDecl GhcPs) where
   nodeComments ConDeclGADT {..} = nodeComments con_g_ext
-  nodeComments ConDeclH98 {..} = nodeComments con_ext
+  nodeComments ConDeclH98 {..}  = nodeComments con_ext
 
 instance CommentExtraction (Match GhcPs a) where
   nodeComments Match {..} = nodeComments m_ext
 
 instance CommentExtraction
            (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
-  nodeComments LastStmt {} = emptyNodeComments
-  nodeComments (BindStmt x _ _) = nodeComments x
+  nodeComments LastStmt {}        = emptyNodeComments
+  nodeComments (BindStmt x _ _)   = nodeComments x
   nodeComments ApplicativeStmt {} = emptyNodeComments
-  nodeComments BodyStmt {} = emptyNodeComments
-  nodeComments (LetStmt x _) = nodeComments x
-  nodeComments ParStmt {} = emptyNodeComments
-  nodeComments TransStmt {..} = nodeComments trS_ext
-  nodeComments RecStmt {..} = nodeComments recS_ext
+  nodeComments BodyStmt {}        = emptyNodeComments
+  nodeComments (LetStmt x _)      = nodeComments x
+  nodeComments ParStmt {}         = emptyNodeComments
+  nodeComments TransStmt {..}     = nodeComments trS_ext
+  nodeComments RecStmt {..}       = nodeComments recS_ext
 
 instance CommentExtraction
            (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
-  nodeComments LastStmt {} = emptyNodeComments
-  nodeComments (BindStmt x _ _) = nodeComments x
+  nodeComments LastStmt {}        = emptyNodeComments
+  nodeComments (BindStmt x _ _)   = nodeComments x
   nodeComments ApplicativeStmt {} = emptyNodeComments
-  nodeComments BodyStmt {} = emptyNodeComments
-  nodeComments (LetStmt x _) = nodeComments x
-  nodeComments ParStmt {} = emptyNodeComments
-  nodeComments TransStmt {..} = nodeComments trS_ext
-  nodeComments RecStmt {..} = nodeComments recS_ext
+  nodeComments BodyStmt {}        = emptyNodeComments
+  nodeComments (LetStmt x _)      = nodeComments x
+  nodeComments ParStmt {}         = emptyNodeComments
+  nodeComments TransStmt {..}     = nodeComments trS_ext
+  nodeComments RecStmt {..}       = nodeComments recS_ext
 
 instance CommentExtraction StmtLRInsideVerticalList where
   nodeComments (StmtLRInsideVerticalList x) = nodeComments x
@@ -295,29 +295,29 @@ instance CommentExtraction (HsType GhcPs) where
   nodeComments = nodeComments . HsType' HsTypeForNormalDecl HsTypeNoDir
 
 instance CommentExtraction HsType' where
-  nodeComments (HsType' _ _ HsForAllTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ HsQualTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ (HsTyVar x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ HsAppTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ HsAppKindTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ (HsFunTy x _ _ _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsListTy x _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsTupleTy x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsSumTy x _)) = nodeComments x
-  nodeComments (HsType' _ _ HsOpTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ (HsParTy x _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsIParamTy x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ HsStarTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ (HsKindSig x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ HsSpliceTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ (HsDocTy x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsBangTy x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsRecTy x _)) = nodeComments x
+  nodeComments (HsType' _ _ HsForAllTy {})            = emptyNodeComments
+  nodeComments (HsType' _ _ HsQualTy {})              = emptyNodeComments
+  nodeComments (HsType' _ _ (HsTyVar x _ _))          = nodeComments x
+  nodeComments (HsType' _ _ HsAppTy {})               = emptyNodeComments
+  nodeComments (HsType' _ _ HsAppKindTy {})           = emptyNodeComments
+  nodeComments (HsType' _ _ (HsFunTy x _ _ _))        = nodeComments x
+  nodeComments (HsType' _ _ (HsListTy x _))           = nodeComments x
+  nodeComments (HsType' _ _ (HsTupleTy x _ _))        = nodeComments x
+  nodeComments (HsType' _ _ (HsSumTy x _))            = nodeComments x
+  nodeComments (HsType' _ _ HsOpTy {})                = emptyNodeComments
+  nodeComments (HsType' _ _ (HsParTy x _))            = nodeComments x
+  nodeComments (HsType' _ _ (HsIParamTy x _ _))       = nodeComments x
+  nodeComments (HsType' _ _ HsStarTy {})              = emptyNodeComments
+  nodeComments (HsType' _ _ (HsKindSig x _ _))        = nodeComments x
+  nodeComments (HsType' _ _ HsSpliceTy {})            = emptyNodeComments
+  nodeComments (HsType' _ _ (HsDocTy x _ _))          = nodeComments x
+  nodeComments (HsType' _ _ (HsBangTy x _ _))         = nodeComments x
+  nodeComments (HsType' _ _ (HsRecTy x _))            = nodeComments x
   nodeComments (HsType' _ _ (HsExplicitListTy x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsExplicitTupleTy x _)) = nodeComments x
-  nodeComments (HsType' _ _ HsTyLit {}) = emptyNodeComments
-  nodeComments (HsType' _ _ HsWildCardTy {}) = emptyNodeComments
-  nodeComments (HsType' _ _ XHsType {}) = emptyNodeComments
+  nodeComments (HsType' _ _ (HsExplicitTupleTy x _))  = nodeComments x
+  nodeComments (HsType' _ _ HsTyLit {})               = emptyNodeComments
+  nodeComments (HsType' _ _ HsWildCardTy {})          = emptyNodeComments
+  nodeComments (HsType' _ _ XHsType {})               = emptyNodeComments
 
 instance CommentExtraction (GRHSs GhcPs a) where
   nodeComments GRHSs {..} = NodeComments {..}
@@ -333,20 +333,20 @@ instance CommentExtraction (HsMatchContext GhcPs) where
   nodeComments = nodeCommentsMatchContext
 
 nodeCommentsMatchContext :: HsMatchContext GhcPs -> NodeComments
-nodeCommentsMatchContext FunRhs {} = emptyNodeComments
-nodeCommentsMatchContext LambdaExpr {} = emptyNodeComments
-nodeCommentsMatchContext CaseAlt {} = emptyNodeComments
-nodeCommentsMatchContext IfAlt {} = emptyNodeComments
+nodeCommentsMatchContext FunRhs {}         = emptyNodeComments
+nodeCommentsMatchContext LambdaExpr {}     = emptyNodeComments
+nodeCommentsMatchContext CaseAlt {}        = emptyNodeComments
+nodeCommentsMatchContext IfAlt {}          = emptyNodeComments
 nodeCommentsMatchContext ArrowMatchCtxt {} = emptyNodeComments
-nodeCommentsMatchContext PatBindRhs {} = emptyNodeComments
-nodeCommentsMatchContext PatBindGuards {} = emptyNodeComments
-nodeCommentsMatchContext RecUpd {} = emptyNodeComments
-nodeCommentsMatchContext StmtCtxt {} = emptyNodeComments
-nodeCommentsMatchContext ThPatSplice {} = emptyNodeComments
-nodeCommentsMatchContext ThPatQuote {} = emptyNodeComments
-nodeCommentsMatchContext PatSyn {} = emptyNodeComments
+nodeCommentsMatchContext PatBindRhs {}     = emptyNodeComments
+nodeCommentsMatchContext PatBindGuards {}  = emptyNodeComments
+nodeCommentsMatchContext RecUpd {}         = emptyNodeComments
+nodeCommentsMatchContext StmtCtxt {}       = emptyNodeComments
+nodeCommentsMatchContext ThPatSplice {}    = emptyNodeComments
+nodeCommentsMatchContext ThPatQuote {}     = emptyNodeComments
+nodeCommentsMatchContext PatSyn {}         = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsMatchContext LamCaseAlt {} = emptyNodeComments
+nodeCommentsMatchContext LamCaseAlt {}     = emptyNodeComments
 #endif
 instance CommentExtraction (ParStmtBlock GhcPs GhcPs) where
   nodeComments ParStmtBlock {} = emptyNodeComments
@@ -356,9 +356,9 @@ instance CommentExtraction ParStmtBlockInsideVerticalList where
 
 instance CommentExtraction RdrName where
   nodeComments Unqual {} = emptyNodeComments
-  nodeComments Qual {} = emptyNodeComments
-  nodeComments Orig {} = emptyNodeComments
-  nodeComments Exact {} = emptyNodeComments
+  nodeComments Qual {}   = emptyNodeComments
+  nodeComments Orig {}   = emptyNodeComments
+  nodeComments Exact {}  = emptyNodeComments
 
 instance CommentExtraction (GRHS GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
   nodeComments = nodeComments . GRHSExpr GRHSExprNormal
@@ -376,10 +376,10 @@ instance CommentExtraction (SpliceDecl GhcPs) where
   nodeComments SpliceDecl {} = emptyNodeComments
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsSplice GhcPs) where
-  nodeComments (HsTypedSplice x _ _ _) = nodeComments x
+  nodeComments (HsTypedSplice x _ _ _)   = nodeComments x
   nodeComments (HsUntypedSplice x _ _ _) = nodeComments x
-  nodeComments HsQuasiQuote {} = emptyNodeComments
-  nodeComments HsSpliced {} = emptyNodeComments
+  nodeComments HsQuasiQuote {}           = emptyNodeComments
+  nodeComments HsSpliced {}              = emptyNodeComments
 #endif
 instance CommentExtraction (Pat GhcPs) where
   nodeComments = nodeCommentsPat
@@ -388,48 +388,48 @@ instance CommentExtraction PatInsidePatDecl where
   nodeComments (PatInsidePatDecl x) = nodeComments x
 
 nodeCommentsPat :: Pat GhcPs -> NodeComments
-nodeCommentsPat WildPat {} = emptyNodeComments
-nodeCommentsPat VarPat {} = emptyNodeComments
-nodeCommentsPat (LazyPat x _) = nodeComments x
+nodeCommentsPat WildPat {}              = emptyNodeComments
+nodeCommentsPat VarPat {}               = emptyNodeComments
+nodeCommentsPat (LazyPat x _)           = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsPat (AsPat x _ _ _) = nodeComments x
+nodeCommentsPat (AsPat x _ _ _)         = nodeComments x
 #else
-nodeCommentsPat (AsPat x _ _) = nodeComments x
+nodeCommentsPat (AsPat x _ _)           = nodeComments x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsPat (ParPat x _ _ _) = nodeComments x
+nodeCommentsPat (ParPat x _ _ _)        = nodeComments x
 #else
-nodeCommentsPat (ParPat x _) = nodeComments x
+nodeCommentsPat (ParPat x _)            = nodeComments x
 #endif
-nodeCommentsPat (BangPat x _) = nodeComments x
-nodeCommentsPat (ListPat x _) = nodeComments x
-nodeCommentsPat (TuplePat x _ _) = nodeComments x
-nodeCommentsPat (SumPat x _ _ _) = nodeComments x
-nodeCommentsPat ConPat {..} = nodeComments pat_con_ext
-nodeCommentsPat (ViewPat x _ _) = nodeComments x
-nodeCommentsPat SplicePat {} = emptyNodeComments
-nodeCommentsPat LitPat {} = emptyNodeComments
-nodeCommentsPat (NPat x _ _ _) = nodeComments x
+nodeCommentsPat (BangPat x _)           = nodeComments x
+nodeCommentsPat (ListPat x _)           = nodeComments x
+nodeCommentsPat (TuplePat x _ _)        = nodeComments x
+nodeCommentsPat (SumPat x _ _ _)        = nodeComments x
+nodeCommentsPat ConPat {..}             = nodeComments pat_con_ext
+nodeCommentsPat (ViewPat x _ _)         = nodeComments x
+nodeCommentsPat SplicePat {}            = emptyNodeComments
+nodeCommentsPat LitPat {}               = emptyNodeComments
+nodeCommentsPat (NPat x _ _ _)          = nodeComments x
 nodeCommentsPat (NPlusKPat x _ _ _ _ _) = nodeComments x
-nodeCommentsPat (SigPat x _ _) = nodeComments x
+nodeCommentsPat (SigPat x _ _)          = nodeComments x
 
 instance CommentExtraction RecConPat where
   nodeComments (RecConPat x) = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (HsBracket GhcPs) where
-  nodeComments ExpBr {} = emptyNodeComments
-  nodeComments PatBr {} = emptyNodeComments
+  nodeComments ExpBr {}  = emptyNodeComments
+  nodeComments PatBr {}  = emptyNodeComments
   nodeComments DecBrL {} = emptyNodeComments
   nodeComments DecBrG {} = emptyNodeComments
-  nodeComments TypBr {} = emptyNodeComments
-  nodeComments VarBr {} = emptyNodeComments
+  nodeComments TypBr {}  = emptyNodeComments
+  nodeComments VarBr {}  = emptyNodeComments
   nodeComments TExpBr {} = emptyNodeComments
 #endif
 instance CommentExtraction SigBindFamily where
-  nodeComments (Sig x) = nodeComments x
-  nodeComments (Bind x) = nodeComments x
-  nodeComments (TypeFamily x) = nodeComments x
-  nodeComments (TyFamInst x) = nodeComments x
+  nodeComments (Sig x)         = nodeComments x
+  nodeComments (Bind x)        = nodeComments x
+  nodeComments (TypeFamily x)  = nodeComments x
+  nodeComments (TyFamInst x)   = nodeComments x
   nodeComments (DataFamInst x) = nodeComments x
 
 instance CommentExtraction EpaComment where
@@ -442,7 +442,7 @@ instance CommentExtraction (SrcAnn a) where
   nodeComments (SrcSpanAnn ep _) = nodeComments ep
 
 instance CommentExtraction SrcSpan where
-  nodeComments RealSrcSpan {} = emptyNodeComments
+  nodeComments RealSrcSpan {}   = emptyNodeComments
   nodeComments UnhelpfulSpan {} = emptyNodeComments
 
 instance CommentExtraction (EpAnn a) where
@@ -457,17 +457,17 @@ instance CommentExtraction (EpAnn a) where
   nodeComments EpAnnNotUsed = emptyNodeComments
 
 instance CommentExtraction (HsLocalBindsLR GhcPs GhcPs) where
-  nodeComments (HsValBinds x _) = nodeComments x
-  nodeComments (HsIPBinds x _) = nodeComments x
+  nodeComments (HsValBinds x _)   = nodeComments x
+  nodeComments (HsIPBinds x _)    = nodeComments x
   nodeComments EmptyLocalBinds {} = emptyNodeComments
 
 instance CommentExtraction (HsValBindsLR GhcPs GhcPs) where
-  nodeComments ValBinds {} = emptyNodeComments
+  nodeComments ValBinds {}    = emptyNodeComments
   nodeComments XValBindsLR {} = notUsedInParsedStage
 
 instance CommentExtraction (HsTupArg GhcPs) where
   nodeComments (Present x _) = nodeComments x
-  nodeComments (Missing x) = nodeComments x
+  nodeComments (Missing x)   = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction RecConField where
   nodeComments (RecConField x) = nodeComments x
@@ -516,8 +516,8 @@ instance CommentExtraction
                  SrcSpanAnnL
                  [GenLocated SrcSpanAnnA (ConDeclField GhcPs)])) where
   nodeComments PrefixCon {} = emptyNodeComments
-  nodeComments RecCon {} = emptyNodeComments
-  nodeComments InfixCon {} = emptyNodeComments
+  nodeComments RecCon {}    = emptyNodeComments
+  nodeComments InfixCon {}  = emptyNodeComments
 
 instance CommentExtraction (HsScaled GhcPs a) where
   nodeComments HsScaled {} = emptyNodeComments
@@ -532,9 +532,9 @@ instance CommentExtraction InfixApp where
   nodeComments InfixApp {} = emptyNodeComments
 
 instance CommentExtraction (BooleanFormula a) where
-  nodeComments Var {} = emptyNodeComments
-  nodeComments And {} = emptyNodeComments
-  nodeComments Or {} = emptyNodeComments
+  nodeComments Var {}    = emptyNodeComments
+  nodeComments And {}    = emptyNodeComments
+  nodeComments Or {}     = emptyNodeComments
   nodeComments Parens {} = emptyNodeComments
 
 instance CommentExtraction (FieldLabelStrings GhcPs) where
@@ -542,7 +542,7 @@ instance CommentExtraction (FieldLabelStrings GhcPs) where
 
 instance CommentExtraction (AmbiguousFieldOcc GhcPs) where
   nodeComments Unambiguous {} = emptyNodeComments
-  nodeComments Ambiguous {} = emptyNodeComments
+  nodeComments Ambiguous {}   = emptyNodeComments
 
 instance CommentExtraction (ImportDecl GhcPs) where
   nodeComments ImportDecl {..} = nodeComments ideclExt
@@ -555,14 +555,14 @@ instance CommentExtraction (HsDerivingClause GhcPs) where
 
 instance CommentExtraction (DerivClauseTys GhcPs) where
   nodeComments DctSingle {} = emptyNodeComments
-  nodeComments DctMulti {} = emptyNodeComments
+  nodeComments DctMulti {}  = emptyNodeComments
 
 instance CommentExtraction OverlapMode where
-  nodeComments NoOverlap {} = emptyNodeComments
+  nodeComments NoOverlap {}    = emptyNodeComments
   nodeComments Overlappable {} = emptyNodeComments
-  nodeComments Overlapping {} = emptyNodeComments
-  nodeComments Overlaps {} = emptyNodeComments
-  nodeComments Incoherent {} = emptyNodeComments
+  nodeComments Overlapping {}  = emptyNodeComments
+  nodeComments Overlaps {}     = emptyNodeComments
+  nodeComments Incoherent {}   = emptyNodeComments
 
 instance CommentExtraction StringLiteral where
   nodeComments StringLiteral {} = emptyNodeComments
@@ -572,25 +572,25 @@ instance CommentExtraction (FamilyDecl GhcPs) where
   nodeComments FamilyDecl {..} = nodeComments fdExt
 
 instance CommentExtraction (FamilyResultSig GhcPs) where
-  nodeComments NoSig {} = emptyNodeComments
-  nodeComments KindSig {} = emptyNodeComments
+  nodeComments NoSig {}    = emptyNodeComments
+  nodeComments KindSig {}  = emptyNodeComments
   nodeComments TyVarSig {} = emptyNodeComments
 
 instance CommentExtraction (HsTyVarBndr a GhcPs) where
-  nodeComments (UserTyVar x _ _) = nodeComments x
+  nodeComments (UserTyVar x _ _)     = nodeComments x
   nodeComments (KindedTyVar x _ _ _) = nodeComments x
 
 instance CommentExtraction (InjectivityAnn GhcPs) where
   nodeComments (InjectivityAnn x _ _) = nodeComments x
 
 instance CommentExtraction (ArithSeqInfo GhcPs) where
-  nodeComments From {} = emptyNodeComments
-  nodeComments FromThen {} = emptyNodeComments
-  nodeComments FromTo {} = emptyNodeComments
+  nodeComments From {}       = emptyNodeComments
+  nodeComments FromThen {}   = emptyNodeComments
+  nodeComments FromTo {}     = emptyNodeComments
   nodeComments FromThenTo {} = emptyNodeComments
 
 instance CommentExtraction (HsForAllTelescope GhcPs) where
-  nodeComments HsForAllVis {..} = nodeComments hsf_xvis
+  nodeComments HsForAllVis {..}   = nodeComments hsf_xvis
   nodeComments HsForAllInvis {..} = nodeComments hsf_xinvis
 
 instance CommentExtraction InfixOp where
@@ -623,24 +623,24 @@ instance CommentExtraction ModuleNameWithPrefix where
   nodeComments ModuleNameWithPrefix {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance CommentExtraction (IE GhcPs) where
-  nodeComments IEVar {} = emptyNodeComments
-  nodeComments (IEThingAbs (_, x) _) = nodeComments x
-  nodeComments (IEThingAll (_, x) _) = nodeComments x
-  nodeComments (IEThingWith (_, x) _ _ _) = nodeComments x
+  nodeComments IEVar {}                    = emptyNodeComments
+  nodeComments (IEThingAbs (_, x) _)       = nodeComments x
+  nodeComments (IEThingAll (_, x) _)       = nodeComments x
+  nodeComments (IEThingWith (_, x) _ _ _)  = nodeComments x
   nodeComments (IEModuleContents (_, x) _) = nodeComments x
-  nodeComments IEGroup {} = emptyNodeComments
-  nodeComments IEDoc {} = emptyNodeComments
-  nodeComments IEDocNamed {} = emptyNodeComments
+  nodeComments IEGroup {}                  = emptyNodeComments
+  nodeComments IEDoc {}                    = emptyNodeComments
+  nodeComments IEDocNamed {}               = emptyNodeComments
 #else
 instance CommentExtraction (IE GhcPs) where
-  nodeComments IEVar {} = emptyNodeComments
-  nodeComments (IEThingAbs x _) = nodeComments x
-  nodeComments (IEThingAll x _) = nodeComments x
-  nodeComments (IEThingWith x _ _ _) = nodeComments x
+  nodeComments IEVar {}               = emptyNodeComments
+  nodeComments (IEThingAbs x _)       = nodeComments x
+  nodeComments (IEThingAll x _)       = nodeComments x
+  nodeComments (IEThingWith x _ _ _)  = nodeComments x
   nodeComments (IEModuleContents x _) = nodeComments x
-  nodeComments IEGroup {} = emptyNodeComments
-  nodeComments IEDoc {} = emptyNodeComments
-  nodeComments IEDocNamed {} = emptyNodeComments
+  nodeComments IEGroup {}             = emptyNodeComments
+  nodeComments IEDoc {}               = emptyNodeComments
+  nodeComments IEDocNamed {}          = emptyNodeComments
 #endif
 instance CommentExtraction
            (FamEqn GhcPs (GenLocated SrcSpanAnnA (HsType GhcPs))) where
@@ -659,26 +659,26 @@ instance CommentExtraction
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  nodeComments HsValArg {} = emptyNodeComments
+  nodeComments HsValArg {}  = emptyNodeComments
   nodeComments HsTypeArg {} = emptyNodeComments
-  nodeComments HsArgPar {} = emptyNodeComments
+  nodeComments HsArgPar {}  = emptyNodeComments
 #else
 instance CommentExtraction
            (HsArg
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  nodeComments HsValArg {} = emptyNodeComments
+  nodeComments HsValArg {}  = emptyNodeComments
   nodeComments HsTypeArg {} = emptyNodeComments
-  nodeComments HsArgPar {} = emptyNodeComments
+  nodeComments HsArgPar {}  = emptyNodeComments
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (HsQuote GhcPs) where
-  nodeComments ExpBr {} = emptyNodeComments
-  nodeComments PatBr {} = emptyNodeComments
+  nodeComments ExpBr {}  = emptyNodeComments
+  nodeComments PatBr {}  = emptyNodeComments
   nodeComments DecBrL {} = emptyNodeComments
   nodeComments DecBrG {} = emptyNodeComments
-  nodeComments TypBr {} = emptyNodeComments
-  nodeComments VarBr {} = emptyNodeComments
+  nodeComments TypBr {}  = emptyNodeComments
+  nodeComments VarBr {}  = emptyNodeComments
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -696,15 +696,15 @@ instance CommentExtraction (WithHsDocIdentifiers StringLiteral GhcPs) where
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (IEWrappedName GhcPs) where
-  nodeComments IEName {} = emptyNodeComments
+  nodeComments IEName {}    = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
-  nodeComments IEType {} = emptyNodeComments
+  nodeComments IEType {}    = emptyNodeComments
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance CommentExtraction (IEWrappedName RdrName) where
-  nodeComments IEName {} = emptyNodeComments
+  nodeComments IEName {}    = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
-  nodeComments IEType {} = emptyNodeComments
+  nodeComments IEType {}    = emptyNodeComments
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (DotFieldOcc GhcPs) where
@@ -773,9 +773,9 @@ instance CommentExtraction CExportSpec where
   nodeComments CExportStatic {} = emptyNodeComments
 
 instance CommentExtraction Safety where
-  nodeComments PlaySafe = emptyNodeComments
+  nodeComments PlaySafe          = emptyNodeComments
   nodeComments PlayInterruptible = emptyNodeComments
-  nodeComments PlayRisky = emptyNodeComments
+  nodeComments PlayRisky         = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (AnnDecl GhcPs) where
   nodeComments (HsAnnotation (x, _) _ _) = nodeComments x
@@ -787,9 +787,9 @@ instance CommentExtraction (RoleAnnotDecl GhcPs) where
   nodeComments (RoleAnnotDecl x _ _) = nodeComments x
 
 instance CommentExtraction Role where
-  nodeComments Nominal = emptyNodeComments
+  nodeComments Nominal          = emptyNodeComments
   nodeComments Representational = emptyNodeComments
-  nodeComments Phantom = emptyNodeComments
+  nodeComments Phantom          = emptyNodeComments
 
 instance CommentExtraction (TyFamInstDecl GhcPs) where
   nodeComments TyFamInstDecl {..} = nodeComments tfid_xtn
@@ -813,8 +813,8 @@ instance CommentExtraction
               (GenLocated SrcSpanAnnN RdrName)
               [RecordPatSynField GhcPs]) where
   nodeComments PrefixCon {} = emptyNodeComments
-  nodeComments RecCon {} = emptyNodeComments
-  nodeComments InfixCon {} = emptyNodeComments
+  nodeComments RecCon {}    = emptyNodeComments
+  nodeComments InfixCon {}  = emptyNodeComments
 
 instance CommentExtraction (FixitySig GhcPs) where
   nodeComments FixitySig {} = emptyNodeComments
@@ -834,25 +834,25 @@ instance CommentExtraction InlineSpec where
   nodeComments = nodeCommentsInlineSpec
 
 nodeCommentsInlineSpec :: InlineSpec -> NodeComments
-nodeCommentsInlineSpec Inline {} = emptyNodeComments
-nodeCommentsInlineSpec Inlinable {} = emptyNodeComments
-nodeCommentsInlineSpec NoInline {} = emptyNodeComments
+nodeCommentsInlineSpec Inline {}           = emptyNodeComments
+nodeCommentsInlineSpec Inlinable {}        = emptyNodeComments
+nodeCommentsInlineSpec NoInline {}         = emptyNodeComments
 nodeCommentsInlineSpec NoUserInlinePrag {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsInlineSpec Opaque {} = emptyNodeComments
+nodeCommentsInlineSpec Opaque {}           = emptyNodeComments
 #endif
 instance CommentExtraction (HsPatSynDir GhcPs) where
-  nodeComments Unidirectional = emptyNodeComments
-  nodeComments ImplicitBidirectional = emptyNodeComments
+  nodeComments Unidirectional           = emptyNodeComments
+  nodeComments ImplicitBidirectional    = emptyNodeComments
   nodeComments ExplicitBidirectional {} = emptyNodeComments
 
 instance CommentExtraction (HsOverLit GhcPs) where
   nodeComments OverLit {} = emptyNodeComments
 
 instance CommentExtraction OverLitVal where
-  nodeComments HsIntegral {} = emptyNodeComments
+  nodeComments HsIntegral {}   = emptyNodeComments
   nodeComments HsFractional {} = emptyNodeComments
-  nodeComments HsIsString {} = emptyNodeComments
+  nodeComments HsIsString {}   = emptyNodeComments
 
 instance CommentExtraction IntegralLit where
   nodeComments IL {} = emptyNodeComments
@@ -861,18 +861,18 @@ instance CommentExtraction FractionalLit where
   nodeComments FL {} = emptyNodeComments
 
 instance CommentExtraction (HsLit GhcPs) where
-  nodeComments HsChar {} = emptyNodeComments
-  nodeComments HsCharPrim {} = emptyNodeComments
-  nodeComments HsString {} = emptyNodeComments
+  nodeComments HsChar {}       = emptyNodeComments
+  nodeComments HsCharPrim {}   = emptyNodeComments
+  nodeComments HsString {}     = emptyNodeComments
   nodeComments HsStringPrim {} = emptyNodeComments
-  nodeComments HsInt {} = emptyNodeComments
-  nodeComments HsIntPrim {} = emptyNodeComments
-  nodeComments HsWordPrim {} = emptyNodeComments
-  nodeComments HsInt64Prim {} = emptyNodeComments
+  nodeComments HsInt {}        = emptyNodeComments
+  nodeComments HsIntPrim {}    = emptyNodeComments
+  nodeComments HsWordPrim {}   = emptyNodeComments
+  nodeComments HsInt64Prim {}  = emptyNodeComments
   nodeComments HsWord64Prim {} = emptyNodeComments
-  nodeComments HsInteger {} = emptyNodeComments
-  nodeComments HsRat {} = emptyNodeComments
-  nodeComments HsFloatPrim {} = emptyNodeComments
+  nodeComments HsInteger {}    = emptyNodeComments
+  nodeComments HsRat {}        = emptyNodeComments
+  nodeComments HsFloatPrim {}  = emptyNodeComments
   nodeComments HsDoublePrim {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsPragE GhcPs) where
@@ -885,13 +885,13 @@ instance CommentExtraction HsIPName where
   nodeComments HsIPName {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsTyLit GhcPs) where
-  nodeComments HsNumTy {} = emptyNodeComments
-  nodeComments HsStrTy {} = emptyNodeComments
+  nodeComments HsNumTy {}  = emptyNodeComments
+  nodeComments HsStrTy {}  = emptyNodeComments
   nodeComments HsCharTy {} = emptyNodeComments
 #else
 instance CommentExtraction HsTyLit where
-  nodeComments HsNumTy {} = emptyNodeComments
-  nodeComments HsStrTy {} = emptyNodeComments
+  nodeComments HsNumTy {}  = emptyNodeComments
+  nodeComments HsStrTy {}  = emptyNodeComments
   nodeComments HsCharTy {} = emptyNodeComments
 #endif
 instance CommentExtraction (HsPatSigType GhcPs) where
@@ -904,10 +904,10 @@ instance CommentExtraction (IPBind GhcPs) where
   nodeComments (IPBind x _ _) = nodeComments x
 
 instance CommentExtraction (DerivStrategy GhcPs) where
-  nodeComments (StockStrategy x) = nodeComments x
+  nodeComments (StockStrategy x)    = nodeComments x
   nodeComments (AnyclassStrategy x) = nodeComments x
-  nodeComments (NewtypeStrategy x) = nodeComments x
-  nodeComments (ViaStrategy x) = nodeComments x
+  nodeComments (NewtypeStrategy x)  = nodeComments x
+  nodeComments (ViaStrategy x)      = nodeComments x
 
 instance CommentExtraction XViaStrategyPs where
   nodeComments (XViaStrategyPs x _) = nodeComments x
@@ -922,28 +922,28 @@ instance CommentExtraction (HsCmd GhcPs) where
   nodeComments = nodeCommentsHsCmd
 
 nodeCommentsHsCmd :: HsCmd GhcPs -> NodeComments
-nodeCommentsHsCmd (HsCmdArrApp x _ _ _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdArrApp x _ _ _ _)  = nodeComments x
 nodeCommentsHsCmd (HsCmdArrForm x _ _ _ _) = nodeComments x
-nodeCommentsHsCmd (HsCmdApp x _ _) = nodeComments x
-nodeCommentsHsCmd HsCmdLam {} = emptyNodeComments
+nodeCommentsHsCmd (HsCmdApp x _ _)         = nodeComments x
+nodeCommentsHsCmd HsCmdLam {}              = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsCmd (HsCmdPar x _ _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdPar x _ _ _)       = nodeComments x
 #else
-nodeCommentsHsCmd (HsCmdPar x _) = nodeComments x
+nodeCommentsHsCmd (HsCmdPar x _)           = nodeComments x
 #endif
-nodeCommentsHsCmd (HsCmdCase x _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdCase x _ _)        = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsCmd (HsCmdLamCase x _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdLamCase x _ _)     = nodeComments x
 #else
-nodeCommentsHsCmd (HsCmdLamCase x _) = nodeComments x
+nodeCommentsHsCmd (HsCmdLamCase x _)       = nodeComments x
 #endif
-nodeCommentsHsCmd (HsCmdIf x _ _ _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdIf x _ _ _ _)      = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsCmd (HsCmdLet x _ _ _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdLet x _ _ _ _)     = nodeComments x
 #else
-nodeCommentsHsCmd (HsCmdLet x _ _) = nodeComments x
+nodeCommentsHsCmd (HsCmdLet x _ _)         = nodeComments x
 #endif
-nodeCommentsHsCmd (HsCmdDo x _) = nodeComments x
+nodeCommentsHsCmd (HsCmdDo x _)            = nodeComments x
 
 instance CommentExtraction ListComprehension where
   nodeComments ListComprehension {} = emptyNodeComments
@@ -955,30 +955,27 @@ instance CommentExtraction LetIn where
   nodeComments LetIn {} = emptyNodeComments
 
 instance CommentExtraction (RuleBndr GhcPs) where
-  nodeComments (RuleBndr x _) = nodeComments x
+  nodeComments (RuleBndr x _)      = nodeComments x
   nodeComments (RuleBndrSig x _ _) = nodeComments x
 
 instance CommentExtraction CCallConv where
   nodeComments = const emptyNodeComments
 
-instance CommentExtraction ModuleDeprecatedPragma where
-  nodeComments ModuleDeprecatedPragma {} = emptyNodeComments
-
 instance CommentExtraction HsSrcBang where
   nodeComments HsSrcBang {} = emptyNodeComments
 
 instance CommentExtraction SrcUnpackedness where
-  nodeComments SrcUnpack = emptyNodeComments
+  nodeComments SrcUnpack   = emptyNodeComments
   nodeComments SrcNoUnpack = emptyNodeComments
   nodeComments NoSrcUnpack = emptyNodeComments
 
 instance CommentExtraction SrcStrictness where
-  nodeComments SrcLazy = emptyNodeComments
-  nodeComments SrcStrict = emptyNodeComments
+  nodeComments SrcLazy     = emptyNodeComments
+  nodeComments SrcStrict   = emptyNodeComments
   nodeComments NoSrcStrict = emptyNodeComments
 
 instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
-  nodeComments HsOuterImplicit {} = emptyNodeComments
+  nodeComments HsOuterImplicit {}   = emptyNodeComments
   nodeComments HsOuterExplicit {..} = nodeComments hso_xexplicit
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction FieldLabelString where
@@ -986,12 +983,12 @@ instance CommentExtraction FieldLabelString where
 
 instance CommentExtraction (HsUntypedSplice GhcPs) where
   nodeComments (HsUntypedSpliceExpr x _) = nodeComments x
-  nodeComments HsQuasiQuote {} = emptyNodeComments
+  nodeComments HsQuasiQuote {}           = emptyNodeComments
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance CommentExtraction (LHsRecUpdFields GhcPs) where
-  nodeComments RegularRecUpdFields {} = emptyNodeComments
+  nodeComments RegularRecUpdFields {}    = emptyNodeComments
   nodeComments OverloadedRecUpdFields {} = emptyNodeComments
 #endif
 -- | Marks an AST node as never appearing in the AST.

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | Comment handling around an AST node
 module HIndent.Pretty.NodeComments
@@ -8,27 +8,27 @@ module HIndent.Pretty.NodeComments
   , emptyNodeComments
   ) where
 
-import           Data.Void
-import           GHC.Core.Coercion
-import           GHC.Data.BooleanFormula
-import           GHC.Hs
-import           GHC.Stack
-import           GHC.Types.Basic
-import           GHC.Types.Fixity
-import           GHC.Types.ForeignCall
-import           GHC.Types.Name
-import           GHC.Types.Name.Reader
-import           GHC.Types.SourceText
-import           GHC.Types.SrcLoc
-import           HIndent.Ast.NodeComments
-import           HIndent.Pragma
-import           HIndent.Pretty.SigBindFamily
-import           HIndent.Pretty.Types
+import Data.Void
+import GHC.Core.Coercion
+import GHC.Data.BooleanFormula
+import GHC.Hs
+import GHC.Stack
+import GHC.Types.Basic
+import GHC.Types.Fixity
+import GHC.Types.ForeignCall
+import GHC.Types.Name
+import GHC.Types.Name.Reader
+import GHC.Types.SourceText
+import GHC.Types.SrcLoc
+import HIndent.Ast.NodeComments
+import HIndent.Pragma
+import HIndent.Pretty.SigBindFamily
+import HIndent.Pretty.Types
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import           GHC.Core.DataCon
+import GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import           GHC.Unit
+import GHC.Unit
 #endif
 -- | An interface to extract comments from an AST node.
 class CommentExtraction a where
@@ -88,64 +88,64 @@ instance CommentExtraction (HsDecl GhcPs) where
   nodeComments RoleAnnotD {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (TyClDecl GhcPs) where
-  nodeComments FamDecl {}                   = emptyNodeComments
-  nodeComments SynDecl {..}                 = nodeComments tcdSExt
-  nodeComments DataDecl {..}                = nodeComments tcdDExt
+  nodeComments FamDecl {} = emptyNodeComments
+  nodeComments SynDecl {..} = nodeComments tcdSExt
+  nodeComments DataDecl {..} = nodeComments tcdDExt
   nodeComments ClassDecl {tcdCExt = (x, _)} = nodeComments x
 #else
 instance CommentExtraction (TyClDecl GhcPs) where
-  nodeComments FamDecl {}                      = emptyNodeComments
-  nodeComments SynDecl {..}                    = nodeComments tcdSExt
-  nodeComments DataDecl {..}                   = nodeComments tcdDExt
+  nodeComments FamDecl {} = emptyNodeComments
+  nodeComments SynDecl {..} = nodeComments tcdSExt
+  nodeComments DataDecl {..} = nodeComments tcdDExt
   nodeComments ClassDecl {tcdCExt = (x, _, _)} = nodeComments x
 #endif
 instance CommentExtraction (InstDecl GhcPs) where
   nodeComments = nodeCommentsInstDecl
 
 nodeCommentsInstDecl :: InstDecl GhcPs -> NodeComments
-nodeCommentsInstDecl ClsInstD {}       = emptyNodeComments
+nodeCommentsInstDecl ClsInstD {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsInstDecl DataFamInstD {}   = emptyNodeComments
+nodeCommentsInstDecl DataFamInstD {} = emptyNodeComments
 #else
 nodeCommentsInstDecl DataFamInstD {..} = nodeComments dfid_ext
 #endif
-nodeCommentsInstDecl TyFamInstD {}     = emptyNodeComments
+nodeCommentsInstDecl TyFamInstD {} = emptyNodeComments
 
 instance CommentExtraction (HsBind GhcPs) where
   nodeComments = nodeCommentsHsBind
 
 nodeCommentsHsBind :: HsBind GhcPs -> NodeComments
-nodeCommentsHsBind FunBind {..}  = nodeComments fun_id
-nodeCommentsHsBind PatBind {..}  = nodeComments pat_ext
-nodeCommentsHsBind VarBind {}    = emptyNodeComments
+nodeCommentsHsBind FunBind {..} = nodeComments fun_id
+nodeCommentsHsBind PatBind {..} = nodeComments pat_ext
+nodeCommentsHsBind VarBind {} = emptyNodeComments
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsBind AbsBinds {}   = emptyNodeComments
+nodeCommentsHsBind AbsBinds {} = emptyNodeComments
 #endif
 nodeCommentsHsBind PatSynBind {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (Sig GhcPs) where
-  nodeComments (TypeSig x _ _)          = nodeComments x
-  nodeComments (PatSynSig x _ _)        = nodeComments x
-  nodeComments (ClassOpSig x _ _ _)     = nodeComments x
-  nodeComments (FixSig x _)             = nodeComments x
-  nodeComments (InlineSig x _ _)        = nodeComments x
-  nodeComments (SpecSig x _ _ _)        = nodeComments x
-  nodeComments (SpecInstSig x _)        = nodeComments $ fst x
-  nodeComments (MinimalSig x _)         = nodeComments $ fst x
-  nodeComments (SCCFunSig x _ _)        = nodeComments $ fst x
+  nodeComments (TypeSig x _ _) = nodeComments x
+  nodeComments (PatSynSig x _ _) = nodeComments x
+  nodeComments (ClassOpSig x _ _ _) = nodeComments x
+  nodeComments (FixSig x _) = nodeComments x
+  nodeComments (InlineSig x _ _) = nodeComments x
+  nodeComments (SpecSig x _ _ _) = nodeComments x
+  nodeComments (SpecInstSig x _) = nodeComments $ fst x
+  nodeComments (MinimalSig x _) = nodeComments $ fst x
+  nodeComments (SCCFunSig x _ _) = nodeComments $ fst x
   nodeComments (CompleteMatchSig x _ _) = nodeComments $ fst x
 #else
 instance CommentExtraction (Sig GhcPs) where
-  nodeComments (TypeSig x _ _)            = nodeComments x
-  nodeComments (PatSynSig x _ _)          = nodeComments x
-  nodeComments (ClassOpSig x _ _ _)       = nodeComments x
-  nodeComments IdSig {}                   = emptyNodeComments
-  nodeComments (FixSig x _)               = nodeComments x
-  nodeComments (InlineSig x _ _)          = nodeComments x
-  nodeComments (SpecSig x _ _ _)          = nodeComments x
-  nodeComments (SpecInstSig x _ _)        = nodeComments x
-  nodeComments (MinimalSig x _ _)         = nodeComments x
-  nodeComments (SCCFunSig x _ _ _)        = nodeComments x
+  nodeComments (TypeSig x _ _) = nodeComments x
+  nodeComments (PatSynSig x _ _) = nodeComments x
+  nodeComments (ClassOpSig x _ _ _) = nodeComments x
+  nodeComments IdSig {} = emptyNodeComments
+  nodeComments (FixSig x _) = nodeComments x
+  nodeComments (InlineSig x _ _) = nodeComments x
+  nodeComments (SpecSig x _ _ _) = nodeComments x
+  nodeComments (SpecInstSig x _ _) = nodeComments x
+  nodeComments (MinimalSig x _ _) = nodeComments x
+  nodeComments (SCCFunSig x _ _ _) = nodeComments x
   nodeComments (CompleteMatchSig x _ _ _) = nodeComments x
 #endif
 instance CommentExtraction (HsDataDefn GhcPs) where
@@ -170,78 +170,78 @@ instance CommentExtraction QualifiedDo where
   nodeComments = const emptyNodeComments
 
 nodeCommentsHsExpr :: HsExpr GhcPs -> NodeComments
-nodeCommentsHsExpr HsVar {}                 = emptyNodeComments
-nodeCommentsHsExpr (HsUnboundVar x _)       = nodeComments x
+nodeCommentsHsExpr HsVar {} = emptyNodeComments
+nodeCommentsHsExpr (HsUnboundVar x _) = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr HsConLikeOut {}          = emptyNodeComments
-nodeCommentsHsExpr HsRecFld {}              = emptyNodeComments
+nodeCommentsHsExpr HsConLikeOut {} = emptyNodeComments
+nodeCommentsHsExpr HsRecFld {} = emptyNodeComments
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsHsExpr (HsOverLabel x _ _)      = nodeComments x
+nodeCommentsHsExpr (HsOverLabel x _ _) = nodeComments x
 #else
-nodeCommentsHsExpr (HsOverLabel x _)        = nodeComments x
+nodeCommentsHsExpr (HsOverLabel x _) = nodeComments x
 #endif
-nodeCommentsHsExpr (HsIPVar x _)            = nodeComments x
-nodeCommentsHsExpr (HsOverLit x _)          = nodeComments x
-nodeCommentsHsExpr (HsLit x _)              = nodeComments x
-nodeCommentsHsExpr HsLam {}                 = emptyNodeComments
+nodeCommentsHsExpr (HsIPVar x _) = nodeComments x
+nodeCommentsHsExpr (HsOverLit x _) = nodeComments x
+nodeCommentsHsExpr (HsLit x _) = nodeComments x
+nodeCommentsHsExpr HsLam {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsLamCase x _ _)        = nodeComments x
+nodeCommentsHsExpr (HsLamCase x _ _) = nodeComments x
 #else
-nodeCommentsHsExpr (HsLamCase x _)          = nodeComments x
+nodeCommentsHsExpr (HsLamCase x _) = nodeComments x
 #endif
-nodeCommentsHsExpr (HsApp x _ _)            = nodeComments x
-nodeCommentsHsExpr HsAppType {}             = emptyNodeComments
-nodeCommentsHsExpr (OpApp x _ _ _)          = nodeComments x
-nodeCommentsHsExpr (NegApp x _ _)           = nodeComments x
+nodeCommentsHsExpr (HsApp x _ _) = nodeComments x
+nodeCommentsHsExpr HsAppType {} = emptyNodeComments
+nodeCommentsHsExpr (OpApp x _ _ _) = nodeComments x
+nodeCommentsHsExpr (NegApp x _ _) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsPar x _ _ _)          = nodeComments x
+nodeCommentsHsExpr (HsPar x _ _ _) = nodeComments x
 #else
-nodeCommentsHsExpr (HsPar x _)              = nodeComments x
+nodeCommentsHsExpr (HsPar x _) = nodeComments x
 #endif
-nodeCommentsHsExpr (SectionL x _ _)         = nodeComments x
-nodeCommentsHsExpr (SectionR x _ _)         = nodeComments x
-nodeCommentsHsExpr (ExplicitTuple x _ _)    = nodeComments x
-nodeCommentsHsExpr (ExplicitSum x _ _ _)    = nodeComments x
-nodeCommentsHsExpr (HsCase x _ _)           = nodeComments x
-nodeCommentsHsExpr (HsIf x _ _ _)           = nodeComments x
-nodeCommentsHsExpr (HsMultiIf x _)          = nodeComments x
+nodeCommentsHsExpr (SectionL x _ _) = nodeComments x
+nodeCommentsHsExpr (SectionR x _ _) = nodeComments x
+nodeCommentsHsExpr (ExplicitTuple x _ _) = nodeComments x
+nodeCommentsHsExpr (ExplicitSum x _ _ _) = nodeComments x
+nodeCommentsHsExpr (HsCase x _ _) = nodeComments x
+nodeCommentsHsExpr (HsIf x _ _ _) = nodeComments x
+nodeCommentsHsExpr (HsMultiIf x _) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsLet x _ _ _ _)        = nodeComments x
+nodeCommentsHsExpr (HsLet x _ _ _ _) = nodeComments x
 #else
-nodeCommentsHsExpr (HsLet x _ _)            = nodeComments x
+nodeCommentsHsExpr (HsLet x _ _) = nodeComments x
 #endif
-nodeCommentsHsExpr (HsDo x _ _)             = nodeComments x
-nodeCommentsHsExpr (ExplicitList x _)       = nodeComments x
-nodeCommentsHsExpr RecordCon {..}           = nodeComments rcon_ext
-nodeCommentsHsExpr RecordUpd {..}           = nodeComments rupd_ext
-nodeCommentsHsExpr HsGetField {..}          = nodeComments gf_ext
-nodeCommentsHsExpr HsProjection {..}        = nodeComments proj_ext
-nodeCommentsHsExpr (ExprWithTySig x _ _)    = nodeComments x
-nodeCommentsHsExpr (ArithSeq x _ _)         = nodeComments x
+nodeCommentsHsExpr (HsDo x _ _) = nodeComments x
+nodeCommentsHsExpr (ExplicitList x _) = nodeComments x
+nodeCommentsHsExpr RecordCon {..} = nodeComments rcon_ext
+nodeCommentsHsExpr RecordUpd {..} = nodeComments rupd_ext
+nodeCommentsHsExpr HsGetField {..} = nodeComments gf_ext
+nodeCommentsHsExpr HsProjection {..} = nodeComments proj_ext
+nodeCommentsHsExpr (ExprWithTySig x _ _) = nodeComments x
+nodeCommentsHsExpr (ArithSeq x _ _) = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr (HsBracket x _)          = nodeComments x
-nodeCommentsHsExpr HsRnBracketOut {}        = notUsedInParsedStage
-nodeCommentsHsExpr HsTcBracketOut {}        = notUsedInParsedStage
+nodeCommentsHsExpr (HsBracket x _) = nodeComments x
+nodeCommentsHsExpr HsRnBracketOut {} = notUsedInParsedStage
+nodeCommentsHsExpr HsTcBracketOut {} = notUsedInParsedStage
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsHsExpr (HsSpliceE x _)          = nodeComments x
+nodeCommentsHsExpr (HsSpliceE x _) = nodeComments x
 #endif
-nodeCommentsHsExpr (HsProc x _ _)           = nodeComments x
-nodeCommentsHsExpr (HsStatic x _)           = nodeComments x
+nodeCommentsHsExpr (HsProc x _ _) = nodeComments x
+nodeCommentsHsExpr (HsStatic x _) = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr HsTick {}                = emptyNodeComments
-nodeCommentsHsExpr HsBinTick {}             = emptyNodeComments
+nodeCommentsHsExpr HsTick {} = emptyNodeComments
+nodeCommentsHsExpr HsBinTick {} = emptyNodeComments
 #endif
-nodeCommentsHsExpr HsPragE {}               = emptyNodeComments
+nodeCommentsHsExpr HsPragE {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsExpr HsRecSel {}              = emptyNodeComments
-nodeCommentsHsExpr (HsTypedBracket x _)     = nodeComments x
-nodeCommentsHsExpr (HsUntypedBracket x _)   = nodeComments x
+nodeCommentsHsExpr HsRecSel {} = emptyNodeComments
+nodeCommentsHsExpr (HsTypedBracket x _) = nodeComments x
+nodeCommentsHsExpr (HsUntypedBracket x _) = nodeComments x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 nodeCommentsHsExpr (HsTypedSplice (x, y) _) = nodeComments x <> nodeComments y
-nodeCommentsHsExpr (HsUntypedSplice x _)    = nodeComments x
+nodeCommentsHsExpr (HsUntypedSplice x _) = nodeComments x
 #endif
 instance CommentExtraction (HsSigType GhcPs) where
   nodeComments HsSig {} = emptyNodeComments
@@ -251,32 +251,32 @@ instance CommentExtraction HsSigType' where
 
 instance CommentExtraction (ConDecl GhcPs) where
   nodeComments ConDeclGADT {..} = nodeComments con_g_ext
-  nodeComments ConDeclH98 {..}  = nodeComments con_ext
+  nodeComments ConDeclH98 {..} = nodeComments con_ext
 
 instance CommentExtraction (Match GhcPs a) where
   nodeComments Match {..} = nodeComments m_ext
 
 instance CommentExtraction
            (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
-  nodeComments LastStmt {}        = emptyNodeComments
-  nodeComments (BindStmt x _ _)   = nodeComments x
+  nodeComments LastStmt {} = emptyNodeComments
+  nodeComments (BindStmt x _ _) = nodeComments x
   nodeComments ApplicativeStmt {} = emptyNodeComments
-  nodeComments BodyStmt {}        = emptyNodeComments
-  nodeComments (LetStmt x _)      = nodeComments x
-  nodeComments ParStmt {}         = emptyNodeComments
-  nodeComments TransStmt {..}     = nodeComments trS_ext
-  nodeComments RecStmt {..}       = nodeComments recS_ext
+  nodeComments BodyStmt {} = emptyNodeComments
+  nodeComments (LetStmt x _) = nodeComments x
+  nodeComments ParStmt {} = emptyNodeComments
+  nodeComments TransStmt {..} = nodeComments trS_ext
+  nodeComments RecStmt {..} = nodeComments recS_ext
 
 instance CommentExtraction
            (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
-  nodeComments LastStmt {}        = emptyNodeComments
-  nodeComments (BindStmt x _ _)   = nodeComments x
+  nodeComments LastStmt {} = emptyNodeComments
+  nodeComments (BindStmt x _ _) = nodeComments x
   nodeComments ApplicativeStmt {} = emptyNodeComments
-  nodeComments BodyStmt {}        = emptyNodeComments
-  nodeComments (LetStmt x _)      = nodeComments x
-  nodeComments ParStmt {}         = emptyNodeComments
-  nodeComments TransStmt {..}     = nodeComments trS_ext
-  nodeComments RecStmt {..}       = nodeComments recS_ext
+  nodeComments BodyStmt {} = emptyNodeComments
+  nodeComments (LetStmt x _) = nodeComments x
+  nodeComments ParStmt {} = emptyNodeComments
+  nodeComments TransStmt {..} = nodeComments trS_ext
+  nodeComments RecStmt {..} = nodeComments recS_ext
 
 instance CommentExtraction StmtLRInsideVerticalList where
   nodeComments (StmtLRInsideVerticalList x) = nodeComments x
@@ -295,29 +295,29 @@ instance CommentExtraction (HsType GhcPs) where
   nodeComments = nodeComments . HsType' HsTypeForNormalDecl HsTypeNoDir
 
 instance CommentExtraction HsType' where
-  nodeComments (HsType' _ _ HsForAllTy {})            = emptyNodeComments
-  nodeComments (HsType' _ _ HsQualTy {})              = emptyNodeComments
-  nodeComments (HsType' _ _ (HsTyVar x _ _))          = nodeComments x
-  nodeComments (HsType' _ _ HsAppTy {})               = emptyNodeComments
-  nodeComments (HsType' _ _ HsAppKindTy {})           = emptyNodeComments
-  nodeComments (HsType' _ _ (HsFunTy x _ _ _))        = nodeComments x
-  nodeComments (HsType' _ _ (HsListTy x _))           = nodeComments x
-  nodeComments (HsType' _ _ (HsTupleTy x _ _))        = nodeComments x
-  nodeComments (HsType' _ _ (HsSumTy x _))            = nodeComments x
-  nodeComments (HsType' _ _ HsOpTy {})                = emptyNodeComments
-  nodeComments (HsType' _ _ (HsParTy x _))            = nodeComments x
-  nodeComments (HsType' _ _ (HsIParamTy x _ _))       = nodeComments x
-  nodeComments (HsType' _ _ HsStarTy {})              = emptyNodeComments
-  nodeComments (HsType' _ _ (HsKindSig x _ _))        = nodeComments x
-  nodeComments (HsType' _ _ HsSpliceTy {})            = emptyNodeComments
-  nodeComments (HsType' _ _ (HsDocTy x _ _))          = nodeComments x
-  nodeComments (HsType' _ _ (HsBangTy x _ _))         = nodeComments x
-  nodeComments (HsType' _ _ (HsRecTy x _))            = nodeComments x
+  nodeComments (HsType' _ _ HsForAllTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ HsQualTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ (HsTyVar x _ _)) = nodeComments x
+  nodeComments (HsType' _ _ HsAppTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ HsAppKindTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ (HsFunTy x _ _ _)) = nodeComments x
+  nodeComments (HsType' _ _ (HsListTy x _)) = nodeComments x
+  nodeComments (HsType' _ _ (HsTupleTy x _ _)) = nodeComments x
+  nodeComments (HsType' _ _ (HsSumTy x _)) = nodeComments x
+  nodeComments (HsType' _ _ HsOpTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ (HsParTy x _)) = nodeComments x
+  nodeComments (HsType' _ _ (HsIParamTy x _ _)) = nodeComments x
+  nodeComments (HsType' _ _ HsStarTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ (HsKindSig x _ _)) = nodeComments x
+  nodeComments (HsType' _ _ HsSpliceTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ (HsDocTy x _ _)) = nodeComments x
+  nodeComments (HsType' _ _ (HsBangTy x _ _)) = nodeComments x
+  nodeComments (HsType' _ _ (HsRecTy x _)) = nodeComments x
   nodeComments (HsType' _ _ (HsExplicitListTy x _ _)) = nodeComments x
-  nodeComments (HsType' _ _ (HsExplicitTupleTy x _))  = nodeComments x
-  nodeComments (HsType' _ _ HsTyLit {})               = emptyNodeComments
-  nodeComments (HsType' _ _ HsWildCardTy {})          = emptyNodeComments
-  nodeComments (HsType' _ _ XHsType {})               = emptyNodeComments
+  nodeComments (HsType' _ _ (HsExplicitTupleTy x _)) = nodeComments x
+  nodeComments (HsType' _ _ HsTyLit {}) = emptyNodeComments
+  nodeComments (HsType' _ _ HsWildCardTy {}) = emptyNodeComments
+  nodeComments (HsType' _ _ XHsType {}) = emptyNodeComments
 
 instance CommentExtraction (GRHSs GhcPs a) where
   nodeComments GRHSs {..} = NodeComments {..}
@@ -333,20 +333,20 @@ instance CommentExtraction (HsMatchContext GhcPs) where
   nodeComments = nodeCommentsMatchContext
 
 nodeCommentsMatchContext :: HsMatchContext GhcPs -> NodeComments
-nodeCommentsMatchContext FunRhs {}         = emptyNodeComments
-nodeCommentsMatchContext LambdaExpr {}     = emptyNodeComments
-nodeCommentsMatchContext CaseAlt {}        = emptyNodeComments
-nodeCommentsMatchContext IfAlt {}          = emptyNodeComments
+nodeCommentsMatchContext FunRhs {} = emptyNodeComments
+nodeCommentsMatchContext LambdaExpr {} = emptyNodeComments
+nodeCommentsMatchContext CaseAlt {} = emptyNodeComments
+nodeCommentsMatchContext IfAlt {} = emptyNodeComments
 nodeCommentsMatchContext ArrowMatchCtxt {} = emptyNodeComments
-nodeCommentsMatchContext PatBindRhs {}     = emptyNodeComments
-nodeCommentsMatchContext PatBindGuards {}  = emptyNodeComments
-nodeCommentsMatchContext RecUpd {}         = emptyNodeComments
-nodeCommentsMatchContext StmtCtxt {}       = emptyNodeComments
-nodeCommentsMatchContext ThPatSplice {}    = emptyNodeComments
-nodeCommentsMatchContext ThPatQuote {}     = emptyNodeComments
-nodeCommentsMatchContext PatSyn {}         = emptyNodeComments
+nodeCommentsMatchContext PatBindRhs {} = emptyNodeComments
+nodeCommentsMatchContext PatBindGuards {} = emptyNodeComments
+nodeCommentsMatchContext RecUpd {} = emptyNodeComments
+nodeCommentsMatchContext StmtCtxt {} = emptyNodeComments
+nodeCommentsMatchContext ThPatSplice {} = emptyNodeComments
+nodeCommentsMatchContext ThPatQuote {} = emptyNodeComments
+nodeCommentsMatchContext PatSyn {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsMatchContext LamCaseAlt {}     = emptyNodeComments
+nodeCommentsMatchContext LamCaseAlt {} = emptyNodeComments
 #endif
 instance CommentExtraction (ParStmtBlock GhcPs GhcPs) where
   nodeComments ParStmtBlock {} = emptyNodeComments
@@ -356,9 +356,9 @@ instance CommentExtraction ParStmtBlockInsideVerticalList where
 
 instance CommentExtraction RdrName where
   nodeComments Unqual {} = emptyNodeComments
-  nodeComments Qual {}   = emptyNodeComments
-  nodeComments Orig {}   = emptyNodeComments
-  nodeComments Exact {}  = emptyNodeComments
+  nodeComments Qual {} = emptyNodeComments
+  nodeComments Orig {} = emptyNodeComments
+  nodeComments Exact {} = emptyNodeComments
 
 instance CommentExtraction (GRHS GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
   nodeComments = nodeComments . GRHSExpr GRHSExprNormal
@@ -376,10 +376,10 @@ instance CommentExtraction (SpliceDecl GhcPs) where
   nodeComments SpliceDecl {} = emptyNodeComments
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsSplice GhcPs) where
-  nodeComments (HsTypedSplice x _ _ _)   = nodeComments x
+  nodeComments (HsTypedSplice x _ _ _) = nodeComments x
   nodeComments (HsUntypedSplice x _ _ _) = nodeComments x
-  nodeComments HsQuasiQuote {}           = emptyNodeComments
-  nodeComments HsSpliced {}              = emptyNodeComments
+  nodeComments HsQuasiQuote {} = emptyNodeComments
+  nodeComments HsSpliced {} = emptyNodeComments
 #endif
 instance CommentExtraction (Pat GhcPs) where
   nodeComments = nodeCommentsPat
@@ -388,48 +388,48 @@ instance CommentExtraction PatInsidePatDecl where
   nodeComments (PatInsidePatDecl x) = nodeComments x
 
 nodeCommentsPat :: Pat GhcPs -> NodeComments
-nodeCommentsPat WildPat {}              = emptyNodeComments
-nodeCommentsPat VarPat {}               = emptyNodeComments
-nodeCommentsPat (LazyPat x _)           = nodeComments x
+nodeCommentsPat WildPat {} = emptyNodeComments
+nodeCommentsPat VarPat {} = emptyNodeComments
+nodeCommentsPat (LazyPat x _) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsPat (AsPat x _ _ _)         = nodeComments x
+nodeCommentsPat (AsPat x _ _ _) = nodeComments x
 #else
-nodeCommentsPat (AsPat x _ _)           = nodeComments x
+nodeCommentsPat (AsPat x _ _) = nodeComments x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsPat (ParPat x _ _ _)        = nodeComments x
+nodeCommentsPat (ParPat x _ _ _) = nodeComments x
 #else
-nodeCommentsPat (ParPat x _)            = nodeComments x
+nodeCommentsPat (ParPat x _) = nodeComments x
 #endif
-nodeCommentsPat (BangPat x _)           = nodeComments x
-nodeCommentsPat (ListPat x _)           = nodeComments x
-nodeCommentsPat (TuplePat x _ _)        = nodeComments x
-nodeCommentsPat (SumPat x _ _ _)        = nodeComments x
-nodeCommentsPat ConPat {..}             = nodeComments pat_con_ext
-nodeCommentsPat (ViewPat x _ _)         = nodeComments x
-nodeCommentsPat SplicePat {}            = emptyNodeComments
-nodeCommentsPat LitPat {}               = emptyNodeComments
-nodeCommentsPat (NPat x _ _ _)          = nodeComments x
+nodeCommentsPat (BangPat x _) = nodeComments x
+nodeCommentsPat (ListPat x _) = nodeComments x
+nodeCommentsPat (TuplePat x _ _) = nodeComments x
+nodeCommentsPat (SumPat x _ _ _) = nodeComments x
+nodeCommentsPat ConPat {..} = nodeComments pat_con_ext
+nodeCommentsPat (ViewPat x _ _) = nodeComments x
+nodeCommentsPat SplicePat {} = emptyNodeComments
+nodeCommentsPat LitPat {} = emptyNodeComments
+nodeCommentsPat (NPat x _ _ _) = nodeComments x
 nodeCommentsPat (NPlusKPat x _ _ _ _ _) = nodeComments x
-nodeCommentsPat (SigPat x _ _)          = nodeComments x
+nodeCommentsPat (SigPat x _ _) = nodeComments x
 
 instance CommentExtraction RecConPat where
   nodeComments (RecConPat x) = nodeComments x
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (HsBracket GhcPs) where
-  nodeComments ExpBr {}  = emptyNodeComments
-  nodeComments PatBr {}  = emptyNodeComments
+  nodeComments ExpBr {} = emptyNodeComments
+  nodeComments PatBr {} = emptyNodeComments
   nodeComments DecBrL {} = emptyNodeComments
   nodeComments DecBrG {} = emptyNodeComments
-  nodeComments TypBr {}  = emptyNodeComments
-  nodeComments VarBr {}  = emptyNodeComments
+  nodeComments TypBr {} = emptyNodeComments
+  nodeComments VarBr {} = emptyNodeComments
   nodeComments TExpBr {} = emptyNodeComments
 #endif
 instance CommentExtraction SigBindFamily where
-  nodeComments (Sig x)         = nodeComments x
-  nodeComments (Bind x)        = nodeComments x
-  nodeComments (TypeFamily x)  = nodeComments x
-  nodeComments (TyFamInst x)   = nodeComments x
+  nodeComments (Sig x) = nodeComments x
+  nodeComments (Bind x) = nodeComments x
+  nodeComments (TypeFamily x) = nodeComments x
+  nodeComments (TyFamInst x) = nodeComments x
   nodeComments (DataFamInst x) = nodeComments x
 
 instance CommentExtraction EpaComment where
@@ -442,7 +442,7 @@ instance CommentExtraction (SrcAnn a) where
   nodeComments (SrcSpanAnn ep _) = nodeComments ep
 
 instance CommentExtraction SrcSpan where
-  nodeComments RealSrcSpan {}   = emptyNodeComments
+  nodeComments RealSrcSpan {} = emptyNodeComments
   nodeComments UnhelpfulSpan {} = emptyNodeComments
 
 instance CommentExtraction (EpAnn a) where
@@ -457,17 +457,17 @@ instance CommentExtraction (EpAnn a) where
   nodeComments EpAnnNotUsed = emptyNodeComments
 
 instance CommentExtraction (HsLocalBindsLR GhcPs GhcPs) where
-  nodeComments (HsValBinds x _)   = nodeComments x
-  nodeComments (HsIPBinds x _)    = nodeComments x
+  nodeComments (HsValBinds x _) = nodeComments x
+  nodeComments (HsIPBinds x _) = nodeComments x
   nodeComments EmptyLocalBinds {} = emptyNodeComments
 
 instance CommentExtraction (HsValBindsLR GhcPs GhcPs) where
-  nodeComments ValBinds {}    = emptyNodeComments
+  nodeComments ValBinds {} = emptyNodeComments
   nodeComments XValBindsLR {} = notUsedInParsedStage
 
 instance CommentExtraction (HsTupArg GhcPs) where
   nodeComments (Present x _) = nodeComments x
-  nodeComments (Missing x)   = nodeComments x
+  nodeComments (Missing x) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction RecConField where
   nodeComments (RecConField x) = nodeComments x
@@ -516,8 +516,8 @@ instance CommentExtraction
                  SrcSpanAnnL
                  [GenLocated SrcSpanAnnA (ConDeclField GhcPs)])) where
   nodeComments PrefixCon {} = emptyNodeComments
-  nodeComments RecCon {}    = emptyNodeComments
-  nodeComments InfixCon {}  = emptyNodeComments
+  nodeComments RecCon {} = emptyNodeComments
+  nodeComments InfixCon {} = emptyNodeComments
 
 instance CommentExtraction (HsScaled GhcPs a) where
   nodeComments HsScaled {} = emptyNodeComments
@@ -532,9 +532,9 @@ instance CommentExtraction InfixApp where
   nodeComments InfixApp {} = emptyNodeComments
 
 instance CommentExtraction (BooleanFormula a) where
-  nodeComments Var {}    = emptyNodeComments
-  nodeComments And {}    = emptyNodeComments
-  nodeComments Or {}     = emptyNodeComments
+  nodeComments Var {} = emptyNodeComments
+  nodeComments And {} = emptyNodeComments
+  nodeComments Or {} = emptyNodeComments
   nodeComments Parens {} = emptyNodeComments
 
 instance CommentExtraction (FieldLabelStrings GhcPs) where
@@ -542,7 +542,7 @@ instance CommentExtraction (FieldLabelStrings GhcPs) where
 
 instance CommentExtraction (AmbiguousFieldOcc GhcPs) where
   nodeComments Unambiguous {} = emptyNodeComments
-  nodeComments Ambiguous {}   = emptyNodeComments
+  nodeComments Ambiguous {} = emptyNodeComments
 
 instance CommentExtraction (ImportDecl GhcPs) where
   nodeComments ImportDecl {..} = nodeComments ideclExt
@@ -555,14 +555,14 @@ instance CommentExtraction (HsDerivingClause GhcPs) where
 
 instance CommentExtraction (DerivClauseTys GhcPs) where
   nodeComments DctSingle {} = emptyNodeComments
-  nodeComments DctMulti {}  = emptyNodeComments
+  nodeComments DctMulti {} = emptyNodeComments
 
 instance CommentExtraction OverlapMode where
-  nodeComments NoOverlap {}    = emptyNodeComments
+  nodeComments NoOverlap {} = emptyNodeComments
   nodeComments Overlappable {} = emptyNodeComments
-  nodeComments Overlapping {}  = emptyNodeComments
-  nodeComments Overlaps {}     = emptyNodeComments
-  nodeComments Incoherent {}   = emptyNodeComments
+  nodeComments Overlapping {} = emptyNodeComments
+  nodeComments Overlaps {} = emptyNodeComments
+  nodeComments Incoherent {} = emptyNodeComments
 
 instance CommentExtraction StringLiteral where
   nodeComments StringLiteral {} = emptyNodeComments
@@ -572,25 +572,25 @@ instance CommentExtraction (FamilyDecl GhcPs) where
   nodeComments FamilyDecl {..} = nodeComments fdExt
 
 instance CommentExtraction (FamilyResultSig GhcPs) where
-  nodeComments NoSig {}    = emptyNodeComments
-  nodeComments KindSig {}  = emptyNodeComments
+  nodeComments NoSig {} = emptyNodeComments
+  nodeComments KindSig {} = emptyNodeComments
   nodeComments TyVarSig {} = emptyNodeComments
 
 instance CommentExtraction (HsTyVarBndr a GhcPs) where
-  nodeComments (UserTyVar x _ _)     = nodeComments x
+  nodeComments (UserTyVar x _ _) = nodeComments x
   nodeComments (KindedTyVar x _ _ _) = nodeComments x
 
 instance CommentExtraction (InjectivityAnn GhcPs) where
   nodeComments (InjectivityAnn x _ _) = nodeComments x
 
 instance CommentExtraction (ArithSeqInfo GhcPs) where
-  nodeComments From {}       = emptyNodeComments
-  nodeComments FromThen {}   = emptyNodeComments
-  nodeComments FromTo {}     = emptyNodeComments
+  nodeComments From {} = emptyNodeComments
+  nodeComments FromThen {} = emptyNodeComments
+  nodeComments FromTo {} = emptyNodeComments
   nodeComments FromThenTo {} = emptyNodeComments
 
 instance CommentExtraction (HsForAllTelescope GhcPs) where
-  nodeComments HsForAllVis {..}   = nodeComments hsf_xvis
+  nodeComments HsForAllVis {..} = nodeComments hsf_xvis
   nodeComments HsForAllInvis {..} = nodeComments hsf_xinvis
 
 instance CommentExtraction InfixOp where
@@ -623,24 +623,24 @@ instance CommentExtraction ModuleNameWithPrefix where
   nodeComments ModuleNameWithPrefix {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance CommentExtraction (IE GhcPs) where
-  nodeComments IEVar {}                    = emptyNodeComments
-  nodeComments (IEThingAbs (_, x) _)       = nodeComments x
-  nodeComments (IEThingAll (_, x) _)       = nodeComments x
-  nodeComments (IEThingWith (_, x) _ _ _)  = nodeComments x
+  nodeComments IEVar {} = emptyNodeComments
+  nodeComments (IEThingAbs (_, x) _) = nodeComments x
+  nodeComments (IEThingAll (_, x) _) = nodeComments x
+  nodeComments (IEThingWith (_, x) _ _ _) = nodeComments x
   nodeComments (IEModuleContents (_, x) _) = nodeComments x
-  nodeComments IEGroup {}                  = emptyNodeComments
-  nodeComments IEDoc {}                    = emptyNodeComments
-  nodeComments IEDocNamed {}               = emptyNodeComments
+  nodeComments IEGroup {} = emptyNodeComments
+  nodeComments IEDoc {} = emptyNodeComments
+  nodeComments IEDocNamed {} = emptyNodeComments
 #else
 instance CommentExtraction (IE GhcPs) where
-  nodeComments IEVar {}               = emptyNodeComments
-  nodeComments (IEThingAbs x _)       = nodeComments x
-  nodeComments (IEThingAll x _)       = nodeComments x
-  nodeComments (IEThingWith x _ _ _)  = nodeComments x
+  nodeComments IEVar {} = emptyNodeComments
+  nodeComments (IEThingAbs x _) = nodeComments x
+  nodeComments (IEThingAll x _) = nodeComments x
+  nodeComments (IEThingWith x _ _ _) = nodeComments x
   nodeComments (IEModuleContents x _) = nodeComments x
-  nodeComments IEGroup {}             = emptyNodeComments
-  nodeComments IEDoc {}               = emptyNodeComments
-  nodeComments IEDocNamed {}          = emptyNodeComments
+  nodeComments IEGroup {} = emptyNodeComments
+  nodeComments IEDoc {} = emptyNodeComments
+  nodeComments IEDocNamed {} = emptyNodeComments
 #endif
 instance CommentExtraction
            (FamEqn GhcPs (GenLocated SrcSpanAnnA (HsType GhcPs))) where
@@ -659,26 +659,26 @@ instance CommentExtraction
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  nodeComments HsValArg {}  = emptyNodeComments
+  nodeComments HsValArg {} = emptyNodeComments
   nodeComments HsTypeArg {} = emptyNodeComments
-  nodeComments HsArgPar {}  = emptyNodeComments
+  nodeComments HsArgPar {} = emptyNodeComments
 #else
 instance CommentExtraction
            (HsArg
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  nodeComments HsValArg {}  = emptyNodeComments
+  nodeComments HsValArg {} = emptyNodeComments
   nodeComments HsTypeArg {} = emptyNodeComments
-  nodeComments HsArgPar {}  = emptyNodeComments
+  nodeComments HsArgPar {} = emptyNodeComments
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (HsQuote GhcPs) where
-  nodeComments ExpBr {}  = emptyNodeComments
-  nodeComments PatBr {}  = emptyNodeComments
+  nodeComments ExpBr {} = emptyNodeComments
+  nodeComments PatBr {} = emptyNodeComments
   nodeComments DecBrL {} = emptyNodeComments
   nodeComments DecBrG {} = emptyNodeComments
-  nodeComments TypBr {}  = emptyNodeComments
-  nodeComments VarBr {}  = emptyNodeComments
+  nodeComments TypBr {} = emptyNodeComments
+  nodeComments VarBr {} = emptyNodeComments
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -696,15 +696,15 @@ instance CommentExtraction (WithHsDocIdentifiers StringLiteral GhcPs) where
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (IEWrappedName GhcPs) where
-  nodeComments IEName {}    = emptyNodeComments
+  nodeComments IEName {} = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
-  nodeComments IEType {}    = emptyNodeComments
+  nodeComments IEType {} = emptyNodeComments
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance CommentExtraction (IEWrappedName RdrName) where
-  nodeComments IEName {}    = emptyNodeComments
+  nodeComments IEName {} = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
-  nodeComments IEType {}    = emptyNodeComments
+  nodeComments IEType {} = emptyNodeComments
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (DotFieldOcc GhcPs) where
@@ -773,9 +773,9 @@ instance CommentExtraction CExportSpec where
   nodeComments CExportStatic {} = emptyNodeComments
 
 instance CommentExtraction Safety where
-  nodeComments PlaySafe          = emptyNodeComments
+  nodeComments PlaySafe = emptyNodeComments
   nodeComments PlayInterruptible = emptyNodeComments
-  nodeComments PlayRisky         = emptyNodeComments
+  nodeComments PlayRisky = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (AnnDecl GhcPs) where
   nodeComments (HsAnnotation (x, _) _ _) = nodeComments x
@@ -787,9 +787,9 @@ instance CommentExtraction (RoleAnnotDecl GhcPs) where
   nodeComments (RoleAnnotDecl x _ _) = nodeComments x
 
 instance CommentExtraction Role where
-  nodeComments Nominal          = emptyNodeComments
+  nodeComments Nominal = emptyNodeComments
   nodeComments Representational = emptyNodeComments
-  nodeComments Phantom          = emptyNodeComments
+  nodeComments Phantom = emptyNodeComments
 
 instance CommentExtraction (TyFamInstDecl GhcPs) where
   nodeComments TyFamInstDecl {..} = nodeComments tfid_xtn
@@ -813,8 +813,8 @@ instance CommentExtraction
               (GenLocated SrcSpanAnnN RdrName)
               [RecordPatSynField GhcPs]) where
   nodeComments PrefixCon {} = emptyNodeComments
-  nodeComments RecCon {}    = emptyNodeComments
-  nodeComments InfixCon {}  = emptyNodeComments
+  nodeComments RecCon {} = emptyNodeComments
+  nodeComments InfixCon {} = emptyNodeComments
 
 instance CommentExtraction (FixitySig GhcPs) where
   nodeComments FixitySig {} = emptyNodeComments
@@ -834,25 +834,25 @@ instance CommentExtraction InlineSpec where
   nodeComments = nodeCommentsInlineSpec
 
 nodeCommentsInlineSpec :: InlineSpec -> NodeComments
-nodeCommentsInlineSpec Inline {}           = emptyNodeComments
-nodeCommentsInlineSpec Inlinable {}        = emptyNodeComments
-nodeCommentsInlineSpec NoInline {}         = emptyNodeComments
+nodeCommentsInlineSpec Inline {} = emptyNodeComments
+nodeCommentsInlineSpec Inlinable {} = emptyNodeComments
+nodeCommentsInlineSpec NoInline {} = emptyNodeComments
 nodeCommentsInlineSpec NoUserInlinePrag {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsInlineSpec Opaque {}           = emptyNodeComments
+nodeCommentsInlineSpec Opaque {} = emptyNodeComments
 #endif
 instance CommentExtraction (HsPatSynDir GhcPs) where
-  nodeComments Unidirectional           = emptyNodeComments
-  nodeComments ImplicitBidirectional    = emptyNodeComments
+  nodeComments Unidirectional = emptyNodeComments
+  nodeComments ImplicitBidirectional = emptyNodeComments
   nodeComments ExplicitBidirectional {} = emptyNodeComments
 
 instance CommentExtraction (HsOverLit GhcPs) where
   nodeComments OverLit {} = emptyNodeComments
 
 instance CommentExtraction OverLitVal where
-  nodeComments HsIntegral {}   = emptyNodeComments
+  nodeComments HsIntegral {} = emptyNodeComments
   nodeComments HsFractional {} = emptyNodeComments
-  nodeComments HsIsString {}   = emptyNodeComments
+  nodeComments HsIsString {} = emptyNodeComments
 
 instance CommentExtraction IntegralLit where
   nodeComments IL {} = emptyNodeComments
@@ -861,18 +861,18 @@ instance CommentExtraction FractionalLit where
   nodeComments FL {} = emptyNodeComments
 
 instance CommentExtraction (HsLit GhcPs) where
-  nodeComments HsChar {}       = emptyNodeComments
-  nodeComments HsCharPrim {}   = emptyNodeComments
-  nodeComments HsString {}     = emptyNodeComments
+  nodeComments HsChar {} = emptyNodeComments
+  nodeComments HsCharPrim {} = emptyNodeComments
+  nodeComments HsString {} = emptyNodeComments
   nodeComments HsStringPrim {} = emptyNodeComments
-  nodeComments HsInt {}        = emptyNodeComments
-  nodeComments HsIntPrim {}    = emptyNodeComments
-  nodeComments HsWordPrim {}   = emptyNodeComments
-  nodeComments HsInt64Prim {}  = emptyNodeComments
+  nodeComments HsInt {} = emptyNodeComments
+  nodeComments HsIntPrim {} = emptyNodeComments
+  nodeComments HsWordPrim {} = emptyNodeComments
+  nodeComments HsInt64Prim {} = emptyNodeComments
   nodeComments HsWord64Prim {} = emptyNodeComments
-  nodeComments HsInteger {}    = emptyNodeComments
-  nodeComments HsRat {}        = emptyNodeComments
-  nodeComments HsFloatPrim {}  = emptyNodeComments
+  nodeComments HsInteger {} = emptyNodeComments
+  nodeComments HsRat {} = emptyNodeComments
+  nodeComments HsFloatPrim {} = emptyNodeComments
   nodeComments HsDoublePrim {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsPragE GhcPs) where
@@ -885,13 +885,13 @@ instance CommentExtraction HsIPName where
   nodeComments HsIPName {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsTyLit GhcPs) where
-  nodeComments HsNumTy {}  = emptyNodeComments
-  nodeComments HsStrTy {}  = emptyNodeComments
+  nodeComments HsNumTy {} = emptyNodeComments
+  nodeComments HsStrTy {} = emptyNodeComments
   nodeComments HsCharTy {} = emptyNodeComments
 #else
 instance CommentExtraction HsTyLit where
-  nodeComments HsNumTy {}  = emptyNodeComments
-  nodeComments HsStrTy {}  = emptyNodeComments
+  nodeComments HsNumTy {} = emptyNodeComments
+  nodeComments HsStrTy {} = emptyNodeComments
   nodeComments HsCharTy {} = emptyNodeComments
 #endif
 instance CommentExtraction (HsPatSigType GhcPs) where
@@ -904,10 +904,10 @@ instance CommentExtraction (IPBind GhcPs) where
   nodeComments (IPBind x _ _) = nodeComments x
 
 instance CommentExtraction (DerivStrategy GhcPs) where
-  nodeComments (StockStrategy x)    = nodeComments x
+  nodeComments (StockStrategy x) = nodeComments x
   nodeComments (AnyclassStrategy x) = nodeComments x
-  nodeComments (NewtypeStrategy x)  = nodeComments x
-  nodeComments (ViaStrategy x)      = nodeComments x
+  nodeComments (NewtypeStrategy x) = nodeComments x
+  nodeComments (ViaStrategy x) = nodeComments x
 
 instance CommentExtraction XViaStrategyPs where
   nodeComments (XViaStrategyPs x _) = nodeComments x
@@ -922,28 +922,28 @@ instance CommentExtraction (HsCmd GhcPs) where
   nodeComments = nodeCommentsHsCmd
 
 nodeCommentsHsCmd :: HsCmd GhcPs -> NodeComments
-nodeCommentsHsCmd (HsCmdArrApp x _ _ _ _)  = nodeComments x
+nodeCommentsHsCmd (HsCmdArrApp x _ _ _ _) = nodeComments x
 nodeCommentsHsCmd (HsCmdArrForm x _ _ _ _) = nodeComments x
-nodeCommentsHsCmd (HsCmdApp x _ _)         = nodeComments x
-nodeCommentsHsCmd HsCmdLam {}              = emptyNodeComments
+nodeCommentsHsCmd (HsCmdApp x _ _) = nodeComments x
+nodeCommentsHsCmd HsCmdLam {} = emptyNodeComments
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsCmd (HsCmdPar x _ _ _)       = nodeComments x
+nodeCommentsHsCmd (HsCmdPar x _ _ _) = nodeComments x
 #else
-nodeCommentsHsCmd (HsCmdPar x _)           = nodeComments x
+nodeCommentsHsCmd (HsCmdPar x _) = nodeComments x
 #endif
-nodeCommentsHsCmd (HsCmdCase x _ _)        = nodeComments x
+nodeCommentsHsCmd (HsCmdCase x _ _) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsCmd (HsCmdLamCase x _ _)     = nodeComments x
+nodeCommentsHsCmd (HsCmdLamCase x _ _) = nodeComments x
 #else
-nodeCommentsHsCmd (HsCmdLamCase x _)       = nodeComments x
+nodeCommentsHsCmd (HsCmdLamCase x _) = nodeComments x
 #endif
-nodeCommentsHsCmd (HsCmdIf x _ _ _ _)      = nodeComments x
+nodeCommentsHsCmd (HsCmdIf x _ _ _ _) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-nodeCommentsHsCmd (HsCmdLet x _ _ _ _)     = nodeComments x
+nodeCommentsHsCmd (HsCmdLet x _ _ _ _) = nodeComments x
 #else
-nodeCommentsHsCmd (HsCmdLet x _ _)         = nodeComments x
+nodeCommentsHsCmd (HsCmdLet x _ _) = nodeComments x
 #endif
-nodeCommentsHsCmd (HsCmdDo x _)            = nodeComments x
+nodeCommentsHsCmd (HsCmdDo x _) = nodeComments x
 
 instance CommentExtraction ListComprehension where
   nodeComments ListComprehension {} = emptyNodeComments
@@ -955,7 +955,7 @@ instance CommentExtraction LetIn where
   nodeComments LetIn {} = emptyNodeComments
 
 instance CommentExtraction (RuleBndr GhcPs) where
-  nodeComments (RuleBndr x _)      = nodeComments x
+  nodeComments (RuleBndr x _) = nodeComments x
   nodeComments (RuleBndrSig x _ _) = nodeComments x
 
 instance CommentExtraction CCallConv where
@@ -965,17 +965,17 @@ instance CommentExtraction HsSrcBang where
   nodeComments HsSrcBang {} = emptyNodeComments
 
 instance CommentExtraction SrcUnpackedness where
-  nodeComments SrcUnpack   = emptyNodeComments
+  nodeComments SrcUnpack = emptyNodeComments
   nodeComments SrcNoUnpack = emptyNodeComments
   nodeComments NoSrcUnpack = emptyNodeComments
 
 instance CommentExtraction SrcStrictness where
-  nodeComments SrcLazy     = emptyNodeComments
-  nodeComments SrcStrict   = emptyNodeComments
+  nodeComments SrcLazy = emptyNodeComments
+  nodeComments SrcStrict = emptyNodeComments
   nodeComments NoSrcStrict = emptyNodeComments
 
 instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
-  nodeComments HsOuterImplicit {}   = emptyNodeComments
+  nodeComments HsOuterImplicit {} = emptyNodeComments
   nodeComments HsOuterExplicit {..} = nodeComments hso_xexplicit
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction FieldLabelString where
@@ -983,12 +983,12 @@ instance CommentExtraction FieldLabelString where
 
 instance CommentExtraction (HsUntypedSplice GhcPs) where
   nodeComments (HsUntypedSpliceExpr x _) = nodeComments x
-  nodeComments HsQuasiQuote {}           = emptyNodeComments
+  nodeComments HsQuasiQuote {} = emptyNodeComments
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance CommentExtraction (LHsRecUpdFields GhcPs) where
-  nodeComments RegularRecUpdFields {}    = emptyNodeComments
+  nodeComments RegularRecUpdFields {} = emptyNodeComments
   nodeComments OverloadedRecUpdFields {} = emptyNodeComments
 #endif
 -- | Marks an AST node as never appearing in the AST.

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 -- | Types to pretty-print certain parts of Haskell codes.
@@ -53,10 +53,10 @@ module HIndent.Pretty.Types
   , DataFamInstDeclFor(..)
   ) where
 
-import           GHC.Hs
-import           GHC.Types.Name.Reader
+import GHC.Hs
+import GHC.Types.Name.Reader
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import           GHC.Unit
+import GHC.Unit
 #endif
 -- | `LHsExpr` used as a infix operator
 newtype InfixExpr =
@@ -83,7 +83,7 @@ newtype PrefixOp =
 -- is not a valid Haskell code.
 data InfixApp = InfixApp
   { lhs :: LHsExpr GhcPs
-  , op  :: LHsExpr GhcPs
+  , op :: LHsExpr GhcPs
   , rhs :: LHsExpr GhcPs
   }
 
@@ -91,13 +91,13 @@ data InfixApp = InfixApp
 -- in.
 data GRHSsExpr = GRHSsExpr
   { grhssExprType :: GRHSExprType
-  , grhssExpr     :: GRHSs GhcPs (LHsExpr GhcPs)
+  , grhssExpr :: GRHSs GhcPs (LHsExpr GhcPs)
   }
 
 -- | 'GRHS' for a normal binding.
 data GRHSExpr = GRHSExpr
   { grhsExprType :: GRHSExprType
-  , grhsExpr     :: GRHS GhcPs (LHsExpr GhcPs)
+  , grhsExpr :: GRHS GhcPs (LHsExpr GhcPs)
   }
 
 -- | 'GRHS' for a @proc@ binding.
@@ -121,7 +121,7 @@ data HsSigType' = HsSigType'
   { hsSigTypeFor :: HsTypeFor -- ^ In which context a `HsSigType` is located in.
   , hsSigTypeDir :: HsTypeDir -- ^ How a `HsSigType` should be printed;
                                 -- either horizontally or vertically.
-  , hsSigType    :: HsSigType GhcPs -- ^ The actual signature.
+  , hsSigType :: HsSigType GhcPs -- ^ The actual signature.
   }
 
 -- | `HsSigType'` for instance declarations.
@@ -141,7 +141,7 @@ data HsType' = HsType'
   { hsTypeFor :: HsTypeFor -- ^ In which context a `HsType` is located in.
   , hsTypeDir :: HsTypeDir -- ^ How a function signature is printed;
                            -- either horizontally or vertically.
-  , hsType    :: HsType GhcPs -- ^ The actual type.
+  , hsType :: HsType GhcPs -- ^ The actual type.
   }
 
 -- | `HsType'` inside a function signature declaration; printed horizontally.
@@ -163,7 +163,7 @@ pattern HsTypeWithVerticalAppTy x = HsType' HsTypeForVerticalAppTy HsTypeVertica
 -- | A wrapper of `DataFamInstDecl`.
 data DataFamInstDecl' = DataFamInstDecl'
   { dataFamInstDeclFor :: DataFamInstDeclFor -- ^ Where a data family instance is declared.
-  , dataFamInstDecl    :: DataFamInstDecl GhcPs -- ^ The actual value.
+  , dataFamInstDecl :: DataFamInstDecl GhcPs -- ^ The actual value.
   }
 
 -- | `DataFamInstDecl'` wrapping a `DataFamInstDecl` representing
@@ -179,7 +179,7 @@ pattern DataFamInstDeclInsideClassInst x = DataFamInstDecl' DataFamInstDeclForIn
 -- | A wrapper for `FamEqn`.
 data FamEqn' = FamEqn'
   { famEqnFor :: DataFamInstDeclFor -- ^ Where a data family instance is declared.
-  , famEqn    :: FamEqn GhcPs (HsDataDefn GhcPs)
+  , famEqn :: FamEqn GhcPs (HsDataDefn GhcPs)
   }
 
 -- | `FamEqn'` wrapping a `FamEqn` representing a top-level data family
@@ -250,7 +250,7 @@ newtype PatInsidePatDecl =
 -- | Lambda case.
 data LambdaCase = LambdaCase
   { lamCaseGroup :: MatchGroup GhcPs (LHsExpr GhcPs)
-  , caseOrCases  :: CaseOrCases
+  , caseOrCases :: CaseOrCases
   }
 
 -- | Use this type to pretty-print a list comprehension.
@@ -261,14 +261,14 @@ data ListComprehension = ListComprehension
 
 -- | Use this type to pretty-print a do expression.
 data DoExpression = DoExpression
-  { doStmts     :: [ExprLStmt GhcPs]
+  { doStmts :: [ExprLStmt GhcPs]
   , qualifiedDo :: QualifiedDo
   }
 
 -- | Use this type to pretty-print a @let ... in ...@ expression.
 data LetIn = LetIn
   { letBinds :: HsLocalBinds GhcPs
-  , inExpr   :: LHsExpr GhcPs
+  , inExpr :: LHsExpr GhcPs
   }
 
 -- | Values indicating whether `do` or `mdo` is used.

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 -- | Types to pretty-print certain parts of Haskell codes.
@@ -40,7 +40,6 @@ module HIndent.Pretty.Types
   , ModuleNameWithPrefix(..)
   , PatInsidePatDecl(..)
   , LambdaCase(..)
-  , ModuleDeprecatedPragma(..)
   , ListComprehension(..)
   , DoExpression(..)
   , DoOrMdo(..)
@@ -54,11 +53,10 @@ module HIndent.Pretty.Types
   , DataFamInstDeclFor(..)
   ) where
 
-import GHC.Hs
-import GHC.Types.Name.Reader
-import GHC.Unit.Module.Warnings
+import           GHC.Hs
+import           GHC.Types.Name.Reader
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import GHC.Unit
+import           GHC.Unit
 #endif
 -- | `LHsExpr` used as a infix operator
 newtype InfixExpr =
@@ -85,7 +83,7 @@ newtype PrefixOp =
 -- is not a valid Haskell code.
 data InfixApp = InfixApp
   { lhs :: LHsExpr GhcPs
-  , op :: LHsExpr GhcPs
+  , op  :: LHsExpr GhcPs
   , rhs :: LHsExpr GhcPs
   }
 
@@ -93,13 +91,13 @@ data InfixApp = InfixApp
 -- in.
 data GRHSsExpr = GRHSsExpr
   { grhssExprType :: GRHSExprType
-  , grhssExpr :: GRHSs GhcPs (LHsExpr GhcPs)
+  , grhssExpr     :: GRHSs GhcPs (LHsExpr GhcPs)
   }
 
 -- | 'GRHS' for a normal binding.
 data GRHSExpr = GRHSExpr
   { grhsExprType :: GRHSExprType
-  , grhsExpr :: GRHS GhcPs (LHsExpr GhcPs)
+  , grhsExpr     :: GRHS GhcPs (LHsExpr GhcPs)
   }
 
 -- | 'GRHS' for a @proc@ binding.
@@ -123,7 +121,7 @@ data HsSigType' = HsSigType'
   { hsSigTypeFor :: HsTypeFor -- ^ In which context a `HsSigType` is located in.
   , hsSigTypeDir :: HsTypeDir -- ^ How a `HsSigType` should be printed;
                                 -- either horizontally or vertically.
-  , hsSigType :: HsSigType GhcPs -- ^ The actual signature.
+  , hsSigType    :: HsSigType GhcPs -- ^ The actual signature.
   }
 
 -- | `HsSigType'` for instance declarations.
@@ -143,7 +141,7 @@ data HsType' = HsType'
   { hsTypeFor :: HsTypeFor -- ^ In which context a `HsType` is located in.
   , hsTypeDir :: HsTypeDir -- ^ How a function signature is printed;
                            -- either horizontally or vertically.
-  , hsType :: HsType GhcPs -- ^ The actual type.
+  , hsType    :: HsType GhcPs -- ^ The actual type.
   }
 
 -- | `HsType'` inside a function signature declaration; printed horizontally.
@@ -165,7 +163,7 @@ pattern HsTypeWithVerticalAppTy x = HsType' HsTypeForVerticalAppTy HsTypeVertica
 -- | A wrapper of `DataFamInstDecl`.
 data DataFamInstDecl' = DataFamInstDecl'
   { dataFamInstDeclFor :: DataFamInstDeclFor -- ^ Where a data family instance is declared.
-  , dataFamInstDecl :: DataFamInstDecl GhcPs -- ^ The actual value.
+  , dataFamInstDecl    :: DataFamInstDecl GhcPs -- ^ The actual value.
   }
 
 -- | `DataFamInstDecl'` wrapping a `DataFamInstDecl` representing
@@ -181,7 +179,7 @@ pattern DataFamInstDeclInsideClassInst x = DataFamInstDecl' DataFamInstDeclForIn
 -- | A wrapper for `FamEqn`.
 data FamEqn' = FamEqn'
   { famEqnFor :: DataFamInstDeclFor -- ^ Where a data family instance is declared.
-  , famEqn :: FamEqn GhcPs (HsDataDefn GhcPs)
+  , famEqn    :: FamEqn GhcPs (HsDataDefn GhcPs)
   }
 
 -- | `FamEqn'` wrapping a `FamEqn` representing a top-level data family
@@ -252,17 +250,9 @@ newtype PatInsidePatDecl =
 -- | Lambda case.
 data LambdaCase = LambdaCase
   { lamCaseGroup :: MatchGroup GhcPs (LHsExpr GhcPs)
-  , caseOrCases :: CaseOrCases
+  , caseOrCases  :: CaseOrCases
   }
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
--- | A deprecation pragma for a module.
-newtype ModuleDeprecatedPragma =
-  ModuleDeprecatedPragma (WarningTxt GhcPs)
-#else
--- | A deprecation pragma for a module.
-newtype ModuleDeprecatedPragma =
-  ModuleDeprecatedPragma WarningTxt
-#endif
+
 -- | Use this type to pretty-print a list comprehension.
 data ListComprehension = ListComprehension
   { listCompLhs :: ExprLStmt GhcPs -- ^ @f x@ of @[f x| x <- xs]@.
@@ -271,14 +261,14 @@ data ListComprehension = ListComprehension
 
 -- | Use this type to pretty-print a do expression.
 data DoExpression = DoExpression
-  { doStmts :: [ExprLStmt GhcPs]
+  { doStmts     :: [ExprLStmt GhcPs]
   , qualifiedDo :: QualifiedDo
   }
 
 -- | Use this type to pretty-print a @let ... in ...@ expression.
 data LetIn = LetIn
   { letBinds :: HsLocalBinds GhcPs
-  , inExpr :: LHsExpr GhcPs
+  , inExpr   :: LHsExpr GhcPs
   }
 
 -- | Values indicating whether `do` or `mdo` is used.


### PR DESCRIPTION
### Description of the PR

Defines `ModuleWarning` in replacement for `WarningTxt`. Related to #819

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
