### PR TITLE
Qualify identifiers of imports from GHC's API as GHC

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -35,7 +35,7 @@ import qualified GHC.Types.Basic                             as GHC
 import qualified GHC.Types.Fixity                            as GHC
 import qualified GHC.Types.ForeignCall                       as GHC
 import           GHC.Types.Name
-import           GHC.Types.Name.Reader
+import qualified GHC.Types.Name.Reader                       as GHC
 import           GHC.Types.SourceText
 import           GHC.Types.SrcLoc
 import           GHC.Unit.Module.Warnings
@@ -1342,7 +1342,7 @@ instance Pretty ParStmtBlockInsideVerticalList where
   pretty' (ParStmtBlockInsideVerticalList (GHC.ParStmtBlock _ xs _ _)) =
     vCommaSep $ fmap pretty xs
 
-instance Pretty GHC.Types.Name.Reader.RdrName where
+instance Pretty GHC.RdrName where
   pretty' = pretty . PrefixOp
 
 instance Pretty
@@ -1827,30 +1827,26 @@ instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
     dot
 
 instance Pretty InfixOp where
-  pretty' (InfixOp (GHC.Types.Name.Reader.Unqual name)) =
-    backticksIfNotSymbol name $ pretty name
-  pretty' (InfixOp (GHC.Types.Name.Reader.Qual modName name)) =
+  pretty' (InfixOp (GHC.Unqual name)) = backticksIfNotSymbol name $ pretty name
+  pretty' (InfixOp (GHC.Qual modName name)) =
     backticksIfNotSymbol name $ do
       pretty modName
       string "."
       pretty name
-  pretty' (InfixOp GHC.Types.Name.Reader.Orig {}) = notUsedInParsedStage
-  pretty' (InfixOp (GHC.Types.Name.Reader.Exact name)) =
-    backticksIfNotSymbol occ $ pretty occ
+  pretty' (InfixOp GHC.Orig {}) = notUsedInParsedStage
+  pretty' (InfixOp (GHC.Exact name)) = backticksIfNotSymbol occ $ pretty occ
     where
       occ = GHC.Types.Name.occName name
 
 instance Pretty PrefixOp where
-  pretty' (PrefixOp (GHC.Types.Name.Reader.Unqual name)) =
-    parensIfSymbol name $ pretty name
-  pretty' (PrefixOp (GHC.Types.Name.Reader.Qual modName name)) =
+  pretty' (PrefixOp (GHC.Unqual name)) = parensIfSymbol name $ pretty name
+  pretty' (PrefixOp (GHC.Qual modName name)) =
     parensIfSymbol name $ do
       pretty modName
       string "."
       pretty name
-  pretty' (PrefixOp GHC.Types.Name.Reader.Orig {}) = notUsedInParsedStage
-  pretty' (PrefixOp (GHC.Types.Name.Reader.Exact name)) =
-    parensIfSymbol occ $ output name
+  pretty' (PrefixOp GHC.Orig {}) = notUsedInParsedStage
+  pretty' (PrefixOp (GHC.Exact name)) = parensIfSymbol occ $ output name
     where
       occ = GHC.Types.Name.occName name
 
@@ -2027,7 +2023,7 @@ instance Pretty (IEWrappedName GhcPs) where
   pretty' (IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
-instance Pretty (GHC.IEWrappedName GHC.Types.Name.Reader.RdrName) where
+instance Pretty (GHC.IEWrappedName GHC.RdrName) where
   pretty' (GHC.IEName name)      = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
   pretty' (GHC.IEType _ name)    = string "type " >> pretty name
@@ -2243,7 +2239,7 @@ instance Pretty (GHC.PatSynBind GHC.GhcPs GHC.GhcPs) where
 instance Pretty
            (GHC.HsConDetails
               Void
-              (GenLocated GHC.SrcSpanAnnN GHC.Types.Name.Reader.RdrName)
+              (GenLocated GHC.SrcSpanAnnN GHC.RdrName)
               [GHC.RecordPatSynField GHC.GhcPs]) where
   pretty' (GHC.PrefixCon _ xs) = spaced $ fmap pretty xs
   pretty' (GHC.RecCon rec) = hFields $ fmap pretty rec

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -26,7 +26,6 @@ import           Control.Monad.RWS
 import           Data.Maybe
 import           Data.Void
 import           GHC.Core.Coercion
-import           GHC.Core.InstEnv
 import           GHC.Data.Bag
 import           GHC.Data.BooleanFormula
 import           GHC.Data.FastString
@@ -1214,8 +1213,9 @@ prettyHsType GHC.HsQualTy {..} = hor <-|> ver
     ver = do
       pretty $ Context hst_ctxt
       lined [string " =>", indentedBlock $ pretty hst_body]
-prettyHsType (GHC.HsTyVar _ NotPromoted x) = pretty x
-prettyHsType (GHC.HsTyVar _ IsPromoted x) = string "'" >> pretty x
+prettyHsType (GHC.HsTyVar _ GHC.Types.Basic.NotPromoted x) = pretty x
+prettyHsType (GHC.HsTyVar _ GHC.Types.Basic.IsPromoted x) =
+  string "'" >> pretty x
 prettyHsType x@(GHC.HsAppTy _ l r) = hor <-|> ver
   where
     hor = spaced $ fmap pretty [l, r]
@@ -1481,8 +1481,10 @@ prettyPat (GHC.ParPat _ inner) = parens $ pretty inner
 #endif
 prettyPat (GHC.BangPat _ x) = string "!" >> pretty x
 prettyPat (GHC.ListPat _ xs) = hList $ fmap pretty xs
-prettyPat (GHC.TuplePat _ pats Boxed) = hTuple $ fmap pretty pats
-prettyPat (GHC.TuplePat _ pats Unboxed) = hUnboxedTuple $ fmap pretty pats
+prettyPat (GHC.TuplePat _ pats GHC.Types.Basic.Boxed) =
+  hTuple $ fmap pretty pats
+prettyPat (GHC.TuplePat _ pats GHC.Types.Basic.Unboxed) =
+  hUnboxedTuple $ fmap pretty pats
 prettyPat (GHC.SumPat _ x position numElem) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -1752,12 +1754,12 @@ instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
   pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
   pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
-instance Pretty OverlapMode where
-  pretty' NoOverlap {}    = notUsedInParsedStage
-  pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
+instance Pretty GHC.Types.Basic.OverlapMode where
+  pretty' GHC.Types.Basic.NoOverlap {}    = notUsedInParsedStage
+  pretty' GHC.Types.Basic.Overlappable {} = string "{-# OVERLAPPABLE #-}"
+  pretty' GHC.Types.Basic.Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' GHC.Types.Basic.Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' GHC.Types.Basic.Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1771,8 +1773,8 @@ instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
         GHC.OpenTypeFamily      -> "type"
         GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel    -> string " family "
-      NotTopLevel -> space
+      GHC.Types.Basic.TopLevel    -> string " family "
+      GHC.Types.Basic.NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
     case unLoc fdResultSig of
@@ -2260,22 +2262,23 @@ instance Pretty FixityDirection where
   pretty' InfixR = string "infixr"
   pretty' InfixN = string "infix"
 
-instance Pretty InlinePragma where
-  pretty' InlinePragma {..} = do
+instance Pretty GHC.Types.Basic.InlinePragma where
+  pretty' GHC.Types.Basic.InlinePragma {..} = do
     pretty inl_inline
     case inl_act of
-      ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                -> pure ()
+      GHC.Types.Basic.ActiveBefore _ x ->
+        space >> brackets (string $ "~" ++ show x)
+      GHC.Types.Basic.ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
-instance Pretty InlineSpec where
+instance Pretty GHC.Types.Basic.InlineSpec where
   pretty' = prettyInlineSpec
 
-prettyInlineSpec :: InlineSpec -> Printer ()
-prettyInlineSpec Inline {} = string "INLINE"
-prettyInlineSpec Inlinable {} = string "INLINABLE"
-prettyInlineSpec NoInline {} = string "NOINLINE"
-prettyInlineSpec NoUserInlinePrag =
+prettyInlineSpec :: GHC.Types.Basic.InlineSpec -> Printer ()
+prettyInlineSpec GHC.Types.Basic.Inline {} = string "INLINE"
+prettyInlineSpec GHC.Types.Basic.Inlinable {} = string "INLINABLE"
+prettyInlineSpec GHC.Types.Basic.NoInline {} = string "NOINLINE"
+prettyInlineSpec GHC.Types.Basic.NoUserInlinePrag =
   error
     "This branch is executed if the inline pragma is not written, but executing this branch means that the pragma is already about to be output, which indicates something goes wrong."
 #if MIN_VERSION_ghc_lib_parser(9,4,1)

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1728,11 +1728,11 @@ instance Pretty InfixApp where
       isSameAssoc (findFixity -> GHC.Fixity _ lv d) = lv == level && d == dir
       GHC.Fixity _ level dir = findFixity op
 
-instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x)    = pretty x
-  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
-  pretty' (Parens x) = parens $ pretty x
+instance Pretty a => Pretty (GHC.Data.BooleanFormula.BooleanFormula a) where
+  pretty' (GHC.Data.BooleanFormula.Var x)    = pretty x
+  pretty' (GHC.Data.BooleanFormula.And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Data.BooleanFormula.Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Data.BooleanFormula.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
   pretty' (GHC.FieldLabelStrings xs) = hDotSep $ fmap pretty xs

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 -- | Pretty printing.
 --
@@ -21,42 +21,42 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import Data.Maybe
-import Data.Void
-import GHC.Core.Coercion
-import GHC.Core.InstEnv
-import GHC.Data.Bag
-import GHC.Data.BooleanFormula
-import GHC.Data.FastString
-import GHC.Hs
-import GHC.Stack
-import GHC.Types.Basic
-import GHC.Types.Fixity
-import GHC.Types.ForeignCall
-import GHC.Types.Name
-import GHC.Types.Name.Reader
-import GHC.Types.SourceText
-import GHC.Types.SrcLoc
-import GHC.Unit.Module.Warnings
-import HIndent.Applicative
-import HIndent.Ast.NodeComments
-import HIndent.Config
-import HIndent.Fixity
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
-import HIndent.Printer
-import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
-import Text.Show.Unicode
+import           Control.Monad
+import           Control.Monad.RWS
+import           Data.Maybe
+import           Data.Void
+import           GHC.Core.Coercion
+import           GHC.Core.InstEnv
+import           GHC.Data.Bag
+import           GHC.Data.BooleanFormula
+import           GHC.Data.FastString
+import qualified GHC.Hs                                      as GHC
+import           GHC.Stack
+import           GHC.Types.Basic
+import           GHC.Types.Fixity
+import           GHC.Types.ForeignCall
+import           GHC.Types.Name
+import           GHC.Types.Name.Reader
+import           GHC.Types.SourceText
+import           GHC.Types.SrcLoc
+import           GHC.Unit.Module.Warnings
+import           HIndent.Applicative
+import           HIndent.Ast.NodeComments
+import           HIndent.Config
+import           HIndent.Fixity
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
+import           HIndent.Printer
+import           Language.Haskell.GhclibParserEx.GHC.Hs.Expr
+import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable as NonEmpty
-import GHC.Core.DataCon
+import qualified Data.Foldable                               as NonEmpty
+import           GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import GHC.Unit
+import           GHC.Unit
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -80,7 +80,7 @@ printCommentsAnd (L l e) f = do
 printCommentsBefore :: CommentExtraction a => a -> Printer ()
 printCommentsBefore p =
   forM_ (commentsBefore $ nodeComments p) $ \(L loc c) -> do
-    let col = fromIntegral $ srcSpanStartCol (anchor loc) - 1
+    let col = fromIntegral $ srcSpanStartCol (GHC.anchor loc) - 1
     indentedWithFixedLevel col $ pretty c
     newline
 
@@ -90,10 +90,8 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
+           (fromIntegral $ srcSpanStartCol $ GHC.anchor $ getLoc c) $
+         spaced $ fmap pretty $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -107,7 +105,7 @@ printCommentsAfter p =
       isThereCommentsOnSameLine <- gets psEolComment
       unless isThereCommentsOnSameLine newline
       forM_ xs $ \(L loc c) -> do
-        let col = fromIntegral $ srcSpanStartCol (anchor loc) - 1
+        let col = fromIntegral $ srcSpanStartCol (GHC.anchor loc) - 1
         indentedWithFixedLevel col $ pretty c
         eolCommentsArePrinted
 
@@ -128,33 +126,34 @@ class CommentExtraction a =>
 instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
-instance Pretty (GHC.Hs.HsDecl GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.TyClD _ d) = pretty d
-  pretty' (GHC.Hs.InstD _ inst) = pretty inst
-  pretty' (GHC.Hs.DerivD _ x) = pretty x
-  pretty' (GHC.Hs.ValD _ bind) = pretty bind
-  pretty' (GHC.Hs.SigD _ s) = pretty s
-  pretty' (GHC.Hs.KindSigD _ x) = pretty x
-  pretty' (GHC.Hs.DefD _ x) = pretty x
-  pretty' (GHC.Hs.ForD _ x) = pretty x
-  pretty' (GHC.Hs.WarningD _ x) = pretty x
-  pretty' (GHC.Hs.AnnD _ x) = pretty x
-  pretty' (GHC.Hs.RuleD _ x) = pretty x
-  pretty' (GHC.Hs.SpliceD _ sp) = pretty sp
-  pretty' GHC.Hs.DocD {} = docNode
-  pretty' (GHC.Hs.RoleAnnotD _ x) = pretty x
+instance Pretty (GHC.HsDecl GHC.GhcPs) where
+  pretty' (GHC.TyClD _ d)      = pretty d
+  pretty' (GHC.InstD _ inst)   = pretty inst
+  pretty' (GHC.DerivD _ x)     = pretty x
+  pretty' (GHC.ValD _ bind)    = pretty bind
+  pretty' (GHC.SigD _ s)       = pretty s
+  pretty' (GHC.KindSigD _ x)   = pretty x
+  pretty' (GHC.DefD _ x)       = pretty x
+  pretty' (GHC.ForD _ x)       = pretty x
+  pretty' (GHC.WarningD _ x)   = pretty x
+  pretty' (GHC.AnnD _ x)       = pretty x
+  pretty' (GHC.RuleD _ x)      = pretty x
+  pretty' (GHC.SpliceD _ sp)   = pretty sp
+  pretty' GHC.DocD {}          = docNode
+  pretty' (GHC.RoleAnnotD _ x) = pretty x
 
-instance Pretty (GHC.Hs.TyClDecl GHC.Hs.GhcPs) where
+instance Pretty (GHC.TyClDecl GHC.GhcPs) where
   pretty' = prettyTyClDecl
 
-prettyTyClDecl :: GHC.Hs.TyClDecl GHC.Hs.GhcPs -> Printer ()
-prettyTyClDecl (GHC.Hs.FamDecl _ x) = pretty x
-prettyTyClDecl GHC.Hs.SynDecl {..} = do
+prettyTyClDecl :: GHC.TyClDecl GHC.GhcPs -> Printer ()
+prettyTyClDecl (GHC.FamDecl _ x) = pretty x
+prettyTyClDecl GHC.SynDecl {..} = do
   string "type "
   case tcdFixity of
-    Prefix -> spaced $ pretty tcdLName : fmap pretty (hsq_explicit tcdTyVars)
+    Prefix ->
+      spaced $ pretty tcdLName : fmap pretty (GHC.hsq_explicit tcdTyVars)
     Infix ->
-      case hsq_explicit tcdTyVars of
+      case GHC.hsq_explicit tcdTyVars of
         (l:r:xs) -> do
           spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
           forM_ xs $ \x -> do
@@ -168,50 +167,50 @@ prettyTyClDecl GHC.Hs.SynDecl {..} = do
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
-    whenJust (dd_ctxt tcdDataDefn) $ \x -> do
+    whenJust (GHC.dd_ctxt tcdDataDefn) $ \x -> do
       pretty $ Context x
       string " =>"
       newline
     pretty tcdLName
-  spacePrefixed $ pretty <$> hsq_explicit tcdTyVars
+  spacePrefixed $ pretty <$> GHC.hsq_explicit tcdTyVars
   pretty tcdDataDefn
   where
     printDataNewtype =
       case dd_cons tcdDataDefn of
         DataTypeCons {} -> string "data "
-        NewTypeCon {} -> string "newtype "
+        NewTypeCon {}   -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
-    whenJust (dd_ctxt tcdDataDefn) $ \x -> do
+    whenJust (GHC.dd_ctxt tcdDataDefn) $ \x -> do
       pretty $ Context x
       string " =>"
       newline
     pretty tcdLName
-  spacePrefixed $ pretty <$> hsq_explicit tcdTyVars
+  spacePrefixed $ pretty <$> GHC.hsq_explicit tcdTyVars
   pretty tcdDataDefn
   where
     printDataNewtype =
-      case dd_ND tcdDataDefn of
+      case GHC.dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #else
-prettyTyClDecl GHC.Hs.DataDecl {..} = do
+prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
-    whenJust (dd_ctxt tcdDataDefn) $ \_ -> do
-      pretty $ Context $ dd_ctxt tcdDataDefn
+    whenJust (GHC.dd_ctxt tcdDataDefn) $ \_ -> do
+      pretty $ Context $ GHC.dd_ctxt tcdDataDefn
       string " =>"
       newline
     pretty tcdLName
-  spacePrefixed $ pretty <$> hsq_explicit tcdTyVars
+  spacePrefixed $ pretty <$> GHC.hsq_explicit tcdTyVars
   pretty tcdDataDefn
   where
     printDataNewtype =
-      case dd_ND tcdDataDefn of
-        GHC.Hs.DataType -> string "data "
-        GHC.Hs.NewType -> string "newtype "
+      case GHC.dd_ND tcdDataDefn of
+        GHC.DataType -> string "data "
+        GHC.NewType  -> string "newtype "
 #endif
-prettyTyClDecl GHC.Hs.ClassDecl {..} = do
+prettyTyClDecl GHC.ClassDecl {..} = do
   if isJust tcdCtxt
     then verHead
     else horHead <-|> verHead
@@ -222,62 +221,61 @@ prettyTyClDecl GHC.Hs.ClassDecl {..} = do
       printNameAndTypeVariables
       unless (null tcdFDs) $ do
         string " | "
-        forM_ tcdFDs $ \x@(L _ GHC.Hs.FunDep {}) ->
-          printCommentsAnd x $ \(GHC.Hs.FunDep _ from to) ->
+        forM_ tcdFDs $ \x@(L _ GHC.FunDep {}) ->
+          printCommentsAnd x $ \(GHC.FunDep _ from to) ->
             spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to
       unless (null sigsMethodsFamilies) $ string " where"
     verHead = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            [] -> string "()"
+            []  -> string "()"
             [x] -> pretty x
-            xs -> hvTuple $ fmap pretty xs
+            xs  -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock
-          $ string "| "
-              |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(L _ GHC.Hs.FunDep {}) ->
-                       printCommentsAnd x $ \(GHC.Hs.FunDep _ from to) ->
-                         spaced
-                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock $
+          string "| " |=>
+          vCommaSep
+            (flip fmap tcdFDs $ \x@(L _ GHC.FunDep {}) ->
+               printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
     printNameAndTypeVariables =
       case tcdFixity of
         Prefix ->
-          spaced $ pretty tcdLName : fmap pretty (hsq_explicit tcdTyVars)
+          spaced $ pretty tcdLName : fmap pretty (GHC.hsq_explicit tcdTyVars)
         Infix ->
-          case hsq_explicit tcdTyVars of
+          case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens
-                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens $
+                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
 
-instance Pretty (GHC.Hs.InstDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.ClsInstD {..} = pretty cid_inst
-  pretty' GHC.Hs.DataFamInstD {..} = pretty dfid_inst
-  pretty' GHC.Hs.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+instance Pretty (GHC.InstDecl GHC.GhcPs) where
+  pretty' GHC.ClsInstD {..}     = pretty cid_inst
+  pretty' GHC.DataFamInstD {..} = pretty dfid_inst
+  pretty' GHC.TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
 
-instance Pretty (GHC.Hs.HsBind GHC.Hs.GhcPs) where
+instance Pretty (GHC.HsBind GHC.GhcPs) where
   pretty' = prettyHsBind
 
-prettyHsBind :: GHC.Hs.HsBind GHC.Hs.GhcPs -> Printer ()
-prettyHsBind GHC.Hs.FunBind {..} = pretty fun_matches
-prettyHsBind GHC.Hs.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind GHC.Hs.VarBind {} = notGeneratedByParser
+prettyHsBind :: GHC.HsBind GHC.GhcPs -> Printer ()
+prettyHsBind GHC.FunBind {..}     = pretty fun_matches
+prettyHsBind GHC.PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.VarBind {}       = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind GHC.Hs.AbsBinds {} = notGeneratedByParser
+prettyHsBind GHC.AbsBinds {}      = notGeneratedByParser
 #endif
-prettyHsBind (GHC.Hs.PatSynBind _ x) = pretty x
+prettyHsBind (GHC.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (Sig GhcPs) where
   pretty' (TypeSig _ funName params) = do
@@ -287,18 +285,18 @@ instance Pretty (Sig GhcPs) where
     where
       horizontal = do
         space
-        pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
+        pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       vertical = do
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
+          then space |=>
+               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -318,9 +316,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -347,38 +345,38 @@ instance Pretty (Sig GhcPs) where
       , string "#-}"
       ]
 #else
-instance Pretty (GHC.Hs.Sig GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.TypeSig _ funName params) = do
+instance Pretty (GHC.Sig GHC.GhcPs) where
+  pretty' (GHC.TypeSig _ funName params) = do
     printFunName
     string " ::"
     horizontal <-|> vertical
     where
       horizontal = do
         space
-        pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
+        pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       vertical = do
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
+          then space |=>
+               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
-  pretty' (GHC.Hs.PatSynSig _ names sig) =
+  pretty' (GHC.PatSynSig _ names sig) =
     spaced
       [string "pattern", hCommaSep $ fmap pretty names, string "::", pretty sig]
-  pretty' (GHC.Hs.ClassOpSig _ True funNames params) =
+  pretty' (GHC.ClassOpSig _ True funNames params) =
     spaced
       [ string "default"
       , hCommaSep $ fmap pretty funNames
       , string "::"
       , printCommentsAnd params pretty
       ]
-  pretty' (GHC.Hs.ClassOpSig _ False funNames params) = do
+  pretty' (GHC.ClassOpSig _ False funNames params) = do
     hCommaSep $ fmap pretty funNames
     string " ::"
     hor <-|> ver
@@ -386,14 +384,14 @@ instance Pretty (GHC.Hs.Sig GHC.Hs.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
-  pretty' GHC.Hs.IdSig {} = notGeneratedByParser
-  pretty' (GHC.Hs.FixSig _ x) = pretty x
-  pretty' (GHC.Hs.InlineSig _ name detail) =
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+  pretty' GHC.IdSig {} = notGeneratedByParser
+  pretty' (GHC.FixSig _ x) = pretty x
+  pretty' (GHC.InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
-  pretty' (GHC.Hs.SpecSig _ name sigs _) =
+  pretty' (GHC.SpecSig _ name sigs _) =
     spaced
       [ string "{-# SPECIALISE"
       , pretty name
@@ -401,15 +399,15 @@ instance Pretty (GHC.Hs.Sig GHC.Hs.GhcPs) where
       , hCommaSep $ fmap pretty sigs
       , string "#-}"
       ]
-  pretty' (GHC.Hs.SpecInstSig _ _ sig) =
+  pretty' (GHC.SpecInstSig _ _ sig) =
     spaced [string "{-# SPECIALISE instance", pretty sig, string "#-}"]
-  pretty' (GHC.Hs.MinimalSig _ _ xs) =
+  pretty' (GHC.MinimalSig _ _ xs) =
     string "{-# MINIMAL " |=> do
       pretty xs
       string " #-}"
-  pretty' (GHC.Hs.SCCFunSig _ _ name _) =
+  pretty' (GHC.SCCFunSig _ _ name _) =
     spaced [string "{-# SCC", pretty name, string "#-}"]
-  pretty' (GHC.Hs.CompleteMatchSig _ _ names _) =
+  pretty' (GHC.CompleteMatchSig _ _ names _) =
     spaced
       [ string "{-# COMPLETE"
       , printCommentsAnd names (hCommaSep . fmap pretty)
@@ -447,18 +445,18 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       cons =
         case dd_cons of
-          NewTypeCon x -> [x]
+          NewTypeCon x      -> [x]
           DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
-          _ -> False
+          _                                       -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
 #else
-instance Pretty (GHC.Hs.HsDataDefn GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsDataDefn {..} =
+instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
+  pretty' GHC.HsDataDefn {..} =
     if isGADT
       then do
         whenJust dd_kindSig $ \x -> do
@@ -469,7 +467,7 @@ instance Pretty (GHC.Hs.HsDataDefn GHC.Hs.GhcPs) where
       else do
         case dd_cons of
           [] -> indentedBlock derivingsAfterNewline
-          [x@(L _ GHC.Hs.ConDeclH98 {con_args = GHC.Hs.RecCon {}})] -> do
+          [x@(L _ GHC.ConDeclH98 {con_args = GHC.RecCon {}})] -> do
             string " = "
             pretty x
             unless (null dd_derivs) $ space |=> printDerivings
@@ -487,20 +485,20 @@ instance Pretty (GHC.Hs.HsDataDefn GHC.Hs.GhcPs) where
     where
       isGADT =
         case dd_cons of
-          (L _ GHC.Hs.ConDeclGADT {}:_) -> True
-          _ -> False
+          (L _ GHC.ConDeclGADT {}:_) -> True
+          _                          -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
 #endif
-instance Pretty (GHC.Hs.ClsInstDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.ClsInstDecl {..} = do
+instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
+  pretty' GHC.ClsInstDecl {..} = do
     string "instance " |=> do
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
+        unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -514,71 +512,68 @@ instance Pretty (GHC.Hs.ClsInstDecl GHC.Hs.GhcPs) where
           cid_datafam_insts
 
 instance Pretty
-           (GHC.Hs.MatchGroup
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
+           (GHC.MatchGroup
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
+  pretty' GHC.MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
 
 instance Pretty
-           (GHC.Hs.MatchGroup
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
+           (GHC.MatchGroup
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsCmd GHC.GhcPs))) where
+  pretty' GHC.MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
 
-instance Pretty (GHC.Hs.HsExpr GHC.Hs.GhcPs) where
+instance Pretty (GHC.HsExpr GHC.GhcPs) where
   pretty' = prettyHsExpr
 
-prettyHsExpr :: GHC.Hs.HsExpr GHC.Hs.GhcPs -> Printer ()
-prettyHsExpr (GHC.Hs.HsVar _ bind) = pretty $ fmap PrefixOp bind
-prettyHsExpr (GHC.Hs.HsUnboundVar _ x) = pretty x
+prettyHsExpr :: GHC.HsExpr GHC.GhcPs -> Printer ()
+prettyHsExpr (GHC.HsVar _ bind) = pretty $ fmap PrefixOp bind
+prettyHsExpr (GHC.HsUnboundVar _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsOverLabel _ _ l) = string "#" >> string (unpackFS l)
 #else
-prettyHsExpr (GHC.Hs.HsOverLabel _ l) = string "#" >> string (unpackFS l)
+prettyHsExpr (GHC.HsOverLabel _ l) = string "#" >> string (unpackFS l)
 #endif
-prettyHsExpr (GHC.Hs.HsIPVar _ var) = string "?" >> pretty var
-prettyHsExpr (GHC.Hs.HsOverLit _ x) = pretty x
-prettyHsExpr (GHC.Hs.HsLit _ l) = pretty l
-prettyHsExpr (GHC.Hs.HsLam _ body) = pretty body
+prettyHsExpr (GHC.HsIPVar _ var) = string "?" >> pretty var
+prettyHsExpr (GHC.HsOverLit _ x) = pretty x
+prettyHsExpr (GHC.HsLit _ l) = pretty l
+prettyHsExpr (GHC.HsLam _ body) = pretty body
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLamCase _ LamCase matches) = pretty $ LambdaCase matches Case
 prettyHsExpr (HsLamCase _ LamCases matches) = pretty $ LambdaCase matches Cases
 #else
-prettyHsExpr (GHC.Hs.HsLamCase _ matches) = pretty $ LambdaCase matches Case
+prettyHsExpr (GHC.HsLamCase _ matches) = pretty $ LambdaCase matches Case
 #endif
-prettyHsExpr (GHC.Hs.HsApp _ l r) = horizontal <-|> vertical
+prettyHsExpr (GHC.HsApp _ l r) = horizontal <-|> vertical
   where
     horizontal = spaced [pretty l, pretty r]
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              [] -> error "Invalid function application."
+              []         -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col'
-              - col
-              - if col == 0
-                  then spaces
-                  else 0
+            col' - col -
+            if col == 0
+              then spaces
+              else 0
       if diff + 1 <= spaces
         then space
         else newline
       spaces' <- getIndentSpaces
       indentedWithSpace spaces' $ lined $ fmap pretty args
-    flatten :: GHC.Hs.LHsExpr GHC.Hs.GhcPs -> [GHC.Hs.LHsExpr GHC.Hs.GhcPs]
-    flatten (L (GHC.Hs.SrcSpanAnn (GHC.Hs.EpAnn _ _ cs) _) (GHC.Hs.HsApp _ l' r')) =
+    flatten :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]
+    flatten (L (GHC.SrcSpanAnn (GHC.EpAnn _ _ cs) _) (GHC.HsApp _ l' r')) =
       flatten l' ++ [insertComments cs r']
     flatten x = [x]
     insertComments ::
-         GHC.Hs.EpAnnComments
-      -> GHC.Hs.LHsExpr GHC.Hs.GhcPs
-      -> GHC.Hs.LHsExpr GHC.Hs.GhcPs
-    insertComments cs (L s@GHC.Hs.SrcSpanAnn {ann = e@GHC.Hs.EpAnn {comments = cs'}} r') =
-      L (s {ann = e {comments = cs <> cs'}}) r'
+         GHC.EpAnnComments -> GHC.LHsExpr GHC.GhcPs -> GHC.LHsExpr GHC.GhcPs
+    insertComments cs (L s@GHC.SrcSpanAnn {GHC.ann = e@GHC.EpAnn {comments = cs'}} r') =
+      L (s {GHC.ann = e {GHC.comments = cs <> cs'}}) r'
     insertComments _ x = x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsAppType _ l _ r) = do
@@ -586,31 +581,30 @@ prettyHsExpr (HsAppType _ l _ r) = do
   string " @"
   pretty r
 #else
-prettyHsExpr (GHC.Hs.HsAppType _ l r) = do
+prettyHsExpr (GHC.HsAppType _ l r) = do
   pretty l
   string " @"
   pretty r
 #endif
-prettyHsExpr (GHC.Hs.OpApp _ l o r) = pretty (InfixApp l o r)
-prettyHsExpr (GHC.Hs.NegApp _ x _) = string "-" >> pretty x
+prettyHsExpr (GHC.OpApp _ l o r) = pretty (InfixApp l o r)
+prettyHsExpr (GHC.NegApp _ x _) = string "-" >> pretty x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsPar _ _ expr _) = parens $ pretty expr
 #else
-prettyHsExpr (GHC.Hs.HsPar _ expr) = parens $ pretty expr
+prettyHsExpr (GHC.HsPar _ expr) = parens $ pretty expr
 #endif
-prettyHsExpr (GHC.Hs.SectionL _ l o) = spaced [pretty l, pretty (InfixExpr o)]
-prettyHsExpr (GHC.Hs.SectionR _ o r) =
-  (pretty (InfixExpr o) >> space) |=> pretty r
-prettyHsExpr (GHC.Hs.ExplicitTuple _ full _) = horizontal <-|> vertical
+prettyHsExpr (GHC.SectionL _ l o) = spaced [pretty l, pretty (InfixExpr o)]
+prettyHsExpr (GHC.SectionR _ o r) = (pretty (InfixExpr o) >> space) |=> pretty r
+prettyHsExpr (GHC.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens
-        $ prefixedLined ","
-        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
-    isMissing GHC.Hs.Missing {} = True
-    isMissing _ = False
-prettyHsExpr (GHC.Hs.ExplicitSum _ position numElem expr) = do
+      parens $
+      prefixedLined "," $
+      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+    isMissing GHC.Missing {} = True
+    isMissing _              = False
+prettyHsExpr (GHC.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
     if idx == position
@@ -618,61 +612,59 @@ prettyHsExpr (GHC.Hs.ExplicitSum _ position numElem expr) = do
       else string " "
     when (idx < numElem) $ string "|"
   string "#)"
-prettyHsExpr (GHC.Hs.HsCase _ cond arms) = do
+prettyHsExpr (GHC.HsCase _ cond arms) = do
   string "case " |=> do
     pretty cond
     string " of"
-  if null $ unLoc $ mg_alts arms
+  if null $ unLoc $ GHC.mg_alts arms
     then string " {}"
     else do
       newline
       indentedBlock $ pretty arms
-prettyHsExpr (GHC.Hs.HsIf _ cond t f) = do
+prettyHsExpr (GHC.HsIf _ cond t f) = do
   string "if " |=> pretty cond
   indentedBlock $ newlinePrefixed [branch "then " t, branch "else " f]
   where
-    branch :: String -> GHC.Hs.LHsExpr GHC.Hs.GhcPs -> Printer ()
+    branch :: String -> GHC.LHsExpr GHC.GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) xs)) ->
-          doStmt (QualifiedDo m Do) xs
-        (L _ (GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) xs)) ->
-          doStmt (QualifiedDo m Mdo) xs
-        _ -> string str |=> pretty e
+        (L _ (GHC.HsDo _ (GHC.DoExpr m) xs))  -> doStmt (QualifiedDo m Do) xs
+        (L _ (GHC.HsDo _ (GHC.MDoExpr m) xs)) -> doStmt (QualifiedDo m Mdo) xs
+        _                                     -> string str |=> pretty e
       where
         doStmt qDo stmts = do
           string str
           pretty qDo
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
-prettyHsExpr (GHC.Hs.HsMultiIf _ guards) =
-  string "if "
-    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+prettyHsExpr (GHC.HsMultiIf _ guards) =
+  string "if " |=>
+  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
-prettyHsExpr (GHC.Hs.HsLet _ binds exprs) = pretty $ LetIn binds exprs
+prettyHsExpr (GHC.HsLet _ binds exprs) = pretty $ LetIn binds exprs
 #endif
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ListComp {} (L _ [])) =
+prettyHsExpr (GHC.HsDo _ GHC.ListComp {} (L _ [])) =
   error "Not enough arguments are passed to pretty-print a list comprehension."
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ListComp {} (L l (lhs:rhs))) =
+prettyHsExpr (GHC.HsDo _ GHC.ListComp {} (L l (lhs:rhs))) =
   pretty $ L l $ ListComprehension lhs rhs
 -- While the name contains 'Monad', 'MonadComp' is for list comprehensions.
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.MonadComp {} (L _ [])) =
+prettyHsExpr (GHC.HsDo _ GHC.MonadComp {} (L _ [])) =
   error "Not enough arguments are passed to pretty-print a list comprehension."
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.MonadComp {} (L l (lhs:rhs))) =
+prettyHsExpr (GHC.HsDo _ GHC.MonadComp {} (L l (lhs:rhs))) =
   pretty $ L l $ ListComprehension lhs rhs
-prettyHsExpr (GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) (L l xs)) =
+prettyHsExpr (GHC.HsDo _ (GHC.DoExpr m) (L l xs)) =
   pretty $ L l $ DoExpression xs (QualifiedDo m Do)
-prettyHsExpr (GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) (L l xs)) =
+prettyHsExpr (GHC.HsDo _ (GHC.MDoExpr m) (L l xs)) =
   pretty $ L l $ DoExpression xs (QualifiedDo m Mdo)
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.GhciStmtCtxt {} _) =
+prettyHsExpr (GHC.HsDo _ GHC.GhciStmtCtxt {} _) =
   error "We're not using GHCi, are we?"
-prettyHsExpr (GHC.Hs.ExplicitList _ xs) = horizontal <-|> vertical
+prettyHsExpr (GHC.ExplicitList _ xs) = horizontal <-|> vertical
   where
     horizontal = brackets $ hCommaSep $ fmap pretty xs
     vertical = vList $ fmap pretty xs
-prettyHsExpr (GHC.Hs.RecordCon _ name fields) = horizontal <-|> vertical
+prettyHsExpr (GHC.RecordCon _ name fields) = horizontal <-|> vertical
   where
     horizontal = spaced [pretty name, pretty fields]
     vertical = do
@@ -711,9 +703,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsFieldBind a b)]
@@ -735,84 +727,83 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
       newline
       indentedBlock $ pretty hfbRHS
 #else
-prettyHsExpr (GHC.Hs.RecordUpd _ name fields) = hor <-|> ver
+prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
   where
     hor = spaced [pretty name, either printHorFields printHorFields fields]
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
-      => [GenLocated l (GHC.Hs.HsRecField' a b)]
+      => [GenLocated l (GHC.HsRecField' a b)]
       -> Printer ()
     printHorFields = hFields . fmap (`printCommentsAnd` horField)
     printVerFields ::
          (Pretty a, Pretty b, CommentExtraction l)
-      => [GenLocated l (GHC.Hs.HsRecField' a b)]
+      => [GenLocated l (GHC.HsRecField' a b)]
       -> Printer ()
     printVerFields = vFields . fmap printField
     printField x = printCommentsAnd x $ (<-|>) <$> horField <*> verField
-    horField GHC.Hs.HsRecField {..} = do
+    horField GHC.HsRecField {..} = do
       pretty hsRecFieldLbl
       string " = "
       pretty hsRecFieldArg
-    verField GHC.Hs.HsRecField {..} = do
+    verField GHC.HsRecField {..} = do
       pretty hsRecFieldLbl
       string " ="
       newline
       indentedBlock $ pretty hsRecFieldArg
 #endif
-prettyHsExpr (GHC.Hs.HsGetField _ e f) = do
+prettyHsExpr (GHC.HsGetField _ e f) = do
   pretty e
   dot
   pretty f
-prettyHsExpr GHC.Hs.HsProjection {..} =
-  parens
-    $ forM_ proj_flds
-    $ \x -> do
-        string "."
-        pretty x
-prettyHsExpr (GHC.Hs.ExprWithTySig _ e sig) = do
+prettyHsExpr GHC.HsProjection {..} =
+  parens $
+  forM_ proj_flds $ \x -> do
+    string "."
+    pretty x
+prettyHsExpr (GHC.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
-  pretty $ hswc_body sig
-prettyHsExpr (GHC.Hs.ArithSeq _ _ x) = pretty x
+  pretty $ GHC.hswc_body sig
+prettyHsExpr (GHC.ArithSeq _ _ x) = pretty x
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-prettyHsExpr (GHC.Hs.HsSpliceE _ x) = pretty x
+prettyHsExpr (GHC.HsSpliceE _ x) = pretty x
 #endif
-prettyHsExpr (GHC.Hs.HsProc _ pat x@(L _ (GHC.Hs.HsCmdTop _ (L _ (GHC.Hs.HsCmdDo _ xs))))) = do
+prettyHsExpr (GHC.HsProc _ pat x@(L _ (GHC.HsCmdTop _ (L _ (GHC.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock
-    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
-prettyHsExpr (GHC.Hs.HsProc _ pat body) = hor <-|> ver
+  indentedBlock $
+    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+prettyHsExpr (GHC.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
     ver = do
       spaced [string "proc", pretty pat, string "->"]
       newline
       indentedBlock (pretty body)
-prettyHsExpr (GHC.Hs.HsStatic _ x) = spaced [string "static", pretty x]
-prettyHsExpr (GHC.Hs.HsPragE _ p x) = spaced [pretty p, pretty x]
+prettyHsExpr (GHC.HsStatic _ x) = spaced [string "static", pretty x]
+prettyHsExpr (GHC.HsPragE _ p x) = spaced [pretty p, pretty x]
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr HsRecSel {} = notGeneratedByParser
 prettyHsExpr (HsTypedBracket _ inner) = typedBrackets $ pretty inner
 prettyHsExpr (HsUntypedBracket _ inner) = pretty inner
 #else
-prettyHsExpr GHC.Hs.HsConLikeOut {} = notGeneratedByParser
-prettyHsExpr GHC.Hs.HsRecFld {} = notGeneratedByParser
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ArrowExpr {} _) = notGeneratedByParser
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.PatGuard {} _) = notGeneratedByParser
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ParStmtCtxt {} _) = notGeneratedByParser
-prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.TransStmtCtxt {} _) = notGeneratedByParser
-prettyHsExpr GHC.Hs.HsTick {} = forHpc
-prettyHsExpr GHC.Hs.HsBinTick {} = forHpc
-prettyHsExpr (GHC.Hs.HsBracket _ inner) = pretty inner
-prettyHsExpr GHC.Hs.HsRnBracketOut {} = notGeneratedByParser
-prettyHsExpr GHC.Hs.HsTcBracketOut {} = notGeneratedByParser
+prettyHsExpr GHC.HsConLikeOut {} = notGeneratedByParser
+prettyHsExpr GHC.HsRecFld {} = notGeneratedByParser
+prettyHsExpr (GHC.HsDo _ GHC.ArrowExpr {} _) = notGeneratedByParser
+prettyHsExpr (GHC.HsDo _ GHC.PatGuard {} _) = notGeneratedByParser
+prettyHsExpr (GHC.HsDo _ GHC.ParStmtCtxt {} _) = notGeneratedByParser
+prettyHsExpr (GHC.HsDo _ GHC.TransStmtCtxt {} _) = notGeneratedByParser
+prettyHsExpr GHC.HsTick {} = forHpc
+prettyHsExpr GHC.HsBinTick {} = forHpc
+prettyHsExpr (GHC.HsBracket _ inner) = pretty inner
+prettyHsExpr GHC.HsRnBracketOut {} = notGeneratedByParser
+prettyHsExpr GHC.HsTcBracketOut {} = notGeneratedByParser
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsTypedSplice _ x) = string "$$" >> pretty x
@@ -821,26 +812,26 @@ prettyHsExpr (HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case -> string "\\case"
+      Case  -> string "\\case"
       Cases -> string "\\cases"
-    if null $ unLoc $ mg_alts matches
+    if null $ unLoc $ GHC.mg_alts matches
       then string " {}"
       else do
         newline
         indentedBlock $ pretty matches
 
-instance Pretty (GHC.Hs.HsSigType GHC.Hs.GhcPs) where
+instance Pretty (GHC.HsSigType GHC.GhcPs) where
   pretty' = pretty' . HsSigType' HsTypeForNormalDecl HsTypeNoDir
 
 instance Pretty HsSigType' where
-  pretty' (HsSigTypeInsideDeclSig GHC.Hs.HsSig {..}) =
+  pretty' (HsSigTypeInsideDeclSig GHC.HsSig {..}) =
     case sig_bndrs of
-      GHC.Hs.HsOuterExplicit _ xs -> do
+      GHC.HsOuterExplicit _ xs -> do
         string "forall "
         spaced $ fmap pretty xs
         dot
         case unLoc sig_body of
-          GHC.Hs.HsQualTy {..} ->
+          GHC.HsQualTy {..} ->
             printCommentsAnd sig_body $ \_ ->
               let hor = do
                     space
@@ -848,12 +839,10 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do
-                    hor <-|> ver
-                    newline
-                    prefixed "=> "
-                      $ prefixedLined "-> "
-                      $ pretty <$> flatten hst_body
+               in do hor <-|> ver
+                     newline
+                     prefixed "=> " $
+                       prefixedLined "-> " $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -861,26 +850,26 @@ instance Pretty HsSigType' where
              in hor <-|> ver
       _ -> pretty $ fmap HsTypeInsideDeclSig sig_body
     where
-      flatten :: GHC.Hs.LHsType GHC.Hs.GhcPs -> [GHC.Hs.LHsType GHC.Hs.GhcPs]
-      flatten (L _ (GHC.Hs.HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x = [x]
-  pretty' (HsSigTypeInsideVerticalFuncSig GHC.Hs.HsSig {..}) =
+      flatten :: GHC.LHsType GHC.GhcPs -> [GHC.LHsType GHC.GhcPs]
+      flatten (L _ (GHC.HsFunTy _ _ l r)) = flatten l ++ flatten r
+      flatten x                           = [x]
+  pretty' (HsSigTypeInsideVerticalFuncSig GHC.HsSig {..}) =
     case sig_bndrs of
-      GHC.Hs.HsOuterExplicit _ xs -> do
+      GHC.HsOuterExplicit _ xs -> do
         string "forall "
         spaced $ fmap pretty xs
         dot
         printCommentsAnd sig_body $ \case
-          GHC.Hs.HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt))
-              <-|> (newline >> pretty (VerticalContext hst_ctxt))
+          GHC.HsQualTy {..} -> do
+            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
+              (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
       _ -> pretty $ fmap HsTypeInsideDeclSig sig_body
-  pretty' (HsSigType' for dir GHC.Hs.HsSig {..}) = do
+  pretty' (HsSigType' for dir GHC.HsSig {..}) = do
     case sig_bndrs of
-      GHC.Hs.HsOuterExplicit _ xs -> do
+      GHC.HsOuterExplicit _ xs -> do
         string "forall "
         spaced $ fmap pretty xs
         dot
@@ -888,10 +877,10 @@ instance Pretty HsSigType' where
       _ -> return ()
     pretty $ HsType' for dir <$> sig_body
 
-instance Pretty (GHC.Hs.ConDecl GHC.Hs.GhcPs) where
+instance Pretty (GHC.ConDecl GHC.GhcPs) where
   pretty' = prettyConDecl
 
-prettyConDecl :: GHC.Hs.ConDecl GHC.Hs.GhcPs -> Printer ()
+prettyConDecl :: GHC.ConDecl GHC.GhcPs -> Printer ()
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyConDecl ConDeclGADT {..} = do
   hCommaSep $ fmap pretty $ NonEmpty.toList con_names
@@ -903,10 +892,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -917,19 +906,19 @@ prettyConDecl ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     forallNeeded =
@@ -937,7 +926,7 @@ prettyConDecl ConDeclGADT {..} = do
         HsOuterImplicit {} -> False
         HsOuterExplicit {} -> True
 #else
-prettyConDecl GHC.Hs.ConDeclGADT {..} = do
+prettyConDecl GHC.ConDeclGADT {..} = do
   hCommaSep $ fmap pretty con_names
   hor <-|> ver
   where
@@ -947,10 +936,10 @@ prettyConDecl GHC.Hs.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -961,110 +950,105 @@ prettyConDecl GHC.Hs.ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt))
-        <-|> (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt)) <-|>
+        (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
-        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-    
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
+      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
-        GHC.Hs.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.Hs.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
-        GHC.Hs.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+        GHC.PrefixConGADT xs ->
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+        GHC.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
+
     verArgs =
       case con_g_args of
-        GHC.Hs.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.Hs.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
-        GHC.Hs.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
+        GHC.PrefixConGADT xs ->
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+        GHC.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
+
     forallNeeded =
       case unLoc con_bndrs of
-        GHC.Hs.HsOuterImplicit {} -> False
-        GHC.Hs.HsOuterExplicit {} -> True
+        GHC.HsOuterImplicit {} -> False
+        GHC.HsOuterExplicit {} -> True
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \c -> do
-             pretty $ Context c
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \c -> do
+        pretty $ Context c
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #else
-prettyConDecl GHC.Hs.ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \_ -> do
-             pretty $ Context con_mb_cxt
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \_ -> do
+        pretty $ Context con_mb_cxt
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #endif
-prettyConDecl GHC.Hs.ConDeclH98 {con_forall = False, ..} =
+prettyConDecl GHC.ConDeclH98 {con_forall = False, ..} =
   case con_args of
-    (GHC.Hs.InfixCon l r) ->
+    (GHC.InfixCon l r) ->
       spaced [pretty l, pretty $ fmap InfixOp con_name, pretty r]
     _ -> do
       pretty con_name
       pretty con_args
 
 instance Pretty
-           (GHC.Hs.Match
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+           (GHC.Match
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
   pretty' = prettyMatchExpr
 
-prettyMatchExpr ::
-     GHC.Hs.Match GHC.Hs.GhcPs (GHC.Hs.LHsExpr GHC.Hs.GhcPs) -> Printer ()
-prettyMatchExpr GHC.Hs.Match {m_ctxt = GHC.Hs.LambdaExpr, ..} = do
+prettyMatchExpr :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Printer ()
+prettyMatchExpr GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case unLoc $ head m_pats of
-        GHC.Hs.LazyPat {} -> space
-        GHC.Hs.BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case unLoc $ head m_pats of
+      GHC.LazyPat {} -> space
+      GHC.BangPat {} -> space
+      _              -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
-prettyMatchExpr GHC.Hs.Match {m_ctxt = GHC.Hs.CaseAlt, ..} = do
+prettyMatchExpr GHC.Match {m_ctxt = GHC.CaseAlt, ..} = do
   mapM_ pretty m_pats
   pretty $ GRHSsExpr GRHSExprCase m_grhss
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1072,38 +1056,36 @@ prettyMatchExpr Match {m_ctxt = LamCaseAlt {}, ..} = do
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprCase m_grhss
 #endif
-prettyMatchExpr GHC.Hs.Match {..} =
-  case mc_fixity m_ctxt of
+prettyMatchExpr GHC.Match {..} =
+  case GHC.mc_fixity m_ctxt of
     Prefix -> do
       pretty m_ctxt
       spacePrefixed $ fmap pretty m_pats
       pretty m_grhss
     Infix -> do
       case (m_pats, m_ctxt) of
-        (l:r:xs, GHC.Hs.FunRhs {..}) -> do
-          spaced
-            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
-                ++ fmap pretty xs
+        (l:r:xs, GHC.FunRhs {..}) -> do
+          spaced $
+            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
 instance Pretty
-           (GHC.Hs.Match
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
+           (GHC.Match
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsCmd GHC.GhcPs))) where
   pretty' = prettyMatchProc
 
-prettyMatchProc ::
-     GHC.Hs.Match GHC.Hs.GhcPs (GHC.Hs.LHsCmd GHC.Hs.GhcPs) -> Printer ()
-prettyMatchProc GHC.Hs.Match {m_ctxt = GHC.Hs.LambdaExpr, ..} = do
+prettyMatchProc :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Printer ()
+prettyMatchProc GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case unLoc $ head m_pats of
-        GHC.Hs.LazyPat {} -> space
-        GHC.Hs.BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case unLoc $ head m_pats of
+      GHC.LazyPat {} -> space
+      GHC.BangPat {} -> space
+      _              -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
-prettyMatchProc GHC.Hs.Match {m_ctxt = GHC.Hs.CaseAlt, ..} =
+prettyMatchProc GHC.Match {m_ctxt = GHC.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyMatchProc Match {m_ctxt = LamCaseAlt {}, ..} = do
@@ -1112,36 +1094,36 @@ prettyMatchProc Match {m_ctxt = LamCaseAlt {}, ..} = do
 prettyMatchProc _ = notGeneratedByParser
 
 instance Pretty
-           (GHC.Hs.StmtLR
-              GHC.Hs.GhcPs
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
-  pretty' (GHC.Hs.LastStmt _ x _ _) = pretty x
-  pretty' (GHC.Hs.BindStmt _ pat body) = do
+           (GHC.StmtLR
+              GHC.GhcPs
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
+  pretty' (GHC.LastStmt _ x _ _) = pretty x
+  pretty' (GHC.BindStmt _ pat body) = do
     pretty pat
     string " <-"
     hor <-|> ver
     where
       hor = space >> pretty body
       ver = newline >> indentedBlock (pretty body)
-  pretty' GHC.Hs.ApplicativeStmt {} = notGeneratedByParser
-  pretty' (GHC.Hs.BodyStmt _ (L loc (GHC.Hs.OpApp _ l o r)) _ _) =
+  pretty' GHC.ApplicativeStmt {} = notGeneratedByParser
+  pretty' (GHC.BodyStmt _ (L loc (GHC.OpApp _ l o r)) _ _) =
     pretty (L loc (InfixApp l o r))
-  pretty' (GHC.Hs.BodyStmt _ body _ _) = pretty body
-  pretty' (GHC.Hs.LetStmt _ l) = string "let " |=> pretty l
-  pretty' (GHC.Hs.ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
-  pretty' GHC.Hs.TransStmt {..} =
+  pretty' (GHC.BodyStmt _ body _ _) = pretty body
+  pretty' (GHC.LetStmt _ l) = string "let " |=> pretty l
+  pretty' (GHC.ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
+  pretty' GHC.TransStmt {..} =
     vCommaSep $ fmap pretty trS_stmts ++ [string "then " >> pretty trS_using]
-  pretty' GHC.Hs.RecStmt {..} =
+  pretty' GHC.RecStmt {..} =
     string "rec " |=> printCommentsAnd recS_stmts (lined . fmap pretty)
 
 instance Pretty
-           (GHC.Hs.StmtLR
-              GHC.Hs.GhcPs
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
-  pretty' (GHC.Hs.LastStmt _ x _ _) = pretty x
-  pretty' (GHC.Hs.BindStmt _ pat body) = hor <-|> ver
+           (GHC.StmtLR
+              GHC.GhcPs
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsCmd GHC.GhcPs))) where
+  pretty' (GHC.LastStmt _ x _ _) = pretty x
+  pretty' (GHC.BindStmt _ pat body) = hor <-|> ver
     where
       hor = spaced [pretty pat, string "<-", pretty body]
       ver = do
@@ -1149,67 +1131,67 @@ instance Pretty
         string " <-"
         newline
         indentedBlock $ pretty body
-  pretty' GHC.Hs.ApplicativeStmt {} = notGeneratedByParser
-  pretty' (GHC.Hs.BodyStmt _ body _ _) = pretty body
-  pretty' (GHC.Hs.LetStmt _ l) = string "let " |=> pretty l
-  pretty' (GHC.Hs.ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
-  pretty' GHC.Hs.TransStmt {..} =
+  pretty' GHC.ApplicativeStmt {} = notGeneratedByParser
+  pretty' (GHC.BodyStmt _ body _ _) = pretty body
+  pretty' (GHC.LetStmt _ l) = string "let " |=> pretty l
+  pretty' (GHC.ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
+  pretty' GHC.TransStmt {..} =
     vCommaSep $ fmap pretty trS_stmts ++ [string "then " >> pretty trS_using]
-  pretty' GHC.Hs.RecStmt {..} =
+  pretty' GHC.RecStmt {..} =
     string "rec " |=> printCommentsAnd recS_stmts (lined . fmap pretty)
 
 instance Pretty StmtLRInsideVerticalList where
-  pretty' (StmtLRInsideVerticalList (GHC.Hs.ParStmt _ xs _ _)) =
+  pretty' (StmtLRInsideVerticalList (GHC.ParStmt _ xs _ _)) =
     vBarSep $ fmap (pretty . ParStmtBlockInsideVerticalList) xs
   pretty' (StmtLRInsideVerticalList x) = pretty x
 
 -- | For pattern matching.
 instance Pretty
-           (GHC.Hs.HsRecFields
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.Pat GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.HsRecFields {..} = horizontal <-|> vertical
+           (GHC.HsRecFields
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.Pat GHC.GhcPs))) where
+  pretty' GHC.HsRecFields {..} = horizontal <-|> vertical
     where
       horizontal =
         case rec_dotdot of
-          Just _ -> braces $ string ".."
+          Just _  -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
 -- | For record updates
 instance Pretty
-           (GHC.Hs.HsRecFields
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.HsRecFields {..} = hvFields fieldPrinters
+           (GHC.HsRecFields
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
+  pretty' GHC.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 
-instance Pretty (GHC.Hs.HsType GHC.Hs.GhcPs) where
+instance Pretty (GHC.HsType GHC.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
 
 instance Pretty HsType' where
-  pretty' (HsTypeInsideVerticalFuncSig (GHC.Hs.HsFunTy _ _ a b)) = do
+  pretty' (HsTypeInsideVerticalFuncSig (GHC.HsFunTy _ _ a b)) = do
     pretty $ HsTypeInsideVerticalFuncSig <$> a
     newline
     prefixed "-> " $ pretty $ HsTypeInsideVerticalFuncSig <$> b
-  pretty' (HsTypeInsideDeclSig GHC.Hs.HsQualTy {..}) = hor <-|> ver
+  pretty' (HsTypeInsideDeclSig GHC.HsQualTy {..}) = hor <-|> ver
     where
       hor = spaced [pretty $ Context hst_ctxt, string "=>", pretty hst_body]
       ver = do
         pretty $ Context hst_ctxt
         newline
         prefixed "=> " $ pretty $ fmap HsTypeInsideVerticalFuncSig hst_body
-  pretty' (HsTypeInsideDeclSig (GHC.Hs.HsFunTy _ _ a b)) = hor <-|> ver
+  pretty' (HsTypeInsideDeclSig (GHC.HsFunTy _ _ a b)) = hor <-|> ver
     where
       hor = spaced [pretty a, string "->", pretty b]
       ver = do
         pretty $ fmap HsTypeInsideVerticalFuncSig a
         newline
         prefixed "-> " $ pretty $ fmap HsTypeInsideVerticalFuncSig b
-  pretty' (HsTypeInsideInstDecl GHC.Hs.HsQualTy {..}) = hor <-|> ver
+  pretty' (HsTypeInsideInstDecl GHC.HsQualTy {..}) = hor <-|> ver
     where
       hor = spaced [pretty (Context hst_ctxt), string "=>", pretty hst_body]
       ver = do
@@ -1217,42 +1199,41 @@ instance Pretty HsType' where
         string " =>"
         newline
         pretty hst_body
-  pretty' (HsTypeWithVerticalAppTy (GHC.Hs.HsAppTy _ l r)) = do
+  pretty' (HsTypeWithVerticalAppTy (GHC.HsAppTy _ l r)) = do
     pretty $ fmap HsTypeWithVerticalAppTy l
     newline
     indentedBlock $ pretty $ fmap HsTypeWithVerticalAppTy r
   pretty' (HsType' _ _ x) = prettyHsType x
 
-prettyHsType :: GHC.Hs.HsType GHC.Hs.GhcPs -> Printer ()
-prettyHsType (GHC.Hs.HsForAllTy _ tele body) =
+prettyHsType :: GHC.HsType GHC.GhcPs -> Printer ()
+prettyHsType (GHC.HsForAllTy _ tele body) =
   (pretty tele >> space) |=> pretty body
-prettyHsType GHC.Hs.HsQualTy {..} = hor <-|> ver
+prettyHsType GHC.HsQualTy {..} = hor <-|> ver
   where
     hor = spaced [pretty $ Context hst_ctxt, string "=>", pretty hst_body]
     ver = do
       pretty $ Context hst_ctxt
       lined [string " =>", indentedBlock $ pretty hst_body]
-prettyHsType (GHC.Hs.HsTyVar _ NotPromoted x) = pretty x
-prettyHsType (GHC.Hs.HsTyVar _ IsPromoted x) = string "'" >> pretty x
-prettyHsType x@(GHC.Hs.HsAppTy _ l r) = hor <-|> ver
+prettyHsType (GHC.HsTyVar _ NotPromoted x) = pretty x
+prettyHsType (GHC.HsTyVar _ IsPromoted x) = string "'" >> pretty x
+prettyHsType x@(GHC.HsAppTy _ l r) = hor <-|> ver
   where
     hor = spaced $ fmap pretty [l, r]
     ver = pretty $ HsTypeWithVerticalAppTy x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 prettyHsType (HsAppKindTy _ l _ r) = pretty l >> string " @" >> pretty r
 #else
-prettyHsType (GHC.Hs.HsAppKindTy _ l r) = pretty l >> string " @" >> pretty r
+prettyHsType (GHC.HsAppKindTy _ l r) = pretty l >> string " @" >> pretty r
 #endif
-prettyHsType (GHC.Hs.HsFunTy _ _ a b) = (pretty a >> string " -> ") |=> pretty b
-prettyHsType (GHC.Hs.HsListTy _ xs) = brackets $ pretty xs
-prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsUnboxedTuple []) = string "(# #)"
-prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsBoxedOrConstraintTuple []) =
-  string "()"
-prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsUnboxedTuple xs) =
+prettyHsType (GHC.HsFunTy _ _ a b) = (pretty a >> string " -> ") |=> pretty b
+prettyHsType (GHC.HsListTy _ xs) = brackets $ pretty xs
+prettyHsType (GHC.HsTupleTy _ GHC.HsUnboxedTuple []) = string "(# #)"
+prettyHsType (GHC.HsTupleTy _ GHC.HsBoxedOrConstraintTuple []) = string "()"
+prettyHsType (GHC.HsTupleTy _ GHC.HsUnboxedTuple xs) =
   hvUnboxedTuple' $ fmap pretty xs
-prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsBoxedOrConstraintTuple xs) =
+prettyHsType (GHC.HsTupleTy _ GHC.HsBoxedOrConstraintTuple xs) =
   hvTuple' $ fmap pretty xs
-prettyHsType (GHC.Hs.HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs
+prettyHsType (GHC.HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs
 -- For `HsOpTy`, we do not need a single quote for the infix operator. An
 -- explicit promotion is necessary if there is a data constructor and
 -- a type with the same name. However, infix data constructors never
@@ -1270,7 +1251,7 @@ prettyHsType (HsOpTy _ _ l op r) = do
       pretty r
     else spaced [pretty l, pretty $ fmap InfixOp op, pretty r]
 #else
-prettyHsType (GHC.Hs.HsOpTy _ l op r) = do
+prettyHsType (GHC.HsOpTy _ l op r) = do
   lineBreak <- gets (configLineBreaks . psConfig)
   if showOutputable op `elem` lineBreak
     then do
@@ -1281,108 +1262,107 @@ prettyHsType (GHC.Hs.HsOpTy _ l op r) = do
       pretty r
     else spaced [pretty l, pretty $ fmap InfixOp op, pretty r]
 #endif
-prettyHsType (GHC.Hs.HsParTy _ inside) = parens $ pretty inside
-prettyHsType (GHC.Hs.HsIParamTy _ x ty) =
+prettyHsType (GHC.HsParTy _ inside) = parens $ pretty inside
+prettyHsType (GHC.HsIParamTy _ x ty) =
   spaced [string "?" >> pretty x, string "::", pretty ty]
-prettyHsType GHC.Hs.HsStarTy {} = string "*"
-prettyHsType (GHC.Hs.HsKindSig _ t k) = spaced [pretty t, string "::", pretty k]
-prettyHsType (GHC.Hs.HsSpliceTy _ sp) = pretty sp
-prettyHsType GHC.Hs.HsDocTy {} = docNode
-prettyHsType (GHC.Hs.HsBangTy _ pack x) = pretty pack >> pretty x
-prettyHsType (GHC.Hs.HsRecTy _ xs) = hvFields $ fmap pretty xs
-prettyHsType (GHC.Hs.HsExplicitListTy _ _ xs) =
+prettyHsType GHC.HsStarTy {} = string "*"
+prettyHsType (GHC.HsKindSig _ t k) = spaced [pretty t, string "::", pretty k]
+prettyHsType (GHC.HsSpliceTy _ sp) = pretty sp
+prettyHsType GHC.HsDocTy {} = docNode
+prettyHsType (GHC.HsBangTy _ pack x) = pretty pack >> pretty x
+prettyHsType (GHC.HsRecTy _ xs) = hvFields $ fmap pretty xs
+prettyHsType (GHC.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hvPromotedList $ fmap pretty xs
-prettyHsType (GHC.Hs.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
-prettyHsType (GHC.Hs.HsTyLit _ x) = pretty x
-prettyHsType GHC.Hs.HsWildCardTy {} = string "_"
-prettyHsType GHC.Hs.XHsType {} = notGeneratedByParser
+    _  -> hvPromotedList $ fmap pretty xs
+prettyHsType (GHC.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
+prettyHsType (GHC.HsTyLit _ x) = pretty x
+prettyHsType GHC.HsWildCardTy {} = string "_"
+prettyHsType GHC.XHsType {} = notGeneratedByParser
 
 instance Pretty
-           (GHC.Hs.GRHSs
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+           (GHC.GRHSs
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
   pretty' = pretty' . GRHSsExpr GRHSExprNormal
 
 instance Pretty GRHSsExpr where
-  pretty' (GRHSsExpr {grhssExpr = GHC.Hs.GRHSs {..}, ..}) = do
+  pretty' (GRHSsExpr {grhssExpr = GHC.GRHSs {..}, ..}) = do
     mapM_ (pretty . fmap (GRHSExpr grhssExprType)) grhssGRHSs
     case (grhssLocalBinds, grhssExprType) of
-      (GHC.Hs.HsValBinds {}, GRHSExprCase) ->
+      (GHC.HsValBinds {}, GRHSExprCase) ->
         indentedBlock $ do
           newline
           string "where " |=> pretty grhssLocalBinds
-      (GHC.Hs.HsValBinds epa lr, _) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+      (GHC.HsValBinds epa lr, _) ->
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty
-           (GHC.Hs.GRHSs
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.GRHSs {..} = do
+           (GHC.GRHSs
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsCmd GHC.GhcPs))) where
+  pretty' GHC.GRHSs {..} = do
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
-      (GHC.Hs.HsValBinds epa lr) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+      (GHC.HsValBinds epa lr) ->
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
-instance Pretty (GHC.Hs.HsMatchContext GHC.Hs.GhcPs) where
+instance Pretty (GHC.HsMatchContext GHC.GhcPs) where
   pretty' = prettyHsMatchContext
 
-prettyHsMatchContext :: GHC.Hs.HsMatchContext GHC.Hs.GhcPs -> Printer ()
-prettyHsMatchContext GHC.Hs.FunRhs {..} = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext GHC.Hs.LambdaExpr = return ()
-prettyHsMatchContext GHC.Hs.CaseAlt = return ()
-prettyHsMatchContext GHC.Hs.IfAlt {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.PatBindRhs {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.PatBindGuards {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.RecUpd {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.StmtCtxt {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.ThPatSplice {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.ThPatQuote {} = notGeneratedByParser
-prettyHsMatchContext GHC.Hs.PatSyn {} = notGeneratedByParser
+prettyHsMatchContext :: GHC.HsMatchContext GHC.GhcPs -> Printer ()
+prettyHsMatchContext GHC.FunRhs {..} = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext GHC.LambdaExpr = return ()
+prettyHsMatchContext GHC.CaseAlt = return ()
+prettyHsMatchContext GHC.IfAlt {} = notGeneratedByParser
+prettyHsMatchContext GHC.ArrowMatchCtxt {} = notGeneratedByParser
+prettyHsMatchContext GHC.PatBindRhs {} = notGeneratedByParser
+prettyHsMatchContext GHC.PatBindGuards {} = notGeneratedByParser
+prettyHsMatchContext GHC.RecUpd {} = notGeneratedByParser
+prettyHsMatchContext GHC.StmtCtxt {} = notGeneratedByParser
+prettyHsMatchContext GHC.ThPatSplice {} = notGeneratedByParser
+prettyHsMatchContext GHC.ThPatQuote {} = notGeneratedByParser
+prettyHsMatchContext GHC.PatSyn {} = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
 #endif
-instance Pretty (GHC.Hs.ParStmtBlock GHC.Hs.GhcPs GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
+instance Pretty (GHC.ParStmtBlock GHC.GhcPs GHC.GhcPs) where
+  pretty' (GHC.ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
 
 instance Pretty ParStmtBlockInsideVerticalList where
-  pretty' (ParStmtBlockInsideVerticalList (GHC.Hs.ParStmtBlock _ xs _ _)) =
+  pretty' (ParStmtBlockInsideVerticalList (GHC.ParStmtBlock _ xs _ _)) =
     vCommaSep $ fmap pretty xs
 
 instance Pretty RdrName where
   pretty' = pretty . PrefixOp
 
 instance Pretty
-           (GHC.Hs.GRHS
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+           (GHC.GRHS
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
   pretty' = pretty' . GRHSExpr GRHSExprNormal
 
 instance Pretty GRHSExpr where
-  pretty' (GRHSExpr {grhsExpr = (GHC.Hs.GRHS _ [] body), ..}) = do
+  pretty' (GRHSExpr {grhsExpr = (GHC.GRHS _ [] body), ..}) = do
     space
     rhsSeparator grhsExprType
     case unLoc body of
-      GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) stmts ->
+      GHC.HsDo _ (GHC.DoExpr m) stmts ->
         printCommentsAnd body (const (doExpr (QualifiedDo m Do) stmts))
-      GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) stmts ->
+      GHC.HsDo _ (GHC.MDoExpr m) stmts ->
         printCommentsAnd body (const (doExpr (QualifiedDo m Mdo) stmts))
-      GHC.Hs.OpApp _ (L _ (GHC.Hs.HsDo _ GHC.Hs.DoExpr {} _)) _ _ ->
-        space >> pretty body
-      GHC.Hs.OpApp _ (L _ (GHC.Hs.HsDo _ GHC.Hs.MDoExpr {} _)) _ _ ->
+      GHC.OpApp _ (L _ (GHC.HsDo _ GHC.DoExpr {} _)) _ _ -> space >> pretty body
+      GHC.OpApp _ (L _ (GHC.HsDo _ GHC.MDoExpr {} _)) _ _ ->
         space >> pretty body
       _ ->
         let hor = space >> pretty body
@@ -1394,7 +1374,7 @@ instance Pretty GRHSExpr where
         pretty qDo
         newline
         indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
-  pretty' (GRHSExpr {grhsExpr = (GHC.Hs.GRHS _ guards body), ..}) = do
+  pretty' (GRHSExpr {grhsExpr = (GHC.GRHS _ guards body), ..}) = do
     unless (grhsExprType == GRHSExprMultiWayIf) newline
     (if grhsExprType == GRHSExprMultiWayIf
        then id
@@ -1403,9 +1383,8 @@ instance Pretty GRHSExpr where
       space
       rhsSeparator grhsExprType
       printCommentsAnd body $ \case
-        GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) stmts -> doExpr (QualifiedDo m Do) stmts
-        GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) stmts ->
-          doExpr (QualifiedDo m Mdo) stmts
+        GHC.HsDo _ (GHC.DoExpr m) stmts -> doExpr (QualifiedDo m Do) stmts
+        GHC.HsDo _ (GHC.MDoExpr m) stmts -> doExpr (QualifiedDo m Mdo) stmts
         x ->
           let hor = space >> pretty x
               ver = newline >> indentedBlock (pretty x)
@@ -1418,7 +1397,7 @@ instance Pretty GRHSExpr where
         indentedBlock (printCommentsAnd stmts (lined . fmap pretty))
 
 instance Pretty GRHSProc where
-  pretty' (GRHSProc (GHC.Hs.GRHS _ guards body)) =
+  pretty' (GRHSProc (GHC.GRHS _ guards body)) =
     if null guards
       then bodyPrinter
       else do
@@ -1431,7 +1410,7 @@ instance Pretty GRHSProc where
       bodyPrinter = do
         string "->"
         printCommentsAnd body $ \case
-          GHC.Hs.HsCmdDo _ stmts ->
+          GHC.HsCmdDo _ stmts ->
             let hor = space >> printCommentsAnd stmts (lined . fmap pretty)
                 ver = do
                   newline
@@ -1442,9 +1421,9 @@ instance Pretty GRHSProc where
                 ver = newline >> indentedBlock (pretty x)
              in hor <-|> ver
 
-instance Pretty GHC.Hs.EpaCommentTok where
-  pretty' (GHC.Hs.EpaLineComment c) = string c
-  pretty' (GHC.Hs.EpaBlockComment c) =
+instance Pretty GHC.EpaCommentTok where
+  pretty' (GHC.EpaLineComment c) = string c
+  pretty' (GHC.EpaBlockComment c) =
     case lines c of
       [] -> pure ()
       [x] -> string x
@@ -1456,60 +1435,55 @@ instance Pretty GHC.Hs.EpaCommentTok where
         indentedWithFixedLevel 0 $ lined $ fmap string xs
   pretty' _ = docNode
 
-instance Pretty (GHC.Hs.SpliceDecl GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.SpliceDecl _ sp _) = pretty sp
+instance Pretty (GHC.SpliceDecl GHC.GhcPs) where
+  pretty' (GHC.SpliceDecl _ sp _) = pretty sp
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-instance Pretty (GHC.Hs.HsSplice GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.HsTypedSplice _ _ _ body) = string "$$" >> pretty body
-  pretty' (GHC.Hs.HsUntypedSplice _ GHC.Hs.DollarSplice _ body) =
+instance Pretty (GHC.HsSplice GHC.GhcPs) where
+  pretty' (GHC.HsTypedSplice _ _ _ body) = string "$$" >> pretty body
+  pretty' (GHC.HsUntypedSplice _ GHC.DollarSplice _ body) =
     string "$" >> pretty body
-  pretty' (GHC.Hs.HsUntypedSplice _ GHC.Hs.BareSplice _ body) = pretty body
+  pretty' (GHC.HsUntypedSplice _ GHC.BareSplice _ body) = pretty body
   -- The body of a quasi-quote must not be changed by a formatter.
   -- Changing it will modify the actual behavior of the code.
-  pretty' (GHC.Hs.HsQuasiQuote _ _ l _ r) =
+  pretty' (GHC.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars
-        $ indentedWithFixedLevel 0
-        $ sequence_
-        $ printers [] ""
-        $ unpackFS r
+      wrapWithBars $
+        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
         printers (newline : string (reverse s) : ps) "" xs
       printers ps s (x:xs) = printers ps (x : s) xs
-  pretty' GHC.Hs.HsSpliced {} = notGeneratedByParser
+  pretty' GHC.HsSpliced {} = notGeneratedByParser
 #endif
-instance Pretty (GHC.Hs.Pat GHC.Hs.GhcPs) where
+instance Pretty (GHC.Pat GHC.GhcPs) where
   pretty' = prettyPat
 
 instance Pretty PatInsidePatDecl where
-  pretty' (PatInsidePatDecl (GHC.Hs.ConPat { pat_args = (GHC.Hs.InfixCon l r)
-                                           , ..
-                                           })) =
+  pretty' (PatInsidePatDecl (GHC.ConPat {pat_args = (GHC.InfixCon l r), ..})) =
     spaced [pretty l, pretty $ fmap InfixOp pat_con, pretty r]
   pretty' (PatInsidePatDecl x) = pretty x
 
-prettyPat :: GHC.Hs.Pat GHC.Hs.GhcPs -> Printer ()
-prettyPat GHC.Hs.WildPat {} = string "_"
-prettyPat (GHC.Hs.VarPat _ x) = pretty x
-prettyPat (GHC.Hs.LazyPat _ x) = string "~" >> pretty x
+prettyPat :: GHC.Pat GHC.GhcPs -> Printer ()
+prettyPat GHC.WildPat {} = string "_"
+prettyPat (GHC.VarPat _ x) = pretty x
+prettyPat (GHC.LazyPat _ x) = string "~" >> pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPat (AsPat _ a _ b) = pretty a >> string "@" >> pretty b
 #else
-prettyPat (GHC.Hs.AsPat _ a b) = pretty a >> string "@" >> pretty b
+prettyPat (GHC.AsPat _ a b) = pretty a >> string "@" >> pretty b
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyPat (ParPat _ _ inner _) = parens $ pretty inner
 #else
-prettyPat (GHC.Hs.ParPat _ inner) = parens $ pretty inner
+prettyPat (GHC.ParPat _ inner) = parens $ pretty inner
 #endif
-prettyPat (GHC.Hs.BangPat _ x) = string "!" >> pretty x
-prettyPat (GHC.Hs.ListPat _ xs) = hList $ fmap pretty xs
-prettyPat (GHC.Hs.TuplePat _ pats Boxed) = hTuple $ fmap pretty pats
-prettyPat (GHC.Hs.TuplePat _ pats Unboxed) = hUnboxedTuple $ fmap pretty pats
-prettyPat (GHC.Hs.SumPat _ x position numElem) = do
+prettyPat (GHC.BangPat _ x) = string "!" >> pretty x
+prettyPat (GHC.ListPat _ xs) = hList $ fmap pretty xs
+prettyPat (GHC.TuplePat _ pats Boxed) = hTuple $ fmap pretty pats
+prettyPat (GHC.TuplePat _ pats Unboxed) = hUnboxedTuple $ fmap pretty pats
+prettyPat (GHC.SumPat _ x position numElem) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
     if idx == position
@@ -1517,76 +1491,76 @@ prettyPat (GHC.Hs.SumPat _ x position numElem) = do
       else string " "
     when (idx < numElem) $ string "|"
   string "#)"
-prettyPat GHC.Hs.ConPat {..} =
+prettyPat GHC.ConPat {..} =
   case pat_args of
-    GHC.Hs.PrefixCon _ as -> do
+    GHC.PrefixCon _ as -> do
       pretty $ fmap PrefixOp pat_con
       spacePrefixed $ fmap pretty as
-    GHC.Hs.RecCon rec -> (pretty pat_con >> space) |=> pretty (RecConPat rec)
-    GHC.Hs.InfixCon a b -> do
+    GHC.RecCon rec -> (pretty pat_con >> space) |=> pretty (RecConPat rec)
+    GHC.InfixCon a b -> do
       pretty a
       unlessSpecialOp (unLoc pat_con) space
       pretty $ fmap InfixOp pat_con
       unlessSpecialOp (unLoc pat_con) space
       pretty b
-prettyPat (GHC.Hs.ViewPat _ l r) = spaced [pretty l, string "->", pretty r]
-prettyPat (GHC.Hs.SplicePat _ x) = pretty x
-prettyPat (GHC.Hs.LitPat _ x) = pretty x
-prettyPat (GHC.Hs.NPat _ x _ _) = pretty x
-prettyPat (GHC.Hs.NPlusKPat _ n k _ _ _) = pretty n >> string "+" >> pretty k
-prettyPat (GHC.Hs.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
+prettyPat (GHC.ViewPat _ l r) = spaced [pretty l, string "->", pretty r]
+prettyPat (GHC.SplicePat _ x) = pretty x
+prettyPat (GHC.LitPat _ x) = pretty x
+prettyPat (GHC.NPat _ x _ _) = pretty x
+prettyPat (GHC.NPlusKPat _ n k _ _ _) = pretty n >> string "+" >> pretty k
+prettyPat (GHC.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 
 instance Pretty RecConPat where
-  pretty' (RecConPat GHC.Hs.HsRecFields {..}) =
+  pretty' (RecConPat GHC.HsRecFields {..}) =
     case fieldPrinters of
-      [] -> string "{}"
+      []  -> string "{}"
       [x] -> braces x
-      xs -> hvFields xs
+      xs  -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-instance Pretty (GHC.Hs.HsBracket GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
-  pretty' (GHC.Hs.PatBr _ expr) =
+instance Pretty (GHC.HsBracket GHC.GhcPs) where
+  pretty' (GHC.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
+  pretty' (GHC.PatBr _ expr) =
     brackets $ string "p" >> wrapWithBars (pretty expr)
-  pretty' (GHC.Hs.DecBrL _ decls) =
+  pretty' (GHC.DecBrL _ decls) =
     brackets $ string "d| " |=> lined (fmap pretty decls) >> string " |"
-  pretty' GHC.Hs.DecBrG {} = notGeneratedByParser
-  pretty' (GHC.Hs.TypBr _ expr) =
+  pretty' GHC.DecBrG {} = notGeneratedByParser
+  pretty' (GHC.TypBr _ expr) =
     brackets $ string "t" >> wrapWithBars (pretty expr)
-  pretty' (GHC.Hs.VarBr _ True var) = string "'" >> pretty var
-  pretty' (GHC.Hs.VarBr _ False var) = string "''" >> pretty var
-  pretty' (GHC.Hs.TExpBr _ x) = typedBrackets $ pretty x
+  pretty' (GHC.VarBr _ True var) = string "'" >> pretty var
+  pretty' (GHC.VarBr _ False var) = string "''" >> pretty var
+  pretty' (GHC.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x) = pretty x
-  pretty' (Bind x) = pretty x
-  pretty' (TypeFamily x) = pretty x
-  pretty' (TyFamInst x) = pretty x
+  pretty' (Sig x)         = pretty x
+  pretty' (Bind x)        = pretty x
+  pretty' (TypeFamily x)  = pretty x
+  pretty' (TyFamInst x)   = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
-instance Pretty GHC.Hs.EpaComment where
-  pretty' GHC.Hs.EpaComment {..} = pretty ac_tok
+instance Pretty GHC.EpaComment where
+  pretty' GHC.EpaComment {..} = pretty ac_tok
 
-instance Pretty (GHC.Hs.HsLocalBindsLR GHC.Hs.GhcPs GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.HsValBinds _ lr) = pretty lr
-  pretty' (GHC.Hs.HsIPBinds _ x) = pretty x
-  pretty' GHC.Hs.EmptyLocalBinds {} =
+instance Pretty (GHC.HsLocalBindsLR GHC.GhcPs GHC.GhcPs) where
+  pretty' (GHC.HsValBinds _ lr) = pretty lr
+  pretty' (GHC.HsIPBinds _ x) = pretty x
+  pretty' GHC.EmptyLocalBinds {} =
     error
       "This branch indicates that the bind is empty, but since calling this code means that let or where has already been output, it cannot be handled here. It should be handled higher up in the AST."
 
-instance Pretty (GHC.Hs.HsValBindsLR GHC.Hs.GhcPs GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.ValBinds _ methods sigs) = lined $ fmap pretty sigsAndMethods
+instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
+  pretty' (GHC.ValBinds _ methods sigs) = lined $ fmap pretty sigsAndMethods
     where
       sigsAndMethods =
         mkSortedLSigBindFamilyList sigs (bagToList methods) [] [] []
-  pretty' GHC.Hs.XValBindsLR {} = notUsedInParsedStage
+  pretty' GHC.XValBindsLR {} = notUsedInParsedStage
 
-instance Pretty (GHC.Hs.HsTupArg GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.Present _ e) = pretty e
-  pretty' GHC.Hs.Missing {} = pure () -- This appears in a tuple section.
+instance Pretty (GHC.HsTupArg GHC.GhcPs) where
+  pretty' (GHC.Present _ e) = pretty e
+  pretty' GHC.Missing {}    = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1597,18 +1571,18 @@ instance Pretty RecConField where
 #else
 -- | For pattern matching against a record.
 instance Pretty
-           (GHC.Hs.HsRecField'
-              (GHC.Hs.FieldOcc GHC.Hs.GhcPs)
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.Pat GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.HsRecField {..} =
+           (GHC.HsRecField'
+              (GHC.FieldOcc GHC.GhcPs)
+              (GenLocated GHC.SrcSpanAnnA (GHC.Pat GHC.GhcPs))) where
+  pretty' GHC.HsRecField {..} =
     (pretty hsRecFieldLbl >> string " = ") |=> pretty hsRecFieldArg
 
 -- | For record updates.
 instance Pretty
-           (GHC.Hs.HsRecField'
-              (GHC.Hs.FieldOcc GHC.Hs.GhcPs)
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.HsRecField {..} = do
+           (GHC.HsRecField'
+              (GHC.FieldOcc GHC.GhcPs)
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
+  pretty' GHC.HsRecField {..} = do
     pretty hsRecFieldLbl
     unless hsRecPun $ do
       string " ="
@@ -1640,7 +1614,7 @@ instance Pretty
       vertical = newline >> indentedBlock (pretty hfbRHS)
 #else
 instance Pretty RecConField where
-  pretty' (RecConField GHC.Hs.HsRecField {..}) = do
+  pretty' (RecConField GHC.HsRecField {..}) = do
     pretty hsRecFieldLbl
     unless hsRecPun $ do
       string " = "
@@ -1650,38 +1624,36 @@ instance Pretty RecConField where
 instance Pretty (FieldOcc GhcPs) where
   pretty' FieldOcc {..} = pretty foLabel
 #else
-instance Pretty (GHC.Hs.FieldOcc GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.FieldOcc {..} = pretty rdrNameFieldOcc
+instance Pretty (GHC.FieldOcc GHC.GhcPs) where
+  pretty' GHC.FieldOcc {..} = pretty rdrNameFieldOcc
 #endif
 -- HsConDeclH98Details
 instance Pretty
-           (GHC.Hs.HsConDetails
+           (GHC.HsConDetails
               Void
-              (GHC.Hs.HsScaled
-                 GHC.Hs.GhcPs
-                 (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.BangType GHC.Hs.GhcPs)))
+              (GHC.HsScaled
+                 GHC.GhcPs
+                 (GenLocated GHC.SrcSpanAnnA (GHC.BangType GHC.GhcPs)))
               (GenLocated
-                 GHC.Hs.SrcSpanAnnL
-                 [GenLocated
-                    GHC.Hs.SrcSpanAnnA
-                    (GHC.Hs.ConDeclField GHC.Hs.GhcPs)])) where
-  pretty' (GHC.Hs.PrefixCon _ xs) = horizontal <-|> vertical
+                 GHC.SrcSpanAnnL
+                 [GenLocated GHC.SrcSpanAnnA (GHC.ConDeclField GHC.GhcPs)])) where
+  pretty' (GHC.PrefixCon _ xs) = horizontal <-|> vertical
     where
       horizontal = spacePrefixed $ fmap pretty xs
       vertical = indentedBlock $ newlinePrefixed $ fmap pretty xs
-  pretty' (GHC.Hs.RecCon x) =
+  pretty' (GHC.RecCon x) =
     printCommentsAnd x $ \rec -> do
       newline
       indentedBlock $ vFields $ fmap pretty rec
-  pretty' GHC.Hs.InfixCon {} =
+  pretty' GHC.InfixCon {} =
     error
       "Cannot handle here because 'InfixCon' does not have the information of its constructor."
 
-instance Pretty a => Pretty (GHC.Hs.HsScaled GHC.Hs.GhcPs a) where
-  pretty' (GHC.Hs.HsScaled _ x) = pretty x
+instance Pretty a => Pretty (GHC.HsScaled GHC.GhcPs a) where
+  pretty' (GHC.HsScaled _ x) = pretty x
 
-instance Pretty (GHC.Hs.ConDeclField GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.ConDeclField {..}
+instance Pretty (GHC.ConDeclField GHC.GhcPs) where
+  pretty' GHC.ConDeclField {..}
     -- Here, we *ignore* the 'cd_fld_doc' field because doc strings are
     -- also stored as comments, and printing both results in duplicated
     -- comments.
@@ -1691,8 +1663,8 @@ instance Pretty (GHC.Hs.ConDeclField GHC.Hs.GhcPs) where
     pretty cd_fld_type
 
 instance Pretty InfixExpr where
-  pretty' (InfixExpr (L _ (GHC.Hs.HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x) = pretty' x
+  pretty' (InfixExpr (L _ (GHC.HsVar _ bind))) = pretty $ fmap InfixOp bind
+  pretty' (InfixExpr x)                        = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1706,20 +1678,20 @@ instance Pretty InfixApp where
       leftAssoc = prettyOps allOperantsAndOperatorsLeftAssoc
       rightAssoc = prettyOps allOperantsAndOperatorsRightAssoc
       noAssoc
-        | L _ (GHC.Hs.OpApp _ _ o _) <- lhs
+        | L _ (GHC.OpApp _ _ o _) <- lhs
         , isSameAssoc o = leftAssoc
         | otherwise = rightAssoc
-      prettyOps [l, o, L _ (GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) xs)] = do
+      prettyOps [l, o, L _ (GHC.HsDo _ (GHC.DoExpr m) xs)] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty $ QualifiedDo m Do]
         newline
         indentedBlock $ printCommentsAnd xs (lined . fmap pretty)
-      prettyOps [l, o, L _ (GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) xs)] = do
+      prettyOps [l, o, L _ (GHC.HsDo _ (GHC.MDoExpr m) xs)] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty $ QualifiedDo m Mdo]
         newline
         indentedBlock $ printCommentsAnd xs (lined . fmap pretty)
-      prettyOps [l, o, r@(L _ GHC.Hs.HsLam {})] = do
+      prettyOps [l, o, r@(L _ GHC.HsLam {})] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty r]
-      prettyOps [l, o, r@(L _ GHC.Hs.HsLamCase {})] = do
+      prettyOps [l, o, r@(L _ GHC.HsLamCase {})] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty r]
       prettyOps (l:xs) = do
         pretty l
@@ -1738,76 +1710,74 @@ instance Pretty InfixApp where
       findFixity o = fromMaybe defaultFixity $ lookup (varToStr o) fixities
       allOperantsAndOperatorsLeftAssoc = reverse $ rhs : op : collect lhs
         where
-          collect ::
-               GHC.Hs.LHsExpr GHC.Hs.GhcPs -> [GHC.Hs.LHsExpr GHC.Hs.GhcPs]
-          collect (L _ (GHC.Hs.OpApp _ l o r))
+          collect :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]
+          collect (L _ (GHC.OpApp _ l o r))
             | isSameAssoc o = r : o : collect l
           collect x = [x]
       allOperantsAndOperatorsRightAssoc = lhs : op : collect rhs
         where
-          collect ::
-               GHC.Hs.LHsExpr GHC.Hs.GhcPs -> [GHC.Hs.LHsExpr GHC.Hs.GhcPs]
-          collect (L _ (GHC.Hs.OpApp _ l o r))
+          collect :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]
+          collect (L _ (GHC.OpApp _ l o r))
             | isSameAssoc o = l : o : collect r
           collect x = [x]
       isSameAssoc (findFixity -> Fixity _ lv d) = lv == level && d == dir
       Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x) = pretty x
-  pretty' (And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs) = hvBarSep $ fmap pretty xs
+  pretty' (Var x)    = pretty x
+  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
-instance Pretty (GHC.Hs.FieldLabelStrings GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.FieldLabelStrings xs) = hDotSep $ fmap pretty xs
+instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
+  pretty' (GHC.FieldLabelStrings xs) = hDotSep $ fmap pretty xs
 
-instance Pretty (GHC.Hs.AmbiguousFieldOcc GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.Unambiguous _ name) = pretty name
-  pretty' (GHC.Hs.Ambiguous _ name) = pretty name
+instance Pretty (GHC.AmbiguousFieldOcc GHC.GhcPs) where
+  pretty' (GHC.Unambiguous _ name) = pretty name
+  pretty' (GHC.Ambiguous _ name)   = pretty name
 
-instance Pretty (GHC.Hs.HsDerivingClause GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsDerivingClause { deriv_clause_strategy = Just strategy@(L _ GHC.Hs.ViaStrategy {})
-                                  , ..
-                                  } =
+instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
+  pretty' GHC.HsDerivingClause { deriv_clause_strategy = Just strategy@(L _ GHC.ViaStrategy {})
+                               , ..
+                               } =
     spaced [string "deriving", pretty deriv_clause_tys, pretty strategy]
-  pretty' GHC.Hs.HsDerivingClause {..} = do
+  pretty' GHC.HsDerivingClause {..} = do
     string "deriving "
     whenJust deriv_clause_strategy $ \x -> do
       pretty x
       space
     pretty deriv_clause_tys
 
-instance Pretty (GHC.Hs.DerivClauseTys GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.DctSingle _ ty) = parens $ pretty ty
-  pretty' (GHC.Hs.DctMulti _ ts) = hvTuple $ fmap pretty ts
+instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
+  pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
+  pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {} = notUsedInParsedStage
+  pretty' NoOverlap {}    = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
 
 -- | This instance is for type family declarations inside a class declaration.
-instance Pretty (GHC.Hs.FamilyDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.FamilyDecl {..} = do
-    string
-      $ case fdInfo of
-          GHC.Hs.DataFamily -> "data"
-          GHC.Hs.OpenTypeFamily -> "type"
-          GHC.Hs.ClosedTypeFamily {} -> "type"
+instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
+  pretty' GHC.FamilyDecl {..} = do
+    string $
+      case fdInfo of
+        GHC.DataFamily          -> "data"
+        GHC.OpenTypeFamily      -> "type"
+        GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel -> string " family "
+      TopLevel    -> string " family "
       NotTopLevel -> space
     pretty fdLName
-    spacePrefixed $ pretty <$> hsq_explicit fdTyVars
+    spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
     case unLoc fdResultSig of
-      GHC.Hs.NoSig {} -> pure ()
-      GHC.Hs.TyVarSig {} -> do
+      GHC.NoSig {} -> pure ()
+      GHC.TyVarSig {} -> do
         string " = "
         pretty fdResultSig
       _ -> do
@@ -1817,42 +1787,42 @@ instance Pretty (GHC.Hs.FamilyDecl GHC.Hs.GhcPs) where
       string " | "
       pretty x
     case fdInfo of
-      GHC.Hs.ClosedTypeFamily (Just xs) -> do
+      GHC.ClosedTypeFamily (Just xs) -> do
         string " where"
         newline
         indentedBlock $ lined $ fmap pretty xs
       _ -> pure ()
 
-instance Pretty (GHC.Hs.FamilyResultSig GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.NoSig {} = pure ()
-  pretty' (GHC.Hs.KindSig _ x) = string ":: " >> pretty x
-  pretty' (GHC.Hs.TyVarSig _ x) = pretty x
+instance Pretty (GHC.FamilyResultSig GHC.GhcPs) where
+  pretty' GHC.NoSig {}       = pure ()
+  pretty' (GHC.KindSig _ x)  = string ":: " >> pretty x
+  pretty' (GHC.TyVarSig _ x) = pretty x
 
-instance Pretty (GHC.Hs.HsTyVarBndr a GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.UserTyVar _ _ x) = pretty x
-  pretty' (GHC.Hs.KindedTyVar _ _ name ty) =
+instance Pretty (GHC.HsTyVarBndr a GHC.GhcPs) where
+  pretty' (GHC.UserTyVar _ _ x) = pretty x
+  pretty' (GHC.KindedTyVar _ _ name ty) =
     parens $ spaced [pretty name, string "::", pretty ty]
 
-instance Pretty (GHC.Hs.InjectivityAnn GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.InjectivityAnn _ from to) =
+instance Pretty (GHC.InjectivityAnn GHC.GhcPs) where
+  pretty' (GHC.InjectivityAnn _ from to) =
     spaced $ pretty from : string "->" : fmap pretty to
 
-instance Pretty (GHC.Hs.ArithSeqInfo GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.From from) = brackets $ spaced [pretty from, string ".."]
-  pretty' (GHC.Hs.FromThen from next) =
+instance Pretty (GHC.ArithSeqInfo GHC.GhcPs) where
+  pretty' (GHC.From from) = brackets $ spaced [pretty from, string ".."]
+  pretty' (GHC.FromThen from next) =
     brackets $ spaced [pretty from >> comma >> pretty next, string ".."]
-  pretty' (GHC.Hs.FromTo from to) =
+  pretty' (GHC.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
-  pretty' (GHC.Hs.FromThenTo from next to) =
-    brackets
-      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+  pretty' (GHC.FromThenTo from next to) =
+    brackets $
+    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
-instance Pretty (GHC.Hs.HsForAllTelescope GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsForAllVis {..} = do
+instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
+  pretty' GHC.HsForAllVis {..} = do
     string "forall "
     spaced $ fmap pretty hsf_vis_bndrs
     dot
-  pretty' GHC.Hs.HsForAllInvis {..} = do
+  pretty' GHC.HsForAllInvis {..} = do
     string "forall "
     spaced $ fmap pretty hsf_invis_bndrs
     dot
@@ -1891,9 +1861,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ []) -> parens
+          (L _ [])  -> parens
           (L _ [_]) -> id
-          _ -> parens
+          _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1908,10 +1878,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing -> id
-          Just (L _ []) -> parens
+          Nothing        -> id
+          Just (L _ [])  -> parens
           Just (L _ [_]) -> id
-          Just _ -> parens
+          Just _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1929,51 +1899,51 @@ instance Pretty ModuleName where
 instance Pretty ModuleNameWithPrefix where
   pretty' (ModuleNameWithPrefix name) = spaced [string "module", pretty name]
 
-instance Pretty (GHC.Hs.IE GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.IEVar _ name) = pretty name
-  pretty' (GHC.Hs.IEThingAbs _ name) = pretty name
-  pretty' (GHC.Hs.IEThingAll _ name) = do
+instance Pretty (GHC.IE GHC.GhcPs) where
+  pretty' (GHC.IEVar _ name) = pretty name
+  pretty' (GHC.IEThingAbs _ name) = pretty name
+  pretty' (GHC.IEThingAll _ name) = do
     pretty name
     string "(..)"
   -- FIXME: Currently, pretty-printing a 'IEThingWith' uses
   -- 'ghc-lib-parser''s pretty-printer. However, we should avoid it because
   -- 'ghc-lib-parser' may suddenly change how it prints, resulting in
   -- unexpected test failures.
-  pretty' x@GHC.Hs.IEThingWith {} =
+  pretty' x@GHC.IEThingWith {} =
     case lines $ showOutputable x of
       [] -> pure ()
       [x'] -> string x'
       xs -> do
         string $ head xs
         indentedWithFixedLevel 0 $ newlinePrefixed $ string <$> tail xs
-  pretty' (GHC.Hs.IEModuleContents _ name) =
+  pretty' (GHC.IEModuleContents _ name) =
     pretty $ fmap ModuleNameWithPrefix name
-  pretty' GHC.Hs.IEGroup {} = docNode
-  pretty' GHC.Hs.IEDoc {} = docNode
-  pretty' GHC.Hs.IEDocNamed {} = docNode
+  pretty' GHC.IEGroup {} = docNode
+  pretty' GHC.IEDoc {} = docNode
+  pretty' GHC.IEDocNamed {} = docNode
 
 instance Pretty
-           (GHC.Hs.FamEqn
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.FamEqn {..} = do
+           (GHC.FamEqn
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
+  pretty' GHC.FamEqn {..} = do
     pretty feqn_tycon
     spacePrefixed $ fmap pretty feqn_pats
     string " = "
     pretty feqn_rhs
 
 -- | Pretty-print a data instance.
-instance Pretty (GHC.Hs.FamEqn GHC.Hs.GhcPs (GHC.Hs.HsDataDefn GHC.Hs.GhcPs)) where
+instance Pretty (GHC.FamEqn GHC.GhcPs (GHC.HsDataDefn GHC.GhcPs)) where
   pretty' = pretty' . FamEqnTopLevel
 
 instance Pretty FamEqn' where
-  pretty' FamEqn' {famEqn = GHC.Hs.FamEqn {..}, ..} = do
+  pretty' FamEqn' {famEqn = GHC.FamEqn {..}, ..} = do
     spaced $ string prefix : pretty feqn_tycon : fmap pretty feqn_pats
     pretty feqn_rhs
     where
       prefix =
         case famEqnFor of
-          DataFamInstDeclForTopLevel -> "data instance"
+          DataFamInstDeclForTopLevel        -> "data instance"
           DataFamInstDeclForInsideClassInst -> "data"
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
@@ -1982,17 +1952,17 @@ instance Pretty
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
+  pretty' (HsValArg x)    = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+  pretty' HsArgPar {}     = notUsedInParsedStage
 #else
 instance Pretty
-           (GHC.Hs.HsArg
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))) where
-  pretty' (GHC.Hs.HsValArg x) = pretty x
-  pretty' (GHC.Hs.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.Hs.HsArgPar {} = notUsedInParsedStage
+           (GHC.HsArg
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
+  pretty' (GHC.HsValArg x)    = pretty x
+  pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
+  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
@@ -2009,15 +1979,15 @@ instance Pretty (HsQuote GhcPs) where
 instance Pretty (WarnDecls GhcPs) where
   pretty' (Warnings _ x) = lined $ fmap pretty x
 #else
-instance Pretty (GHC.Hs.WarnDecls GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.Warnings _ _ x) = lined $ fmap pretty x
+instance Pretty (GHC.WarnDecls GHC.GhcPs) where
+  pretty' (GHC.Warnings _ _ x) = lined $ fmap pretty x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2027,11 +1997,11 @@ instance Pretty (WarnDecl GhcPs) where
           , string " #-}"
           ]
 #else
-instance Pretty (GHC.Hs.WarnDecl GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.Warning _ names deprecatedOrWarning) =
+instance Pretty (GHC.WarnDecl GHC.GhcPs) where
+  pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2049,15 +2019,15 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
-  pretty' (IEName _ name) = pretty name
+  pretty' (IEName _ name)    = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+  pretty' (IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
-instance Pretty (GHC.Hs.IEWrappedName RdrName) where
-  pretty' (GHC.Hs.IEName name) = pretty name
-  pretty' (GHC.Hs.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.Hs.IEType _ name) = string "type " >> pretty name
+instance Pretty (GHC.IEWrappedName RdrName) where
+  pretty' (GHC.IEName name)      = pretty name
+  pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
+  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -2066,12 +2036,11 @@ instance Pretty (DotFieldOcc GhcPs) where
 instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel (string . unpackFS)
 #else
-instance Pretty (GHC.Hs.HsFieldLabel GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsFieldLabel {..} =
-    printCommentsAnd hflLabel (string . unpackFS)
+instance Pretty (GHC.HsFieldLabel GHC.GhcPs) where
+  pretty' GHC.HsFieldLabel {..} = printCommentsAnd hflLabel (string . unpackFS)
 #endif
-instance Pretty (GHC.Hs.RuleDecls GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsRules {..} =
+instance Pretty (GHC.RuleDecls GHC.GhcPs) where
+  pretty' GHC.HsRules {..} =
     lined $ string "{-# RULES" : fmap pretty rds_rules ++ [string " #-}"]
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (RuleDecl GhcPs) where
@@ -2093,8 +2062,8 @@ instance Pretty (RuleDecl GhcPs) where
             space
             pretty rd_lhs
 #else
-instance Pretty (GHC.Hs.RuleDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsRule {..} =
+instance Pretty (GHC.RuleDecl GHC.GhcPs) where
+  pretty' GHC.HsRule {..} =
     spaced
       [ printCommentsAnd rd_name (doubleQuotes . string . unpackFS . snd)
       , lhs
@@ -2115,17 +2084,17 @@ instance Pretty (GHC.Hs.RuleDecl GHC.Hs.GhcPs) where
 instance Pretty OccName where
   pretty' = output
 
-instance Pretty (GHC.Hs.DerivDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.DerivDecl { deriv_strategy = (Just deriv_strategy@(L _ GHC.Hs.ViaStrategy {}))
-                           , ..
-                           } =
+instance Pretty (GHC.DerivDecl GHC.GhcPs) where
+  pretty' GHC.DerivDecl { deriv_strategy = (Just deriv_strategy@(L _ GHC.ViaStrategy {}))
+                        , ..
+                        } =
     spaced
       [ string "deriving"
       , pretty deriv_strategy
       , string "instance"
       , pretty deriv_type
       ]
-  pretty' GHC.Hs.DerivDecl {..} = do
+  pretty' GHC.DerivDecl {..} = do
     string "deriving "
     whenJust deriv_strategy $ \x -> do
       pretty x
@@ -2135,28 +2104,28 @@ instance Pretty (GHC.Hs.DerivDecl GHC.Hs.GhcPs) where
 
 -- | 'Pretty' for 'LHsSigWcType GhcPs'.
 instance Pretty
-           (GHC.Hs.HsWildCardBndrs
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsSigType GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.HsWC {..} = pretty hswc_body
+           (GHC.HsWildCardBndrs
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsSigType GHC.GhcPs))) where
+  pretty' GHC.HsWC {..} = pretty hswc_body
 
 -- | 'Pretty' for 'LHsWcType'
 instance Pretty
-           (GHC.Hs.HsWildCardBndrs
-              GHC.Hs.GhcPs
-              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))) where
-  pretty' GHC.Hs.HsWC {..} = pretty hswc_body
+           (GHC.HsWildCardBndrs
+              GHC.GhcPs
+              (GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
+  pretty' GHC.HsWC {..} = pretty hswc_body
 
-instance Pretty (GHC.Hs.StandaloneKindSig GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.StandaloneKindSig _ name kind) =
+instance Pretty (GHC.StandaloneKindSig GHC.GhcPs) where
+  pretty' (GHC.StandaloneKindSig _ name kind) =
     spaced [string "type", pretty name, string "::", pretty kind]
 
-instance Pretty (GHC.Hs.DefaultDecl GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.DefaultDecl _ xs) =
+instance Pretty (GHC.DefaultDecl GHC.GhcPs) where
+  pretty' (GHC.DefaultDecl _ xs) =
     spaced [string "default", hTuple $ fmap pretty xs]
 
-instance Pretty (GHC.Hs.ForeignDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.ForeignImport {..} =
+instance Pretty (GHC.ForeignDecl GHC.GhcPs) where
+  pretty' GHC.ForeignImport {..} =
     spaced
       [ string "foreign import"
       , pretty fd_fi
@@ -2164,7 +2133,7 @@ instance Pretty (GHC.Hs.ForeignDecl GHC.Hs.GhcPs) where
       , string "::"
       , pretty fd_sig_ty
       ]
-  pretty' GHC.Hs.ForeignExport {..} =
+  pretty' GHC.ForeignExport {..} =
     spaced
       [ string "foreign export"
       , pretty fd_fe
@@ -2183,34 +2152,33 @@ instance Pretty (ForeignImport GhcPs) where
     spaced [pretty conv, pretty safety, string s]
   pretty' (CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #else
-instance Pretty GHC.Hs.ForeignImport where
-  pretty' (GHC.Hs.CImport conv safety _ _ (L _ (SourceText s))) =
+instance Pretty GHC.ForeignImport where
+  pretty' (GHC.CImport conv safety _ _ (L _ (SourceText s))) =
     spaced [pretty conv, pretty safety, string s]
-  pretty' (GHC.Hs.CImport conv safety _ _ _) =
-    spaced [pretty conv, pretty safety]
+  pretty' (GHC.CImport conv safety _ _ _) = spaced [pretty conv, pretty safety]
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, output s]
-  pretty' (CExport _ conv) = pretty conv
+  pretty' (CExport _ conv)                    = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv) = pretty conv
+  pretty' (CExport _ conv)                    = pretty conv
 #else
-instance Pretty GHC.Hs.ForeignExport where
-  pretty' (GHC.Hs.CExport conv (L _ (SourceText s))) =
+instance Pretty GHC.ForeignExport where
+  pretty' (GHC.CExport conv (L _ (SourceText s))) =
     spaced [pretty conv, string s]
-  pretty' (GHC.Hs.CExport conv _) = pretty conv
+  pretty' (GHC.CExport conv _) = pretty conv
 #endif
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe = string "safe"
+  pretty' PlaySafe          = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky = string "unsafe"
+  pretty' PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2220,71 +2188,71 @@ instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
 #else
-instance Pretty (GHC.Hs.AnnDecl GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.HsAnnotation _ _ (GHC.Hs.ValueAnnProvenance name) expr) =
+instance Pretty (GHC.AnnDecl GHC.GhcPs) where
+  pretty' (GHC.HsAnnotation _ _ (GHC.ValueAnnProvenance name) expr) =
     spaced [string "{-# ANN", pretty name, pretty expr, string "#-}"]
-  pretty' (GHC.Hs.HsAnnotation _ _ (GHC.Hs.TypeAnnProvenance name) expr) =
+  pretty' (GHC.HsAnnotation _ _ (GHC.TypeAnnProvenance name) expr) =
     spaced [string "{-# ANN type", pretty name, pretty expr, string "#-}"]
-  pretty' (GHC.Hs.HsAnnotation _ _ GHC.Hs.ModuleAnnProvenance expr) =
+  pretty' (GHC.HsAnnotation _ _ GHC.ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
 #endif
-instance Pretty (GHC.Hs.RoleAnnotDecl GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.RoleAnnotDecl _ name roles) =
-    spaced
-      $ [string "type role", pretty name]
-          ++ fmap (maybe (string "_") pretty . unLoc) roles
+instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
+  pretty' (GHC.RoleAnnotDecl _ name roles) =
+    spaced $
+    [string "type role", pretty name] ++
+    fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal = string "nominal"
+  pretty' Nominal          = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom = string "phantom"
+  pretty' Phantom          = string "phantom"
 
-instance Pretty (GHC.Hs.TyFamInstDecl GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
+instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
+  pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
 
 instance Pretty TopLevelTyFamInstDecl where
-  pretty' (TopLevelTyFamInstDecl GHC.Hs.TyFamInstDecl {..}) =
+  pretty' (TopLevelTyFamInstDecl GHC.TyFamInstDecl {..}) =
     string "type instance " >> pretty tfid_eqn
 
-instance Pretty (GHC.Hs.DataFamInstDecl GHC.Hs.GhcPs) where
+instance Pretty (GHC.DataFamInstDecl GHC.GhcPs) where
   pretty' = pretty' . DataFamInstDeclTopLevel
 
 instance Pretty DataFamInstDecl' where
-  pretty' DataFamInstDecl' {dataFamInstDecl = GHC.Hs.DataFamInstDecl {..}, ..} =
+  pretty' DataFamInstDecl' {dataFamInstDecl = GHC.DataFamInstDecl {..}, ..} =
     pretty $ FamEqn' dataFamInstDeclFor dfid_eqn
 
-instance Pretty (GHC.Hs.PatSynBind GHC.Hs.GhcPs GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.PSB {..} = do
+instance Pretty (GHC.PatSynBind GHC.GhcPs GHC.GhcPs) where
+  pretty' GHC.PSB {..} = do
     string "pattern "
     case psb_args of
-      GHC.Hs.InfixCon l r ->
+      GHC.InfixCon l r ->
         spaced [pretty l, pretty $ fmap InfixOp psb_id, pretty r]
-      GHC.Hs.PrefixCon _ [] -> pretty psb_id
+      GHC.PrefixCon _ [] -> pretty psb_id
       _ -> spaced [pretty psb_id, pretty psb_args]
     spacePrefixed [pretty psb_dir, pretty $ fmap PatInsidePatDecl psb_def]
     case psb_dir of
-      GHC.Hs.ExplicitBidirectional matches -> do
+      GHC.ExplicitBidirectional matches -> do
         newline
         indentedBlock $ string "where " |=> pretty matches
       _ -> pure ()
 
 -- | 'Pretty' for 'HsPatSynDetails'.
 instance Pretty
-           (GHC.Hs.HsConDetails
+           (GHC.HsConDetails
               Void
-              (GenLocated GHC.Hs.SrcSpanAnnN RdrName)
-              [GHC.Hs.RecordPatSynField GHC.Hs.GhcPs]) where
-  pretty' (GHC.Hs.PrefixCon _ xs) = spaced $ fmap pretty xs
-  pretty' (GHC.Hs.RecCon rec) = hFields $ fmap pretty rec
-  pretty' GHC.Hs.InfixCon {} =
+              (GenLocated GHC.SrcSpanAnnN RdrName)
+              [GHC.RecordPatSynField GHC.GhcPs]) where
+  pretty' (GHC.PrefixCon _ xs) = spaced $ fmap pretty xs
+  pretty' (GHC.RecCon rec) = hFields $ fmap pretty rec
+  pretty' GHC.InfixCon {} =
     error
       "Cannot handle here because `InfixCon` does not have the information of the constructor."
 
-instance Pretty (GHC.Hs.FixitySig GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.FixitySig _ names fixity) =
+instance Pretty (GHC.FixitySig GHC.GhcPs) where
+  pretty' (GHC.FixitySig _ names fixity) =
     spaced [pretty fixity, hCommaSep $ fmap (pretty . fmap InfixOp) names]
 
-instance Pretty GHC.Hs.Fixity where
+instance Pretty GHC.Fixity where
   pretty' (Fixity _ level dir) = spaced [pretty dir, string $ show level]
 
 instance Pretty FixityDirection where
@@ -2297,8 +2265,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x -> space >> brackets (string $ show x)
-      _ -> pure ()
+      ActiveAfter _ x  -> space >> brackets (string $ show x)
+      _                -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -2313,46 +2281,46 @@ prettyInlineSpec NoUserInlinePrag =
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
-instance Pretty (GHC.Hs.HsPatSynDir GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.Unidirectional = string "<-"
-  pretty' GHC.Hs.ImplicitBidirectional = string "="
-  pretty' GHC.Hs.ExplicitBidirectional {} = string "<-"
+instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
+  pretty' GHC.Unidirectional           = string "<-"
+  pretty' GHC.ImplicitBidirectional    = string "="
+  pretty' GHC.ExplicitBidirectional {} = string "<-"
 
-instance Pretty (GHC.Hs.HsOverLit GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.OverLit {..} = pretty ol_val
+instance Pretty (GHC.HsOverLit GHC.GhcPs) where
+  pretty' GHC.OverLit {..} = pretty ol_val
 
-instance Pretty GHC.Hs.OverLitVal where
-  pretty' (GHC.Hs.HsIntegral x) = pretty x
-  pretty' (GHC.Hs.HsFractional x) = pretty x
-  pretty' (GHC.Hs.HsIsString _ x) = string $ unpackFS x
+instance Pretty GHC.OverLitVal where
+  pretty' (GHC.HsIntegral x)   = pretty x
+  pretty' (GHC.HsFractional x) = pretty x
+  pretty' (GHC.HsIsString _ x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 #else
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 #endif
 instance Pretty FractionalLit where
   pretty' = output
 
-instance Pretty (GHC.Hs.HsLit GHC.Hs.GhcPs) where
-  pretty' x@(GHC.Hs.HsChar _ _) = output x
-  pretty' x@GHC.Hs.HsCharPrim {} = output x
-  pretty' GHC.Hs.HsInt {} = notUsedInParsedStage
-  pretty' (GHC.Hs.HsIntPrim _ x) = string $ show x ++ "#"
-  pretty' GHC.Hs.HsWordPrim {} = notUsedInParsedStage
-  pretty' GHC.Hs.HsInt64Prim {} = notUsedInParsedStage
-  pretty' GHC.Hs.HsWord64Prim {} = notUsedInParsedStage
-  pretty' GHC.Hs.HsInteger {} = notUsedInParsedStage
-  pretty' GHC.Hs.HsRat {} = notUsedInParsedStage
-  pretty' (GHC.Hs.HsFloatPrim _ x) = pretty x >> string "#"
-  pretty' GHC.Hs.HsDoublePrim {} = notUsedInParsedStage
+instance Pretty (GHC.HsLit GHC.GhcPs) where
+  pretty' x@(GHC.HsChar _ _) = output x
+  pretty' x@GHC.HsCharPrim {} = output x
+  pretty' GHC.HsInt {} = notUsedInParsedStage
+  pretty' (GHC.HsIntPrim _ x) = string $ show x ++ "#"
+  pretty' GHC.HsWordPrim {} = notUsedInParsedStage
+  pretty' GHC.HsInt64Prim {} = notUsedInParsedStage
+  pretty' GHC.HsWord64Prim {} = notUsedInParsedStage
+  pretty' GHC.HsInteger {} = notUsedInParsedStage
+  pretty' GHC.HsRat {} = notUsedInParsedStage
+  pretty' (GHC.HsFloatPrim _ x) = pretty x >> string "#"
+  pretty' GHC.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      GHC.Hs.HsString {} -> prettyString
-      GHC.Hs.HsStringPrim {} -> prettyString
+      GHC.HsString {}     -> prettyString
+      GHC.HsStringPrim {} -> prettyString
     where
       prettyString =
         case lines $ showOutputable x of
@@ -2362,85 +2330,84 @@ instance Pretty (GHC.Hs.HsLit GHC.Hs.GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1)
-                $ lined
-                $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1) $
+                lined $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
 #else
-instance Pretty (GHC.Hs.HsPragE GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.HsPragSCC _ _ x) =
+instance Pretty (GHC.HsPragE GHC.GhcPs) where
+  pretty' (GHC.HsPragSCC _ _ x) =
     spaced [string "{-# SCC", pretty x, string "#-}"]
 #endif
-instance Pretty GHC.Hs.HsIPName where
-  pretty' (GHC.Hs.HsIPName x) = string $ unpackFS x
+instance Pretty GHC.HsIPName where
+  pretty' (GHC.HsIPName x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsNumTy _ x)  = string $ show x
+  pretty' (HsStrTy _ x)  = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
-instance Pretty GHC.Hs.HsTyLit where
-  pretty' (GHC.Hs.HsNumTy _ x) = string $ show x
-  pretty' (GHC.Hs.HsStrTy _ x) = string $ ushow x
-  pretty' (GHC.Hs.HsCharTy _ x) = string $ show x
+instance Pretty GHC.HsTyLit where
+  pretty' (GHC.HsNumTy _ x)  = string $ show x
+  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
+  pretty' (GHC.HsCharTy _ x) = string $ show x
 #endif
-instance Pretty (GHC.Hs.HsPatSigType GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsPS {..} = pretty hsps_body
+instance Pretty (GHC.HsPatSigType GHC.GhcPs) where
+  pretty' GHC.HsPS {..} = pretty hsps_body
 
-instance Pretty (GHC.Hs.HsIPBinds GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.IPBinds _ xs) = lined $ fmap pretty xs
+instance Pretty (GHC.HsIPBinds GHC.GhcPs) where
+  pretty' (GHC.IPBinds _ xs) = lined $ fmap pretty xs
 
-instance Pretty (GHC.Hs.IPBind GHC.Hs.GhcPs) where
+instance Pretty (GHC.IPBind GHC.GhcPs) where
   pretty' = prettyIPBind
 
-prettyIPBind :: GHC.Hs.IPBind GHC.Hs.GhcPs -> Printer ()
+prettyIPBind :: GHC.IPBind GHC.GhcPs -> Printer ()
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyIPBind (IPBind _ l r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #else
-prettyIPBind (GHC.Hs.IPBind _ (Right _) _) = notUsedInParsedStage
-prettyIPBind (GHC.Hs.IPBind _ (Left l) r) =
+prettyIPBind (GHC.IPBind _ (Right _) _) = notUsedInParsedStage
+prettyIPBind (GHC.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
-instance Pretty (GHC.Hs.DerivStrategy GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.StockStrategy {} = string "stock"
-  pretty' GHC.Hs.AnyclassStrategy {} = string "anyclass"
-  pretty' GHC.Hs.NewtypeStrategy {} = string "newtype"
-  pretty' (GHC.Hs.ViaStrategy x) = string "via " >> pretty x
+instance Pretty (GHC.DerivStrategy GHC.GhcPs) where
+  pretty' GHC.StockStrategy {}    = string "stock"
+  pretty' GHC.AnyclassStrategy {} = string "anyclass"
+  pretty' GHC.NewtypeStrategy {}  = string "newtype"
+  pretty' (GHC.ViaStrategy x)     = string "via " >> pretty x
 
-instance Pretty GHC.Hs.XViaStrategyPs where
-  pretty' (GHC.Hs.XViaStrategyPs _ ty) = pretty ty
+instance Pretty GHC.XViaStrategyPs where
+  pretty' (GHC.XViaStrategyPs _ ty) = pretty ty
 
-instance Pretty (GHC.Hs.RecordPatSynField GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.RecordPatSynField {..} = pretty recordPatSynField
+instance Pretty (GHC.RecordPatSynField GHC.GhcPs) where
+  pretty' GHC.RecordPatSynField {..} = pretty recordPatSynField
 
-instance Pretty (GHC.Hs.HsCmdTop GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.HsCmdTop _ cmd) = pretty cmd
+instance Pretty (GHC.HsCmdTop GHC.GhcPs) where
+  pretty' (GHC.HsCmdTop _ cmd) = pretty cmd
 
-instance Pretty (GHC.Hs.HsCmd GHC.Hs.GhcPs) where
+instance Pretty (GHC.HsCmd GHC.GhcPs) where
   pretty' = prettyHsCmd
 
-prettyHsCmd :: GHC.Hs.HsCmd GHC.Hs.GhcPs -> Printer ()
-prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsHigherOrderApp True) =
+prettyHsCmd :: GHC.HsCmd GHC.GhcPs -> Printer ()
+prettyHsCmd (GHC.HsCmdArrApp _ f arg GHC.HsHigherOrderApp True) =
   spaced [pretty f, string "-<<", pretty arg]
-prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsHigherOrderApp False) =
+prettyHsCmd (GHC.HsCmdArrApp _ f arg GHC.HsHigherOrderApp False) =
   spaced [pretty arg, string ">>-", pretty f]
-prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsFirstOrderApp True) =
+prettyHsCmd (GHC.HsCmdArrApp _ f arg GHC.HsFirstOrderApp True) =
   spaced [pretty f, string "-<", pretty arg]
-prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsFirstOrderApp False) =
+prettyHsCmd (GHC.HsCmdArrApp _ f arg GHC.HsFirstOrderApp False) =
   spaced [pretty arg, string ">-", pretty f]
-prettyHsCmd (GHC.Hs.HsCmdArrForm _ f _ _ args) =
+prettyHsCmd (GHC.HsCmdArrForm _ f _ _ args) =
   bananaBrackets $ spaced $ pretty f : fmap pretty args
-prettyHsCmd (GHC.Hs.HsCmdApp _ f arg) = spaced [pretty f, pretty arg]
-prettyHsCmd (GHC.Hs.HsCmdLam _ x) = pretty x
+prettyHsCmd (GHC.HsCmdApp _ f arg) = spaced [pretty f, pretty arg]
+prettyHsCmd (GHC.HsCmdLam _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsCmd (HsCmdPar _ _ x _) = parens $ pretty x
 #else
-prettyHsCmd (GHC.Hs.HsCmdPar _ x) = parens $ pretty x
+prettyHsCmd (GHC.HsCmdPar _ x) = parens $ pretty x
 #endif
-prettyHsCmd (GHC.Hs.HsCmdCase _ cond arms) = do
+prettyHsCmd (GHC.HsCmdCase _ cond arms) = do
   spaced [string "case", pretty cond, string "of"]
   newline
   indentedBlock $ pretty arms
@@ -2450,12 +2417,12 @@ prettyHsCmd (HsCmdLamCase _ _ arms) = do
   newline
   indentedBlock $ pretty arms
 #else
-prettyHsCmd (GHC.Hs.HsCmdLamCase _ arms) = do
+prettyHsCmd (GHC.HsCmdLamCase _ arms) = do
   string "\\case"
   newline
   indentedBlock $ pretty arms
 #endif
-prettyHsCmd (GHC.Hs.HsCmdIf _ _ cond t f) = do
+prettyHsCmd (GHC.HsCmdIf _ _ cond t f) = do
   string "if "
   pretty cond
   newline
@@ -2464,10 +2431,10 @@ prettyHsCmd (GHC.Hs.HsCmdIf _ _ cond t f) = do
 prettyHsCmd (HsCmdLet _ _ binds _ expr) =
   lined [string "let " |=> pretty binds, string " in " |=> pretty expr]
 #else
-prettyHsCmd (GHC.Hs.HsCmdLet _ binds expr) =
+prettyHsCmd (GHC.HsCmdLet _ binds expr) =
   lined [string "let " |=> pretty binds, string " in " |=> pretty expr]
 #endif
-prettyHsCmd (GHC.Hs.HsCmdDo _ stmts) = do
+prettyHsCmd (GHC.HsCmdDo _ stmts) = do
   string "do"
   newline
   indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
@@ -2476,12 +2443,9 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets
-          $ spaced
-              [ pretty listCompLhs
-              , string "|"
-              , hCommaSep $ fmap pretty listCompRhs
-              ]
+        brackets $
+        spaced
+          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2499,7 +2463,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do = string "do"
+  pretty' Do  = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2513,37 +2477,37 @@ instance Pretty LetIn where
   pretty' LetIn {..} =
     lined [string "let " |=> pretty letBinds, string " in " |=> pretty inExpr]
 
-instance Pretty (GHC.Hs.RuleBndr GHC.Hs.GhcPs) where
-  pretty' (GHC.Hs.RuleBndr _ name) = pretty name
-  pretty' (GHC.Hs.RuleBndrSig _ name sig) =
+instance Pretty (GHC.RuleBndr GHC.GhcPs) where
+  pretty' (GHC.RuleBndr _ name) = pretty name
+  pretty' (GHC.RuleBndrSig _ name sig) =
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv = string "ccall"
-  pretty' CApiConv = string "capi"
-  pretty' StdCallConv = string "stdcall"
-  pretty' PrimCallConv = string "prim"
+  pretty' CCallConv          = string "ccall"
+  pretty' CApiConv           = string "capi"
+  pretty' StdCallConv        = string "stdcall"
+  pretty' PrimCallConv       = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 
-instance Pretty GHC.Hs.HsSrcBang where
-  pretty' (GHC.Hs.HsSrcBang _ unpack strictness) = do
+instance Pretty GHC.HsSrcBang where
+  pretty' (GHC.HsSrcBang _ unpack strictness) = do
     pretty unpack
-    unless (unpack == GHC.Hs.NoSrcUnpack) space
+    unless (unpack == GHC.NoSrcUnpack) space
     pretty strictness
 
-instance Pretty GHC.Hs.SrcUnpackedness where
-  pretty' GHC.Hs.SrcUnpack = string "{-# UNPACK #-}"
-  pretty' GHC.Hs.SrcNoUnpack = string "{-# NOUNPACK #-}"
-  pretty' GHC.Hs.NoSrcUnpack = pure ()
+instance Pretty GHC.SrcUnpackedness where
+  pretty' GHC.SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' GHC.SrcNoUnpack = string "{-# NOUNPACK #-}"
+  pretty' GHC.NoSrcUnpack = pure ()
 
-instance Pretty GHC.Hs.SrcStrictness where
-  pretty' GHC.Hs.SrcLazy = string "~"
-  pretty' GHC.Hs.SrcStrict = string "!"
-  pretty' GHC.Hs.NoSrcStrict = pure ()
+instance Pretty GHC.SrcStrictness where
+  pretty' GHC.SrcLazy     = string "~"
+  pretty' GHC.SrcStrict   = string "!"
+  pretty' GHC.NoSrcStrict = pure ()
 
-instance Pretty (GHC.Hs.HsOuterSigTyVarBndrs GHC.Hs.GhcPs) where
-  pretty' GHC.Hs.HsOuterImplicit {} = pure ()
-  pretty' GHC.Hs.HsOuterExplicit {..} = do
+instance Pretty (GHC.HsOuterSigTyVarBndrs GHC.GhcPs) where
+  pretty' GHC.HsOuterImplicit {} = pure ()
+  pretty' GHC.HsOuterExplicit {..} = do
     string "forall"
     spacePrefixed $ fmap pretty hso_bndrs
     dot
@@ -2562,11 +2526,8 @@ instance Pretty (HsUntypedSplice GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars
-           . indentedWithFixedLevel 0
-           . sequence_
-           . printers [] ""
-           . unpackFS)
+        (wrapWithBars .
+         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -36,7 +36,7 @@ import qualified GHC.Types.Fixity                            as GHC
 import qualified GHC.Types.ForeignCall                       as GHC
 import           GHC.Types.Name
 import qualified GHC.Types.Name.Reader                       as GHC
-import           GHC.Types.SourceText
+import qualified GHC.Types.SourceText                        as GHC
 import           GHC.Types.SrcLoc
 import           GHC.Unit.Module.Warnings
 import           HIndent.Applicative
@@ -1758,7 +1758,7 @@ instance Pretty GHC.OverlapMode where
   pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
   pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
 
-instance Pretty GHC.Types.SourceText.StringLiteral where
+instance Pretty GHC.StringLiteral where
   pretty' = output
 
 -- | This instance is for type family declarations inside a class declaration.
@@ -2152,7 +2152,7 @@ instance Pretty (ForeignImport GhcPs) where
   pretty' (CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #else
 instance Pretty GHC.ForeignImport where
-  pretty' (GHC.CImport conv safety _ _ (L _ (GHC.Types.SourceText.SourceText s))) =
+  pretty' (GHC.CImport conv safety _ _ (L _ (GHC.SourceText s))) =
     spaced [pretty conv, pretty safety, string s]
   pretty' (GHC.CImport conv safety _ _ _) = spaced [pretty conv, pretty safety]
 #endif
@@ -2167,7 +2167,7 @@ instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport _ conv)                    = pretty conv
 #else
 instance Pretty GHC.ForeignExport where
-  pretty' (GHC.CExport conv (L _ (GHC.Types.SourceText.SourceText s))) =
+  pretty' (GHC.CExport conv (L _ (GHC.SourceText s))) =
     spaced [pretty conv, string s]
   pretty' (GHC.CExport conv _) = pretty conv
 #endif
@@ -2297,12 +2297,11 @@ instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
   pretty' IL {..}                     = string $ show il_value
 #else
-instance Pretty GHC.Types.SourceText.IntegralLit where
-  pretty' GHC.Types.SourceText.IL {il_text = GHC.Types.SourceText.SourceText s} =
-    string s
-  pretty' GHC.Types.SourceText.IL {..} = string $ show il_value
+instance Pretty GHC.IntegralLit where
+  pretty' GHC.IL {il_text = GHC.SourceText s} = string s
+  pretty' GHC.IL {..}                         = string $ show il_value
 #endif
-instance Pretty GHC.Types.SourceText.FractionalLit where
+instance Pretty GHC.FractionalLit where
   pretty' = output
 
 instance Pretty (GHC.HsLit GHC.GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -48,7 +48,7 @@ import           HIndent.Pretty.NodeComments
 import           HIndent.Pretty.SigBindFamily
 import           HIndent.Pretty.Types
 import           HIndent.Printer
-import           Language.Haskell.GhclibParserEx.GHC.Hs.Expr
+import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr as GHC
 import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 import qualified Data.Foldable                               as NonEmpty
@@ -1712,8 +1712,7 @@ instance Pretty InfixApp where
               "The number of the sum of operants and operators should be odd."
       prettyOps _ = error "Too short list."
       findFixity o =
-        fromMaybe GHC.defaultFixity $
-        lookup (Language.Haskell.GhclibParserEx.GHC.Hs.Expr.varToStr o) fixities
+        fromMaybe GHC.defaultFixity $ lookup (GHC.varToStr o) fixities
       allOperantsAndOperatorsLeftAssoc = reverse $ rhs : op : collect lhs
         where
           collect :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -38,7 +38,7 @@ import           GHC.Types.Name
 import qualified GHC.Types.Name.Reader                       as GHC
 import qualified GHC.Types.SourceText                        as GHC
 import qualified GHC.Types.SrcLoc                            as GHC
-import           GHC.Unit.Module.Warnings
+import qualified GHC.Unit.Module.Warnings                    as GHC
 import           HIndent.Applicative
 import           HIndent.Ast.NodeComments
 import           HIndent.Config
@@ -2004,10 +2004,8 @@ instance Pretty (WarnDecl GhcPs) where
 instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
-      GHC.Unit.Module.Warnings.DeprecatedTxt _ reasons ->
-        prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.Unit.Module.Warnings.WarningTxt _ reasons ->
-        prettyWithTitleReasons "WARNING" reasons
+      GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
+      GHC.WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -55,7 +55,7 @@ import qualified Data.Foldable                               as NonEmpty
 import           GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import           GHC.Unit
+import qualified GHC.Unit                                    as GHC
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -1898,7 +1898,7 @@ instance Pretty VerticalContext where
 #endif
 -- Wrap a value of this type with 'ModulenameWithPrefix' to print it with
 -- the "module " prefix.
-instance Pretty GHC.Unit.ModuleName where
+instance Pretty GHC.ModuleName where
   pretty' = output
 
 instance Pretty ModuleNameWithPrefix where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -260,7 +260,12 @@ prettyTyClDecl GHC.ClassDecl {..} = do
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
-      mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
+      mkSortedLSigBindFamilyList
+        tcdSigs
+        (GHC.Data.Bag.bagToList tcdMeths)
+        tcdATs
+        []
+        []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
   pretty' GHC.ClsInstD {..}     = pretty cid_inst
@@ -508,7 +513,7 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       sigsAndMethods =
         mkSortedLSigBindFamilyList
           cid_sigs
-          (bagToList cid_binds)
+          (GHC.Data.Bag.bagToList cid_binds)
           []
           cid_tyfam_insts
           cid_datafam_insts
@@ -1559,7 +1564,12 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
   pretty' (GHC.ValBinds _ methods sigs) = lined $ fmap pretty sigsAndMethods
     where
       sigsAndMethods =
-        mkSortedLSigBindFamilyList sigs (bagToList methods) [] [] []
+        mkSortedLSigBindFamilyList
+          sigs
+          (GHC.Data.Bag.bagToList methods)
+          []
+          []
+          []
   pretty' GHC.XValBindsLR {} = notUsedInParsedStage
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -149,9 +149,9 @@ prettyTyClDecl (GHC.FamDecl _ x) = pretty x
 prettyTyClDecl GHC.SynDecl {..} = do
   string "type "
   case tcdFixity of
-    Prefix ->
+    GHC.Types.Fixity.Prefix ->
       spaced $ pretty tcdLName : fmap pretty (GHC.hsq_explicit tcdTyVars)
-    Infix ->
+    GHC.Types.Fixity.Infix ->
       case GHC.hsq_explicit tcdTyVars of
         (l:r:xs) -> do
           spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
@@ -247,9 +247,9 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         indentedBlock $ string "where"
     printNameAndTypeVariables =
       case tcdFixity of
-        Prefix ->
+        GHC.Types.Fixity.Prefix ->
           spaced $ pretty tcdLName : fmap pretty (GHC.hsq_explicit tcdTyVars)
-        Infix ->
+        GHC.Types.Fixity.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
               parens $
@@ -1057,11 +1057,11 @@ prettyMatchExpr Match {m_ctxt = LamCaseAlt {}, ..} = do
 #endif
 prettyMatchExpr GHC.Match {..} =
   case GHC.mc_fixity m_ctxt of
-    Prefix -> do
+    GHC.Types.Fixity.Prefix -> do
       pretty m_ctxt
       spacePrefixed $ fmap pretty m_pats
       pretty m_grhss
-    Infix -> do
+    GHC.Types.Fixity.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
           spaced $
@@ -1671,9 +1671,9 @@ instance Pretty InfixApp where
       horizontal = spaced [pretty lhs, pretty (InfixExpr op), pretty rhs]
       vertical =
         case findFixity op of
-          Fixity _ _ InfixL -> leftAssoc
-          Fixity _ _ InfixR -> rightAssoc
-          Fixity _ _ InfixN -> noAssoc
+          GHC.Types.Fixity.Fixity _ _ GHC.Types.Fixity.InfixL -> leftAssoc
+          GHC.Types.Fixity.Fixity _ _ GHC.Types.Fixity.InfixR -> rightAssoc
+          GHC.Types.Fixity.Fixity _ _ GHC.Types.Fixity.InfixN -> noAssoc
       leftAssoc = prettyOps allOperantsAndOperatorsLeftAssoc
       rightAssoc = prettyOps allOperantsAndOperatorsRightAssoc
       noAssoc
@@ -1706,7 +1706,8 @@ instance Pretty InfixApp where
             error
               "The number of the sum of operants and operators should be odd."
       prettyOps _ = error "Too short list."
-      findFixity o = fromMaybe defaultFixity $ lookup (varToStr o) fixities
+      findFixity o =
+        fromMaybe GHC.Types.Fixity.defaultFixity $ lookup (varToStr o) fixities
       allOperantsAndOperatorsLeftAssoc = reverse $ rhs : op : collect lhs
         where
           collect :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]
@@ -1719,8 +1720,9 @@ instance Pretty InfixApp where
           collect (L _ (GHC.OpApp _ l o r))
             | isSameAssoc o = l : o : collect r
           collect x = [x]
-      isSameAssoc (findFixity -> Fixity _ lv d) = lv == level && d == dir
-      Fixity _ level dir = findFixity op
+      isSameAssoc (findFixity -> GHC.Types.Fixity.Fixity _ lv d) =
+        lv == level && d == dir
+      GHC.Types.Fixity.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
   pretty' (Var x)    = pretty x
@@ -2251,13 +2253,14 @@ instance Pretty (GHC.FixitySig GHC.GhcPs) where
   pretty' (GHC.FixitySig _ names fixity) =
     spaced [pretty fixity, hCommaSep $ fmap (pretty . fmap InfixOp) names]
 
-instance Pretty GHC.Fixity where
-  pretty' (Fixity _ level dir) = spaced [pretty dir, string $ show level]
+instance Pretty GHC.Types.Fixity.Fixity where
+  pretty' (GHC.Types.Fixity.Fixity _ level dir) =
+    spaced [pretty dir, string $ show level]
 
-instance Pretty FixityDirection where
-  pretty' InfixL = string "infixl"
-  pretty' InfixR = string "infixr"
-  pretty' InfixN = string "infix"
+instance Pretty GHC.Types.Fixity.FixityDirection where
+  pretty' GHC.Types.Fixity.InfixL = string "infixl"
+  pretty' GHC.Types.Fixity.InfixR = string "infixr"
+  pretty' GHC.Types.Fixity.InfixN = string "infix"
 
 instance Pretty GHC.InlinePragma where
   pretty' GHC.InlinePragma {..} = do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -534,7 +534,8 @@ prettyHsExpr (GHC.HsUnboundVar _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsOverLabel _ _ l) = string "#" >> string (unpackFS l)
 #else
-prettyHsExpr (GHC.HsOverLabel _ l) = string "#" >> string (unpackFS l)
+prettyHsExpr (GHC.HsOverLabel _ l) =
+  string "#" >> string (GHC.Data.FastString.unpackFS l)
 #endif
 prettyHsExpr (GHC.HsIPVar _ var) = string "?" >> pretty var
 prettyHsExpr (GHC.HsOverLit _ x) = pretty x
@@ -1453,7 +1454,8 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
     brackets $ do
       pretty l
       wrapWithBars $
-        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ unpackFS r
+        indentedWithFixedLevel 0 $
+        sequence_ $ printers [] "" $ GHC.Data.FastString.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -2042,7 +2044,8 @@ instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel (string . unpackFS)
 #else
 instance Pretty (GHC.HsFieldLabel GHC.GhcPs) where
-  pretty' GHC.HsFieldLabel {..} = printCommentsAnd hflLabel (string . unpackFS)
+  pretty' GHC.HsFieldLabel {..} =
+    printCommentsAnd hflLabel (string . GHC.Data.FastString.unpackFS)
 #endif
 instance Pretty (GHC.RuleDecls GHC.GhcPs) where
   pretty' GHC.HsRules {..} =
@@ -2070,7 +2073,9 @@ instance Pretty (RuleDecl GhcPs) where
 instance Pretty (GHC.RuleDecl GHC.GhcPs) where
   pretty' GHC.HsRule {..} =
     spaced
-      [ printCommentsAnd rd_name (doubleQuotes . string . unpackFS . snd)
+      [ printCommentsAnd
+          rd_name
+          (doubleQuotes . string . GHC.Data.FastString.unpackFS . snd)
       , lhs
       , string "="
       , pretty rd_rhs
@@ -2297,7 +2302,7 @@ instance Pretty (GHC.HsOverLit GHC.GhcPs) where
 instance Pretty GHC.OverLitVal where
   pretty' (GHC.HsIntegral x)   = pretty x
   pretty' (GHC.HsFractional x) = pretty x
-  pretty' (GHC.HsIsString _ x) = string $ unpackFS x
+  pretty' (GHC.HsIsString _ x) = string $ GHC.Data.FastString.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
@@ -2346,7 +2351,7 @@ instance Pretty (GHC.HsPragE GHC.GhcPs) where
     spaced [string "{-# SCC", pretty x, string "#-}"]
 #endif
 instance Pretty GHC.HsIPName where
-  pretty' (GHC.HsIPName x) = string $ unpackFS x
+  pretty' (GHC.HsIPName x) = string $ GHC.Data.FastString.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
   pretty' (HsNumTy _ x)  = string $ show x

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2171,13 +2171,13 @@ instance Pretty GHC.ForeignExport where
     spaced [pretty conv, string s]
   pretty' (GHC.CExport conv _) = pretty conv
 #endif
-instance Pretty CExportSpec where
-  pretty' (CExportStatic _ _ x) = pretty x
+instance Pretty GHC.Types.ForeignCall.CExportSpec where
+  pretty' (GHC.Types.ForeignCall.CExportStatic _ _ x) = pretty x
 
-instance Pretty Safety where
-  pretty' PlaySafe          = string "safe"
-  pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky         = string "unsafe"
+instance Pretty GHC.Types.ForeignCall.Safety where
+  pretty' GHC.Types.ForeignCall.PlaySafe          = string "safe"
+  pretty' GHC.Types.ForeignCall.PlayInterruptible = string "interruptible"
+  pretty' GHC.Types.ForeignCall.PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2481,12 +2481,12 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
   pretty' (GHC.RuleBndrSig _ name sig) =
     parens $ spaced [pretty name, string "::", pretty sig]
 
-instance Pretty CCallConv where
-  pretty' CCallConv          = string "ccall"
-  pretty' CApiConv           = string "capi"
-  pretty' StdCallConv        = string "stdcall"
-  pretty' PrimCallConv       = string "prim"
-  pretty' JavaScriptCallConv = string "javascript"
+instance Pretty GHC.Types.ForeignCall.CCallConv where
+  pretty' GHC.Types.ForeignCall.CCallConv          = string "ccall"
+  pretty' GHC.Types.ForeignCall.CApiConv           = string "capi"
+  pretty' GHC.Types.ForeignCall.StdCallConv        = string "stdcall"
+  pretty' GHC.Types.ForeignCall.PrimCallConv       = string "prim"
+  pretty' GHC.Types.ForeignCall.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
   pretty' (GHC.HsSrcBang _ unpack strictness) = do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2208,10 +2208,10 @@ instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
     [string "type role", pretty name] ++
     fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
-instance Pretty Role where
-  pretty' Nominal          = string "nominal"
-  pretty' Representational = string "representational"
-  pretty' Phantom          = string "phantom"
+instance Pretty GHC.Core.Coercion.Role where
+  pretty' GHC.Core.Coercion.Nominal          = string "nominal"
+  pretty' GHC.Core.Coercion.Representational = string "representational"
+  pretty' GHC.Core.Coercion.Phantom          = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2176,10 +2176,10 @@ instance Pretty (GHC.ForeignImport GHC.GhcPs) where
     spaced [pretty conv, pretty safety, output s]
   pretty' (GHC.CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
-instance Pretty (ForeignImport GhcPs) where
-  pretty' (CImport (L _ (SourceText s)) conv safety _ _) =
+instance Pretty (GHC.ForeignImport GHC.GhcPs) where
+  pretty' (GHC.CImport (GHC.L _ (GHC.SourceText s)) conv safety _ _) =
     spaced [pretty conv, pretty safety, string s]
-  pretty' (CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
+  pretty' (GHC.CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #else
 instance Pretty GHC.ForeignImport where
   pretty' (GHC.CImport conv safety _ _ (GHC.L _ (GHC.SourceText s))) =
@@ -2193,9 +2193,10 @@ instance Pretty (GHC.ForeignExport GHC.GhcPs) where
     spaced [pretty conv, output s]
   pretty' (GHC.CExport _ conv) = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
-instance Pretty (ForeignExport GhcPs) where
-  pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv) = pretty conv
+instance Pretty (GHC.ForeignExport GHC.GhcPs) where
+  pretty' (GHC.CExport (GHC.L _ (GHC.SourceText s)) conv) =
+    spaced [pretty conv, string s]
+  pretty' (GHC.CExport _ conv) = pretty conv
 #else
 instance Pretty GHC.ForeignExport where
   pretty' (GHC.CExport conv (GHC.L _ (GHC.SourceText s))) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -128,28 +128,28 @@ class CommentExtraction a =>
 instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
-instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d) = pretty d
-  pretty' (InstD _ inst) = pretty inst
-  pretty' (DerivD _ x) = pretty x
-  pretty' (ValD _ bind) = pretty bind
-  pretty' (SigD _ s) = pretty s
-  pretty' (KindSigD _ x) = pretty x
-  pretty' (DefD _ x) = pretty x
-  pretty' (ForD _ x) = pretty x
-  pretty' (WarningD _ x) = pretty x
-  pretty' (AnnD _ x) = pretty x
-  pretty' (RuleD _ x) = pretty x
-  pretty' (SpliceD _ sp) = pretty sp
-  pretty' DocD {} = docNode
-  pretty' (RoleAnnotD _ x) = pretty x
+instance Pretty (GHC.Hs.HsDecl GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.TyClD _ d) = pretty d
+  pretty' (GHC.Hs.InstD _ inst) = pretty inst
+  pretty' (GHC.Hs.DerivD _ x) = pretty x
+  pretty' (GHC.Hs.ValD _ bind) = pretty bind
+  pretty' (GHC.Hs.SigD _ s) = pretty s
+  pretty' (GHC.Hs.KindSigD _ x) = pretty x
+  pretty' (GHC.Hs.DefD _ x) = pretty x
+  pretty' (GHC.Hs.ForD _ x) = pretty x
+  pretty' (GHC.Hs.WarningD _ x) = pretty x
+  pretty' (GHC.Hs.AnnD _ x) = pretty x
+  pretty' (GHC.Hs.RuleD _ x) = pretty x
+  pretty' (GHC.Hs.SpliceD _ sp) = pretty sp
+  pretty' GHC.Hs.DocD {} = docNode
+  pretty' (GHC.Hs.RoleAnnotD _ x) = pretty x
 
-instance Pretty (TyClDecl GhcPs) where
+instance Pretty (GHC.Hs.TyClDecl GHC.Hs.GhcPs) where
   pretty' = prettyTyClDecl
 
-prettyTyClDecl :: TyClDecl GhcPs -> Printer ()
-prettyTyClDecl (FamDecl _ x) = pretty x
-prettyTyClDecl SynDecl {..} = do
+prettyTyClDecl :: GHC.Hs.TyClDecl GHC.Hs.GhcPs -> Printer ()
+prettyTyClDecl (GHC.Hs.FamDecl _ x) = pretty x
+prettyTyClDecl GHC.Hs.SynDecl {..} = do
   string "type "
   case tcdFixity of
     Prefix -> spaced $ pretty tcdLName : fmap pretty (hsq_explicit tcdTyVars)
@@ -196,7 +196,7 @@ prettyTyClDecl DataDecl {..} = do
         DataType -> string "data "
         NewType -> string "newtype "
 #else
-prettyTyClDecl DataDecl {..} = do
+prettyTyClDecl GHC.Hs.DataDecl {..} = do
   printDataNewtype |=> do
     whenJust (dd_ctxt tcdDataDefn) $ \_ -> do
       pretty $ Context $ dd_ctxt tcdDataDefn
@@ -208,10 +208,10 @@ prettyTyClDecl DataDecl {..} = do
   where
     printDataNewtype =
       case dd_ND tcdDataDefn of
-        DataType -> string "data "
-        NewType -> string "newtype "
+        GHC.Hs.DataType -> string "data "
+        GHC.Hs.NewType -> string "newtype "
 #endif
-prettyTyClDecl ClassDecl {..} = do
+prettyTyClDecl GHC.Hs.ClassDecl {..} = do
   if isJust tcdCtxt
     then verHead
     else horHead <-|> verHead
@@ -222,8 +222,8 @@ prettyTyClDecl ClassDecl {..} = do
       printNameAndTypeVariables
       unless (null tcdFDs) $ do
         string " | "
-        forM_ tcdFDs $ \x@(L _ FunDep {}) ->
-          printCommentsAnd x $ \(FunDep _ from to) ->
+        forM_ tcdFDs $ \x@(L _ GHC.Hs.FunDep {}) ->
+          printCommentsAnd x $ \(GHC.Hs.FunDep _ from to) ->
             spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to
       unless (null sigsMethodsFamilies) $ string " where"
     verHead = do
@@ -241,8 +241,8 @@ prettyTyClDecl ClassDecl {..} = do
         indentedBlock
           $ string "| "
               |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
-                       printCommentsAnd x $ \(FunDep _ from to) ->
+                    (flip fmap tcdFDs $ \x@(L _ GHC.Hs.FunDep {}) ->
+                       printCommentsAnd x $ \(GHC.Hs.FunDep _ from to) ->
                          spaced
                            $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
@@ -262,22 +262,22 @@ prettyTyClDecl ClassDecl {..} = do
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
 
-instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..} = pretty cid_inst
-  pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+instance Pretty (GHC.Hs.InstDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.ClsInstD {..} = pretty cid_inst
+  pretty' GHC.Hs.DataFamInstD {..} = pretty dfid_inst
+  pretty' GHC.Hs.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
-instance Pretty (HsBind GhcPs) where
+instance Pretty (GHC.Hs.HsBind GHC.Hs.GhcPs) where
   pretty' = prettyHsBind
 
-prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..} = pretty fun_matches
-prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {} = notGeneratedByParser
+prettyHsBind :: GHC.Hs.HsBind GHC.Hs.GhcPs -> Printer ()
+prettyHsBind GHC.Hs.FunBind {..} = pretty fun_matches
+prettyHsBind GHC.Hs.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.Hs.VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {} = notGeneratedByParser
+prettyHsBind GHC.Hs.AbsBinds {} = notGeneratedByParser
 #endif
-prettyHsBind (PatSynBind _ x) = pretty x
+prettyHsBind (GHC.Hs.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (Sig GhcPs) where
   pretty' (TypeSig _ funName params) = do
@@ -347,8 +347,8 @@ instance Pretty (Sig GhcPs) where
       , string "#-}"
       ]
 #else
-instance Pretty (Sig GhcPs) where
-  pretty' (TypeSig _ funName params) = do
+instance Pretty (GHC.Hs.Sig GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.TypeSig _ funName params) = do
     printFunName
     string " ::"
     horizontal <-|> vertical
@@ -368,17 +368,17 @@ instance Pretty (Sig GhcPs) where
               $ pretty
               $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
-  pretty' (PatSynSig _ names sig) =
+  pretty' (GHC.Hs.PatSynSig _ names sig) =
     spaced
       [string "pattern", hCommaSep $ fmap pretty names, string "::", pretty sig]
-  pretty' (ClassOpSig _ True funNames params) =
+  pretty' (GHC.Hs.ClassOpSig _ True funNames params) =
     spaced
       [ string "default"
       , hCommaSep $ fmap pretty funNames
       , string "::"
       , printCommentsAnd params pretty
       ]
-  pretty' (ClassOpSig _ False funNames params) = do
+  pretty' (GHC.Hs.ClassOpSig _ False funNames params) = do
     hCommaSep $ fmap pretty funNames
     string " ::"
     hor <-|> ver
@@ -389,11 +389,11 @@ instance Pretty (Sig GhcPs) where
         indentedBlock
           $ indentedWithSpace 3
           $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
-  pretty' IdSig {} = notGeneratedByParser
-  pretty' (FixSig _ x) = pretty x
-  pretty' (InlineSig _ name detail) =
+  pretty' GHC.Hs.IdSig {} = notGeneratedByParser
+  pretty' (GHC.Hs.FixSig _ x) = pretty x
+  pretty' (GHC.Hs.InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
-  pretty' (SpecSig _ name sigs _) =
+  pretty' (GHC.Hs.SpecSig _ name sigs _) =
     spaced
       [ string "{-# SPECIALISE"
       , pretty name
@@ -401,15 +401,15 @@ instance Pretty (Sig GhcPs) where
       , hCommaSep $ fmap pretty sigs
       , string "#-}"
       ]
-  pretty' (SpecInstSig _ _ sig) =
+  pretty' (GHC.Hs.SpecInstSig _ _ sig) =
     spaced [string "{-# SPECIALISE instance", pretty sig, string "#-}"]
-  pretty' (MinimalSig _ _ xs) =
+  pretty' (GHC.Hs.MinimalSig _ _ xs) =
     string "{-# MINIMAL " |=> do
       pretty xs
       string " #-}"
-  pretty' (SCCFunSig _ _ name _) =
+  pretty' (GHC.Hs.SCCFunSig _ _ name _) =
     spaced [string "{-# SCC", pretty name, string "#-}"]
-  pretty' (CompleteMatchSig _ _ names _) =
+  pretty' (GHC.Hs.CompleteMatchSig _ _ names _) =
     spaced
       [ string "{-# COMPLETE"
       , printCommentsAnd names (hCommaSep . fmap pretty)
@@ -457,8 +457,8 @@ instance Pretty (HsDataDefn GhcPs) where
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
 #else
-instance Pretty (HsDataDefn GhcPs) where
-  pretty' HsDataDefn {..} =
+instance Pretty (GHC.Hs.HsDataDefn GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsDataDefn {..} =
     if isGADT
       then do
         whenJust dd_kindSig $ \x -> do
@@ -469,7 +469,7 @@ instance Pretty (HsDataDefn GhcPs) where
       else do
         case dd_cons of
           [] -> indentedBlock derivingsAfterNewline
-          [x@(L _ ConDeclH98 {con_args = RecCon {}})] -> do
+          [x@(L _ GHC.Hs.ConDeclH98 {con_args = GHC.Hs.RecCon {}})] -> do
             string " = "
             pretty x
             unless (null dd_derivs) $ space |=> printDerivings
@@ -487,14 +487,14 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       isGADT =
         case dd_cons of
-          (L _ ConDeclGADT {}:_) -> True
+          (L _ GHC.Hs.ConDeclGADT {}:_) -> True
           _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
 #endif
-instance Pretty (ClsInstDecl GhcPs) where
-  pretty' ClsInstDecl {..} = do
+instance Pretty (GHC.Hs.ClsInstDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.ClsInstDecl {..} = do
     string "instance " |=> do
       whenJust cid_overlap_mode $ \x -> do
         pretty x
@@ -513,34 +513,40 @@ instance Pretty (ClsInstDecl GhcPs) where
           cid_tyfam_insts
           cid_datafam_insts
 
-instance Pretty (MatchGroup GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
-  pretty' MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
+instance Pretty
+           (GHC.Hs.MatchGroup
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
 
-instance Pretty (MatchGroup GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
-  pretty' MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
+instance Pretty
+           (GHC.Hs.MatchGroup
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.MG {..} = printCommentsAnd mg_alts (lined . fmap pretty)
 
-instance Pretty (HsExpr GhcPs) where
+instance Pretty (GHC.Hs.HsExpr GHC.Hs.GhcPs) where
   pretty' = prettyHsExpr
 
-prettyHsExpr :: HsExpr GhcPs -> Printer ()
-prettyHsExpr (HsVar _ bind) = pretty $ fmap PrefixOp bind
-prettyHsExpr (HsUnboundVar _ x) = pretty x
+prettyHsExpr :: GHC.Hs.HsExpr GHC.Hs.GhcPs -> Printer ()
+prettyHsExpr (GHC.Hs.HsVar _ bind) = pretty $ fmap PrefixOp bind
+prettyHsExpr (GHC.Hs.HsUnboundVar _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsOverLabel _ _ l) = string "#" >> string (unpackFS l)
 #else
-prettyHsExpr (HsOverLabel _ l) = string "#" >> string (unpackFS l)
+prettyHsExpr (GHC.Hs.HsOverLabel _ l) = string "#" >> string (unpackFS l)
 #endif
-prettyHsExpr (HsIPVar _ var) = string "?" >> pretty var
-prettyHsExpr (HsOverLit _ x) = pretty x
-prettyHsExpr (HsLit _ l) = pretty l
-prettyHsExpr (HsLam _ body) = pretty body
+prettyHsExpr (GHC.Hs.HsIPVar _ var) = string "?" >> pretty var
+prettyHsExpr (GHC.Hs.HsOverLit _ x) = pretty x
+prettyHsExpr (GHC.Hs.HsLit _ l) = pretty l
+prettyHsExpr (GHC.Hs.HsLam _ body) = pretty body
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLamCase _ LamCase matches) = pretty $ LambdaCase matches Case
 prettyHsExpr (HsLamCase _ LamCases matches) = pretty $ LambdaCase matches Cases
 #else
-prettyHsExpr (HsLamCase _ matches) = pretty $ LambdaCase matches Case
+prettyHsExpr (GHC.Hs.HsLamCase _ matches) = pretty $ LambdaCase matches Case
 #endif
-prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
+prettyHsExpr (GHC.Hs.HsApp _ l r) = horizontal <-|> vertical
   where
     horizontal = spaced [pretty l, pretty r]
     vertical = do
@@ -563,12 +569,15 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
         else newline
       spaces' <- getIndentSpaces
       indentedWithSpace spaces' $ lined $ fmap pretty args
-    flatten :: LHsExpr GhcPs -> [LHsExpr GhcPs]
-    flatten (L (SrcSpanAnn (EpAnn _ _ cs) _) (HsApp _ l' r')) =
+    flatten :: GHC.Hs.LHsExpr GHC.Hs.GhcPs -> [GHC.Hs.LHsExpr GHC.Hs.GhcPs]
+    flatten (L (GHC.Hs.SrcSpanAnn (GHC.Hs.EpAnn _ _ cs) _) (GHC.Hs.HsApp _ l' r')) =
       flatten l' ++ [insertComments cs r']
     flatten x = [x]
-    insertComments :: EpAnnComments -> LHsExpr GhcPs -> LHsExpr GhcPs
-    insertComments cs (L s@SrcSpanAnn {ann = e@EpAnn {comments = cs'}} r') =
+    insertComments ::
+         GHC.Hs.EpAnnComments
+      -> GHC.Hs.LHsExpr GHC.Hs.GhcPs
+      -> GHC.Hs.LHsExpr GHC.Hs.GhcPs
+    insertComments cs (L s@GHC.Hs.SrcSpanAnn {ann = e@GHC.Hs.EpAnn {comments = cs'}} r') =
       L (s {ann = e {comments = cs <> cs'}}) r'
     insertComments _ x = x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -577,30 +586,31 @@ prettyHsExpr (HsAppType _ l _ r) = do
   string " @"
   pretty r
 #else
-prettyHsExpr (HsAppType _ l r) = do
+prettyHsExpr (GHC.Hs.HsAppType _ l r) = do
   pretty l
   string " @"
   pretty r
 #endif
-prettyHsExpr (OpApp _ l o r) = pretty (InfixApp l o r)
-prettyHsExpr (NegApp _ x _) = string "-" >> pretty x
+prettyHsExpr (GHC.Hs.OpApp _ l o r) = pretty (InfixApp l o r)
+prettyHsExpr (GHC.Hs.NegApp _ x _) = string "-" >> pretty x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsPar _ _ expr _) = parens $ pretty expr
 #else
-prettyHsExpr (HsPar _ expr) = parens $ pretty expr
+prettyHsExpr (GHC.Hs.HsPar _ expr) = parens $ pretty expr
 #endif
-prettyHsExpr (SectionL _ l o) = spaced [pretty l, pretty (InfixExpr o)]
-prettyHsExpr (SectionR _ o r) = (pretty (InfixExpr o) >> space) |=> pretty r
-prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
+prettyHsExpr (GHC.Hs.SectionL _ l o) = spaced [pretty l, pretty (InfixExpr o)]
+prettyHsExpr (GHC.Hs.SectionR _ o r) =
+  (pretty (InfixExpr o) >> space) |=> pretty r
+prettyHsExpr (GHC.Hs.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
       parens
         $ prefixedLined ","
         $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
-    isMissing Missing {} = True
+    isMissing GHC.Hs.Missing {} = True
     isMissing _ = False
-prettyHsExpr (ExplicitSum _ position numElem expr) = do
+prettyHsExpr (GHC.Hs.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
     if idx == position
@@ -608,7 +618,7 @@ prettyHsExpr (ExplicitSum _ position numElem expr) = do
       else string " "
     when (idx < numElem) $ string "|"
   string "#)"
-prettyHsExpr (HsCase _ cond arms) = do
+prettyHsExpr (GHC.Hs.HsCase _ cond arms) = do
   string "case " |=> do
     pretty cond
     string " of"
@@ -617,15 +627,17 @@ prettyHsExpr (HsCase _ cond arms) = do
     else do
       newline
       indentedBlock $ pretty arms
-prettyHsExpr (HsIf _ cond t f) = do
+prettyHsExpr (GHC.Hs.HsIf _ cond t f) = do
   string "if " |=> pretty cond
   indentedBlock $ newlinePrefixed [branch "then " t, branch "else " f]
   where
-    branch :: String -> LHsExpr GhcPs -> Printer ()
+    branch :: String -> GHC.Hs.LHsExpr GHC.Hs.GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ (DoExpr m) xs)) -> doStmt (QualifiedDo m Do) xs
-        (L _ (HsDo _ (MDoExpr m) xs)) -> doStmt (QualifiedDo m Mdo) xs
+        (L _ (GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) xs)) ->
+          doStmt (QualifiedDo m Do) xs
+        (L _ (GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) xs)) ->
+          doStmt (QualifiedDo m Mdo) xs
         _ -> string str |=> pretty e
       where
         doStmt qDo stmts = do
@@ -633,33 +645,34 @@ prettyHsExpr (HsIf _ cond t f) = do
           pretty qDo
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
-prettyHsExpr (HsMultiIf _ guards) =
+prettyHsExpr (GHC.Hs.HsMultiIf _ guards) =
   string "if "
     |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
-prettyHsExpr (HsLet _ binds exprs) = pretty $ LetIn binds exprs
+prettyHsExpr (GHC.Hs.HsLet _ binds exprs) = pretty $ LetIn binds exprs
 #endif
-prettyHsExpr (HsDo _ ListComp {} (L _ [])) =
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ListComp {} (L _ [])) =
   error "Not enough arguments are passed to pretty-print a list comprehension."
-prettyHsExpr (HsDo _ ListComp {} (L l (lhs:rhs))) =
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ListComp {} (L l (lhs:rhs))) =
   pretty $ L l $ ListComprehension lhs rhs
 -- While the name contains 'Monad', 'MonadComp' is for list comprehensions.
-prettyHsExpr (HsDo _ MonadComp {} (L _ [])) =
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.MonadComp {} (L _ [])) =
   error "Not enough arguments are passed to pretty-print a list comprehension."
-prettyHsExpr (HsDo _ MonadComp {} (L l (lhs:rhs))) =
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.MonadComp {} (L l (lhs:rhs))) =
   pretty $ L l $ ListComprehension lhs rhs
-prettyHsExpr (HsDo _ (DoExpr m) (L l xs)) =
+prettyHsExpr (GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) (L l xs)) =
   pretty $ L l $ DoExpression xs (QualifiedDo m Do)
-prettyHsExpr (HsDo _ (MDoExpr m) (L l xs)) =
+prettyHsExpr (GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) (L l xs)) =
   pretty $ L l $ DoExpression xs (QualifiedDo m Mdo)
-prettyHsExpr (HsDo _ GhciStmtCtxt {} _) = error "We're not using GHCi, are we?"
-prettyHsExpr (ExplicitList _ xs) = horizontal <-|> vertical
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.GhciStmtCtxt {} _) =
+  error "We're not using GHCi, are we?"
+prettyHsExpr (GHC.Hs.ExplicitList _ xs) = horizontal <-|> vertical
   where
     horizontal = brackets $ hCommaSep $ fmap pretty xs
     vertical = vList $ fmap pretty xs
-prettyHsExpr (RecordCon _ name fields) = horizontal <-|> vertical
+prettyHsExpr (GHC.Hs.RecordCon _ name fields) = horizontal <-|> vertical
   where
     horizontal = spaced [pretty name, pretty fields]
     vertical = do
@@ -722,7 +735,7 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
       newline
       indentedBlock $ pretty hfbRHS
 #else
-prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
+prettyHsExpr (GHC.Hs.RecordUpd _ name fields) = hor <-|> ver
   where
     hor = spaced [pretty name, either printHorFields printHorFields fields]
     ver = do
@@ -733,73 +746,73 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
             <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
-      => [GenLocated l (HsRecField' a b)]
+      => [GenLocated l (GHC.Hs.HsRecField' a b)]
       -> Printer ()
     printHorFields = hFields . fmap (`printCommentsAnd` horField)
     printVerFields ::
          (Pretty a, Pretty b, CommentExtraction l)
-      => [GenLocated l (HsRecField' a b)]
+      => [GenLocated l (GHC.Hs.HsRecField' a b)]
       -> Printer ()
     printVerFields = vFields . fmap printField
     printField x = printCommentsAnd x $ (<-|>) <$> horField <*> verField
-    horField HsRecField {..} = do
+    horField GHC.Hs.HsRecField {..} = do
       pretty hsRecFieldLbl
       string " = "
       pretty hsRecFieldArg
-    verField HsRecField {..} = do
+    verField GHC.Hs.HsRecField {..} = do
       pretty hsRecFieldLbl
       string " ="
       newline
       indentedBlock $ pretty hsRecFieldArg
 #endif
-prettyHsExpr (HsGetField _ e f) = do
+prettyHsExpr (GHC.Hs.HsGetField _ e f) = do
   pretty e
   dot
   pretty f
-prettyHsExpr HsProjection {..} =
+prettyHsExpr GHC.Hs.HsProjection {..} =
   parens
     $ forM_ proj_flds
     $ \x -> do
         string "."
         pretty x
-prettyHsExpr (ExprWithTySig _ e sig) = do
+prettyHsExpr (GHC.Hs.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
   pretty $ hswc_body sig
-prettyHsExpr (ArithSeq _ _ x) = pretty x
+prettyHsExpr (GHC.Hs.ArithSeq _ _ x) = pretty x
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-prettyHsExpr (HsSpliceE _ x) = pretty x
+prettyHsExpr (GHC.Hs.HsSpliceE _ x) = pretty x
 #endif
-prettyHsExpr (HsProc _ pat x@(L _ (HsCmdTop _ (L _ (HsCmdDo _ xs))))) = do
+prettyHsExpr (GHC.Hs.HsProc _ pat x@(L _ (GHC.Hs.HsCmdTop _ (L _ (GHC.Hs.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
   indentedBlock
     $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
-prettyHsExpr (HsProc _ pat body) = hor <-|> ver
+prettyHsExpr (GHC.Hs.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
     ver = do
       spaced [string "proc", pretty pat, string "->"]
       newline
       indentedBlock (pretty body)
-prettyHsExpr (HsStatic _ x) = spaced [string "static", pretty x]
-prettyHsExpr (HsPragE _ p x) = spaced [pretty p, pretty x]
+prettyHsExpr (GHC.Hs.HsStatic _ x) = spaced [string "static", pretty x]
+prettyHsExpr (GHC.Hs.HsPragE _ p x) = spaced [pretty p, pretty x]
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr HsRecSel {} = notGeneratedByParser
 prettyHsExpr (HsTypedBracket _ inner) = typedBrackets $ pretty inner
 prettyHsExpr (HsUntypedBracket _ inner) = pretty inner
 #else
-prettyHsExpr HsConLikeOut {} = notGeneratedByParser
-prettyHsExpr HsRecFld {} = notGeneratedByParser
-prettyHsExpr (HsDo _ ArrowExpr {} _) = notGeneratedByParser
-prettyHsExpr (HsDo _ PatGuard {} _) = notGeneratedByParser
-prettyHsExpr (HsDo _ ParStmtCtxt {} _) = notGeneratedByParser
-prettyHsExpr (HsDo _ TransStmtCtxt {} _) = notGeneratedByParser
-prettyHsExpr HsTick {} = forHpc
-prettyHsExpr HsBinTick {} = forHpc
-prettyHsExpr (HsBracket _ inner) = pretty inner
-prettyHsExpr HsRnBracketOut {} = notGeneratedByParser
-prettyHsExpr HsTcBracketOut {} = notGeneratedByParser
+prettyHsExpr GHC.Hs.HsConLikeOut {} = notGeneratedByParser
+prettyHsExpr GHC.Hs.HsRecFld {} = notGeneratedByParser
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ArrowExpr {} _) = notGeneratedByParser
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.PatGuard {} _) = notGeneratedByParser
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.ParStmtCtxt {} _) = notGeneratedByParser
+prettyHsExpr (GHC.Hs.HsDo _ GHC.Hs.TransStmtCtxt {} _) = notGeneratedByParser
+prettyHsExpr GHC.Hs.HsTick {} = forHpc
+prettyHsExpr GHC.Hs.HsBinTick {} = forHpc
+prettyHsExpr (GHC.Hs.HsBracket _ inner) = pretty inner
+prettyHsExpr GHC.Hs.HsRnBracketOut {} = notGeneratedByParser
+prettyHsExpr GHC.Hs.HsTcBracketOut {} = notGeneratedByParser
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsTypedSplice _ x) = string "$$" >> pretty x
@@ -816,18 +829,18 @@ instance Pretty LambdaCase where
         newline
         indentedBlock $ pretty matches
 
-instance Pretty (HsSigType GhcPs) where
+instance Pretty (GHC.Hs.HsSigType GHC.Hs.GhcPs) where
   pretty' = pretty' . HsSigType' HsTypeForNormalDecl HsTypeNoDir
 
 instance Pretty HsSigType' where
-  pretty' (HsSigTypeInsideDeclSig HsSig {..}) =
+  pretty' (HsSigTypeInsideDeclSig GHC.Hs.HsSig {..}) =
     case sig_bndrs of
-      HsOuterExplicit _ xs -> do
+      GHC.Hs.HsOuterExplicit _ xs -> do
         string "forall "
         spaced $ fmap pretty xs
         dot
         case unLoc sig_body of
-          HsQualTy {..} ->
+          GHC.Hs.HsQualTy {..} ->
             printCommentsAnd sig_body $ \_ ->
               let hor = do
                     space
@@ -848,26 +861,26 @@ instance Pretty HsSigType' where
              in hor <-|> ver
       _ -> pretty $ fmap HsTypeInsideDeclSig sig_body
     where
-      flatten :: LHsType GhcPs -> [LHsType GhcPs]
-      flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
+      flatten :: GHC.Hs.LHsType GHC.Hs.GhcPs -> [GHC.Hs.LHsType GHC.Hs.GhcPs]
+      flatten (L _ (GHC.Hs.HsFunTy _ _ l r)) = flatten l ++ flatten r
       flatten x = [x]
-  pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
+  pretty' (HsSigTypeInsideVerticalFuncSig GHC.Hs.HsSig {..}) =
     case sig_bndrs of
-      HsOuterExplicit _ xs -> do
+      GHC.Hs.HsOuterExplicit _ xs -> do
         string "forall "
         spaced $ fmap pretty xs
         dot
         printCommentsAnd sig_body $ \case
-          HsQualTy {..} -> do
+          GHC.Hs.HsQualTy {..} -> do
             (space >> pretty (HorizontalContext hst_ctxt))
               <-|> (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
       _ -> pretty $ fmap HsTypeInsideDeclSig sig_body
-  pretty' (HsSigType' for dir HsSig {..}) = do
+  pretty' (HsSigType' for dir GHC.Hs.HsSig {..}) = do
     case sig_bndrs of
-      HsOuterExplicit _ xs -> do
+      GHC.Hs.HsOuterExplicit _ xs -> do
         string "forall "
         spaced $ fmap pretty xs
         dot
@@ -875,10 +888,10 @@ instance Pretty HsSigType' where
       _ -> return ()
     pretty $ HsType' for dir <$> sig_body
 
-instance Pretty (ConDecl GhcPs) where
+instance Pretty (GHC.Hs.ConDecl GHC.Hs.GhcPs) where
   pretty' = prettyConDecl
 
-prettyConDecl :: ConDecl GhcPs -> Printer ()
+prettyConDecl :: GHC.Hs.ConDecl GHC.Hs.GhcPs -> Printer ()
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyConDecl ConDeclGADT {..} = do
   hCommaSep $ fmap pretty $ NonEmpty.toList con_names
@@ -924,7 +937,7 @@ prettyConDecl ConDeclGADT {..} = do
         HsOuterImplicit {} -> False
         HsOuterExplicit {} -> True
 #else
-prettyConDecl ConDeclGADT {..} = do
+prettyConDecl GHC.Hs.ConDeclGADT {..} = do
   hCommaSep $ fmap pretty con_names
   hor <-|> ver
   where
@@ -980,24 +993,24 @@ prettyConDecl ConDeclGADT {..} = do
     
     horArgs =
       case con_g_args of
-        PrefixConGADT xs ->
+        GHC.Hs.PrefixConGADT xs ->
           inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
-        RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
+            $ fmap (\(GHC.Hs.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+        GHC.Hs.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     
     verArgs =
       case con_g_args of
-        PrefixConGADT xs ->
+        GHC.Hs.PrefixConGADT xs ->
           prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
-        RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
+            $ fmap (\(GHC.Hs.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+        GHC.Hs.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     
     forallNeeded =
       case unLoc con_bndrs of
-        HsOuterImplicit {} -> False
-        HsOuterExplicit {} -> True
+        GHC.Hs.HsOuterImplicit {} -> False
+        GHC.Hs.HsOuterExplicit {} -> True
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
@@ -1013,7 +1026,7 @@ prettyConDecl ConDeclH98 {con_forall = True, ..} =
            pretty con_name
            pretty con_args)
 #else
-prettyConDecl ConDeclH98 {con_forall = True, ..} =
+prettyConDecl GHC.Hs.ConDeclH98 {con_forall = True, ..} =
   (do
      string "forall "
      spaced $ fmap pretty con_ex_tvs
@@ -1026,28 +1039,32 @@ prettyConDecl ConDeclH98 {con_forall = True, ..} =
            pretty con_name
            pretty con_args)
 #endif
-prettyConDecl ConDeclH98 {con_forall = False, ..} =
+prettyConDecl GHC.Hs.ConDeclH98 {con_forall = False, ..} =
   case con_args of
-    (InfixCon l r) ->
+    (GHC.Hs.InfixCon l r) ->
       spaced [pretty l, pretty $ fmap InfixOp con_name, pretty r]
     _ -> do
       pretty con_name
       pretty con_args
 
-instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
+instance Pretty
+           (GHC.Hs.Match
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
   pretty' = prettyMatchExpr
 
-prettyMatchExpr :: Match GhcPs (LHsExpr GhcPs) -> Printer ()
-prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
+prettyMatchExpr ::
+     GHC.Hs.Match GHC.Hs.GhcPs (GHC.Hs.LHsExpr GHC.Hs.GhcPs) -> Printer ()
+prettyMatchExpr GHC.Hs.Match {m_ctxt = GHC.Hs.LambdaExpr, ..} = do
   string "\\"
   unless (null m_pats)
     $ case unLoc $ head m_pats of
-        LazyPat {} -> space
-        BangPat {} -> space
+        GHC.Hs.LazyPat {} -> space
+        GHC.Hs.BangPat {} -> space
         _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
-prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
+prettyMatchExpr GHC.Hs.Match {m_ctxt = GHC.Hs.CaseAlt, ..} = do
   mapM_ pretty m_pats
   pretty $ GRHSsExpr GRHSExprCase m_grhss
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1055,7 +1072,7 @@ prettyMatchExpr Match {m_ctxt = LamCaseAlt {}, ..} = do
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprCase m_grhss
 #endif
-prettyMatchExpr Match {..} =
+prettyMatchExpr GHC.Hs.Match {..} =
   case mc_fixity m_ctxt of
     Prefix -> do
       pretty m_ctxt
@@ -1063,26 +1080,30 @@ prettyMatchExpr Match {..} =
       pretty m_grhss
     Infix -> do
       case (m_pats, m_ctxt) of
-        (l:r:xs, FunRhs {..}) -> do
+        (l:r:xs, GHC.Hs.FunRhs {..}) -> do
           spaced
             $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
                 ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
-instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
+instance Pretty
+           (GHC.Hs.Match
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
   pretty' = prettyMatchProc
 
-prettyMatchProc :: Match GhcPs (LHsCmd GhcPs) -> Printer ()
-prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
+prettyMatchProc ::
+     GHC.Hs.Match GHC.Hs.GhcPs (GHC.Hs.LHsCmd GHC.Hs.GhcPs) -> Printer ()
+prettyMatchProc GHC.Hs.Match {m_ctxt = GHC.Hs.LambdaExpr, ..} = do
   string "\\"
   unless (null m_pats)
     $ case unLoc $ head m_pats of
-        LazyPat {} -> space
-        BangPat {} -> space
+        GHC.Hs.LazyPat {} -> space
+        GHC.Hs.BangPat {} -> space
         _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
-prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
+prettyMatchProc GHC.Hs.Match {m_ctxt = GHC.Hs.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyMatchProc Match {m_ctxt = LamCaseAlt {}, ..} = do
@@ -1090,29 +1111,37 @@ prettyMatchProc Match {m_ctxt = LamCaseAlt {}, ..} = do
 #endif
 prettyMatchProc _ = notGeneratedByParser
 
-instance Pretty (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
-  pretty' (LastStmt _ x _ _) = pretty x
-  pretty' (BindStmt _ pat body) = do
+instance Pretty
+           (GHC.Hs.StmtLR
+              GHC.Hs.GhcPs
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+  pretty' (GHC.Hs.LastStmt _ x _ _) = pretty x
+  pretty' (GHC.Hs.BindStmt _ pat body) = do
     pretty pat
     string " <-"
     hor <-|> ver
     where
       hor = space >> pretty body
       ver = newline >> indentedBlock (pretty body)
-  pretty' ApplicativeStmt {} = notGeneratedByParser
-  pretty' (BodyStmt _ (L loc (OpApp _ l o r)) _ _) =
+  pretty' GHC.Hs.ApplicativeStmt {} = notGeneratedByParser
+  pretty' (GHC.Hs.BodyStmt _ (L loc (GHC.Hs.OpApp _ l o r)) _ _) =
     pretty (L loc (InfixApp l o r))
-  pretty' (BodyStmt _ body _ _) = pretty body
-  pretty' (LetStmt _ l) = string "let " |=> pretty l
-  pretty' (ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
-  pretty' TransStmt {..} =
+  pretty' (GHC.Hs.BodyStmt _ body _ _) = pretty body
+  pretty' (GHC.Hs.LetStmt _ l) = string "let " |=> pretty l
+  pretty' (GHC.Hs.ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
+  pretty' GHC.Hs.TransStmt {..} =
     vCommaSep $ fmap pretty trS_stmts ++ [string "then " >> pretty trS_using]
-  pretty' RecStmt {..} =
+  pretty' GHC.Hs.RecStmt {..} =
     string "rec " |=> printCommentsAnd recS_stmts (lined . fmap pretty)
 
-instance Pretty (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
-  pretty' (LastStmt _ x _ _) = pretty x
-  pretty' (BindStmt _ pat body) = hor <-|> ver
+instance Pretty
+           (GHC.Hs.StmtLR
+              GHC.Hs.GhcPs
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
+  pretty' (GHC.Hs.LastStmt _ x _ _) = pretty x
+  pretty' (GHC.Hs.BindStmt _ pat body) = hor <-|> ver
     where
       hor = spaced [pretty pat, string "<-", pretty body]
       ver = do
@@ -1120,23 +1149,26 @@ instance Pretty (StmtLR GhcPs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) wher
         string " <-"
         newline
         indentedBlock $ pretty body
-  pretty' ApplicativeStmt {} = notGeneratedByParser
-  pretty' (BodyStmt _ body _ _) = pretty body
-  pretty' (LetStmt _ l) = string "let " |=> pretty l
-  pretty' (ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
-  pretty' TransStmt {..} =
+  pretty' GHC.Hs.ApplicativeStmt {} = notGeneratedByParser
+  pretty' (GHC.Hs.BodyStmt _ body _ _) = pretty body
+  pretty' (GHC.Hs.LetStmt _ l) = string "let " |=> pretty l
+  pretty' (GHC.Hs.ParStmt _ xs _ _) = hvBarSep $ fmap pretty xs
+  pretty' GHC.Hs.TransStmt {..} =
     vCommaSep $ fmap pretty trS_stmts ++ [string "then " >> pretty trS_using]
-  pretty' RecStmt {..} =
+  pretty' GHC.Hs.RecStmt {..} =
     string "rec " |=> printCommentsAnd recS_stmts (lined . fmap pretty)
 
 instance Pretty StmtLRInsideVerticalList where
-  pretty' (StmtLRInsideVerticalList (ParStmt _ xs _ _)) =
+  pretty' (StmtLRInsideVerticalList (GHC.Hs.ParStmt _ xs _ _)) =
     vBarSep $ fmap (pretty . ParStmtBlockInsideVerticalList) xs
   pretty' (StmtLRInsideVerticalList x) = pretty x
 
 -- | For pattern matching.
-instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
-  pretty' HsRecFields {..} = horizontal <-|> vertical
+instance Pretty
+           (GHC.Hs.HsRecFields
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.Pat GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.HsRecFields {..} = horizontal <-|> vertical
     where
       horizontal =
         case rec_dotdot of
@@ -1145,36 +1177,39 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
       vertical = vFields $ fmap pretty rec_flds
 
 -- | For record updates
-instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
-  pretty' HsRecFields {..} = hvFields fieldPrinters
+instance Pretty
+           (GHC.Hs.HsRecFields
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
         fmap pretty rec_flds
           ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 
-instance Pretty (HsType GhcPs) where
+instance Pretty (GHC.Hs.HsType GHC.Hs.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
 
 instance Pretty HsType' where
-  pretty' (HsTypeInsideVerticalFuncSig (HsFunTy _ _ a b)) = do
+  pretty' (HsTypeInsideVerticalFuncSig (GHC.Hs.HsFunTy _ _ a b)) = do
     pretty $ HsTypeInsideVerticalFuncSig <$> a
     newline
     prefixed "-> " $ pretty $ HsTypeInsideVerticalFuncSig <$> b
-  pretty' (HsTypeInsideDeclSig HsQualTy {..}) = hor <-|> ver
+  pretty' (HsTypeInsideDeclSig GHC.Hs.HsQualTy {..}) = hor <-|> ver
     where
       hor = spaced [pretty $ Context hst_ctxt, string "=>", pretty hst_body]
       ver = do
         pretty $ Context hst_ctxt
         newline
         prefixed "=> " $ pretty $ fmap HsTypeInsideVerticalFuncSig hst_body
-  pretty' (HsTypeInsideDeclSig (HsFunTy _ _ a b)) = hor <-|> ver
+  pretty' (HsTypeInsideDeclSig (GHC.Hs.HsFunTy _ _ a b)) = hor <-|> ver
     where
       hor = spaced [pretty a, string "->", pretty b]
       ver = do
         pretty $ fmap HsTypeInsideVerticalFuncSig a
         newline
         prefixed "-> " $ pretty $ fmap HsTypeInsideVerticalFuncSig b
-  pretty' (HsTypeInsideInstDecl HsQualTy {..}) = hor <-|> ver
+  pretty' (HsTypeInsideInstDecl GHC.Hs.HsQualTy {..}) = hor <-|> ver
     where
       hor = spaced [pretty (Context hst_ctxt), string "=>", pretty hst_body]
       ver = do
@@ -1182,39 +1217,42 @@ instance Pretty HsType' where
         string " =>"
         newline
         pretty hst_body
-  pretty' (HsTypeWithVerticalAppTy (HsAppTy _ l r)) = do
+  pretty' (HsTypeWithVerticalAppTy (GHC.Hs.HsAppTy _ l r)) = do
     pretty $ fmap HsTypeWithVerticalAppTy l
     newline
     indentedBlock $ pretty $ fmap HsTypeWithVerticalAppTy r
   pretty' (HsType' _ _ x) = prettyHsType x
 
-prettyHsType :: HsType GhcPs -> Printer ()
-prettyHsType (HsForAllTy _ tele body) = (pretty tele >> space) |=> pretty body
-prettyHsType HsQualTy {..} = hor <-|> ver
+prettyHsType :: GHC.Hs.HsType GHC.Hs.GhcPs -> Printer ()
+prettyHsType (GHC.Hs.HsForAllTy _ tele body) =
+  (pretty tele >> space) |=> pretty body
+prettyHsType GHC.Hs.HsQualTy {..} = hor <-|> ver
   where
     hor = spaced [pretty $ Context hst_ctxt, string "=>", pretty hst_body]
     ver = do
       pretty $ Context hst_ctxt
       lined [string " =>", indentedBlock $ pretty hst_body]
-prettyHsType (HsTyVar _ NotPromoted x) = pretty x
-prettyHsType (HsTyVar _ IsPromoted x) = string "'" >> pretty x
-prettyHsType x@(HsAppTy _ l r) = hor <-|> ver
+prettyHsType (GHC.Hs.HsTyVar _ NotPromoted x) = pretty x
+prettyHsType (GHC.Hs.HsTyVar _ IsPromoted x) = string "'" >> pretty x
+prettyHsType x@(GHC.Hs.HsAppTy _ l r) = hor <-|> ver
   where
     hor = spaced $ fmap pretty [l, r]
     ver = pretty $ HsTypeWithVerticalAppTy x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 prettyHsType (HsAppKindTy _ l _ r) = pretty l >> string " @" >> pretty r
 #else
-prettyHsType (HsAppKindTy _ l r) = pretty l >> string " @" >> pretty r
+prettyHsType (GHC.Hs.HsAppKindTy _ l r) = pretty l >> string " @" >> pretty r
 #endif
-prettyHsType (HsFunTy _ _ a b) = (pretty a >> string " -> ") |=> pretty b
-prettyHsType (HsListTy _ xs) = brackets $ pretty xs
-prettyHsType (HsTupleTy _ HsUnboxedTuple []) = string "(# #)"
-prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple []) = string "()"
-prettyHsType (HsTupleTy _ HsUnboxedTuple xs) = hvUnboxedTuple' $ fmap pretty xs
-prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple xs) =
+prettyHsType (GHC.Hs.HsFunTy _ _ a b) = (pretty a >> string " -> ") |=> pretty b
+prettyHsType (GHC.Hs.HsListTy _ xs) = brackets $ pretty xs
+prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsUnboxedTuple []) = string "(# #)"
+prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsBoxedOrConstraintTuple []) =
+  string "()"
+prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsUnboxedTuple xs) =
+  hvUnboxedTuple' $ fmap pretty xs
+prettyHsType (GHC.Hs.HsTupleTy _ GHC.Hs.HsBoxedOrConstraintTuple xs) =
   hvTuple' $ fmap pretty xs
-prettyHsType (HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs
+prettyHsType (GHC.Hs.HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs
 -- For `HsOpTy`, we do not need a single quote for the infix operator. An
 -- explicit promotion is necessary if there is a data constructor and
 -- a type with the same name. However, infix data constructors never
@@ -1232,7 +1270,7 @@ prettyHsType (HsOpTy _ _ l op r) = do
       pretty r
     else spaced [pretty l, pretty $ fmap InfixOp op, pretty r]
 #else
-prettyHsType (HsOpTy _ l op r) = do
+prettyHsType (GHC.Hs.HsOpTy _ l op r) = do
   lineBreak <- gets (configLineBreaks . psConfig)
   if showOutputable op `elem` lineBreak
     then do
@@ -1243,36 +1281,39 @@ prettyHsType (HsOpTy _ l op r) = do
       pretty r
     else spaced [pretty l, pretty $ fmap InfixOp op, pretty r]
 #endif
-prettyHsType (HsParTy _ inside) = parens $ pretty inside
-prettyHsType (HsIParamTy _ x ty) =
+prettyHsType (GHC.Hs.HsParTy _ inside) = parens $ pretty inside
+prettyHsType (GHC.Hs.HsIParamTy _ x ty) =
   spaced [string "?" >> pretty x, string "::", pretty ty]
-prettyHsType HsStarTy {} = string "*"
-prettyHsType (HsKindSig _ t k) = spaced [pretty t, string "::", pretty k]
-prettyHsType (HsSpliceTy _ sp) = pretty sp
-prettyHsType HsDocTy {} = docNode
-prettyHsType (HsBangTy _ pack x) = pretty pack >> pretty x
-prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
-prettyHsType (HsExplicitListTy _ _ xs) =
+prettyHsType GHC.Hs.HsStarTy {} = string "*"
+prettyHsType (GHC.Hs.HsKindSig _ t k) = spaced [pretty t, string "::", pretty k]
+prettyHsType (GHC.Hs.HsSpliceTy _ sp) = pretty sp
+prettyHsType GHC.Hs.HsDocTy {} = docNode
+prettyHsType (GHC.Hs.HsBangTy _ pack x) = pretty pack >> pretty x
+prettyHsType (GHC.Hs.HsRecTy _ xs) = hvFields $ fmap pretty xs
+prettyHsType (GHC.Hs.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
     _ -> hvPromotedList $ fmap pretty xs
-prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
-prettyHsType (HsTyLit _ x) = pretty x
-prettyHsType HsWildCardTy {} = string "_"
-prettyHsType XHsType {} = notGeneratedByParser
+prettyHsType (GHC.Hs.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
+prettyHsType (GHC.Hs.HsTyLit _ x) = pretty x
+prettyHsType GHC.Hs.HsWildCardTy {} = string "_"
+prettyHsType GHC.Hs.XHsType {} = notGeneratedByParser
 
-instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
+instance Pretty
+           (GHC.Hs.GRHSs
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
   pretty' = pretty' . GRHSsExpr GRHSExprNormal
 
 instance Pretty GRHSsExpr where
-  pretty' (GRHSsExpr {grhssExpr = GRHSs {..}, ..}) = do
+  pretty' (GRHSsExpr {grhssExpr = GHC.Hs.GRHSs {..}, ..}) = do
     mapM_ (pretty . fmap (GRHSExpr grhssExprType)) grhssGRHSs
     case (grhssLocalBinds, grhssExprType) of
-      (HsValBinds {}, GRHSExprCase) ->
+      (GHC.Hs.HsValBinds {}, GRHSExprCase) ->
         indentedBlock $ do
           newline
           string "where " |=> pretty grhssLocalBinds
-      (HsValBinds epa lr, _) ->
+      (GHC.Hs.HsValBinds epa lr, _) ->
         indentedWithSpace 2
           $ newlinePrefixed
               [ string "where"
@@ -1280,11 +1321,14 @@ instance Pretty GRHSsExpr where
               ]
       _ -> return ()
 
-instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
-  pretty' GRHSs {..} = do
+instance Pretty
+           (GHC.Hs.GRHSs
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsCmd GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.GRHSs {..} = do
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
-      (HsValBinds epa lr) ->
+      (GHC.Hs.HsValBinds epa lr) ->
         indentedWithSpace 2
           $ newlinePrefixed
               [ string "where"
@@ -1292,49 +1336,54 @@ instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
               ]
       _ -> return ()
 
-instance Pretty (HsMatchContext GhcPs) where
+instance Pretty (GHC.Hs.HsMatchContext GHC.Hs.GhcPs) where
   pretty' = prettyHsMatchContext
 
-prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr = return ()
-prettyHsMatchContext CaseAlt = return ()
-prettyHsMatchContext IfAlt {} = notGeneratedByParser
-prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
-prettyHsMatchContext RecUpd {} = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
-prettyHsMatchContext PatSyn {} = notGeneratedByParser
+prettyHsMatchContext :: GHC.Hs.HsMatchContext GHC.Hs.GhcPs -> Printer ()
+prettyHsMatchContext GHC.Hs.FunRhs {..} = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext GHC.Hs.LambdaExpr = return ()
+prettyHsMatchContext GHC.Hs.CaseAlt = return ()
+prettyHsMatchContext GHC.Hs.IfAlt {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.ArrowMatchCtxt {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.PatBindRhs {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.PatBindGuards {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.RecUpd {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.StmtCtxt {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.ThPatSplice {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.ThPatQuote {} = notGeneratedByParser
+prettyHsMatchContext GHC.Hs.PatSyn {} = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
 #endif
-instance Pretty (ParStmtBlock GhcPs GhcPs) where
-  pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
+instance Pretty (GHC.Hs.ParStmtBlock GHC.Hs.GhcPs GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
 
 instance Pretty ParStmtBlockInsideVerticalList where
-  pretty' (ParStmtBlockInsideVerticalList (ParStmtBlock _ xs _ _)) =
+  pretty' (ParStmtBlockInsideVerticalList (GHC.Hs.ParStmtBlock _ xs _ _)) =
     vCommaSep $ fmap pretty xs
 
 instance Pretty RdrName where
   pretty' = pretty . PrefixOp
 
-instance Pretty (GRHS GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
+instance Pretty
+           (GHC.Hs.GRHS
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
   pretty' = pretty' . GRHSExpr GRHSExprNormal
 
 instance Pretty GRHSExpr where
-  pretty' (GRHSExpr {grhsExpr = (GRHS _ [] body), ..}) = do
+  pretty' (GRHSExpr {grhsExpr = (GHC.Hs.GRHS _ [] body), ..}) = do
     space
     rhsSeparator grhsExprType
     case unLoc body of
-      HsDo _ (DoExpr m) stmts ->
+      GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) stmts ->
         printCommentsAnd body (const (doExpr (QualifiedDo m Do) stmts))
-      HsDo _ (MDoExpr m) stmts ->
+      GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) stmts ->
         printCommentsAnd body (const (doExpr (QualifiedDo m Mdo) stmts))
-      OpApp _ (L _ (HsDo _ DoExpr {} _)) _ _ -> space >> pretty body
-      OpApp _ (L _ (HsDo _ MDoExpr {} _)) _ _ -> space >> pretty body
+      GHC.Hs.OpApp _ (L _ (GHC.Hs.HsDo _ GHC.Hs.DoExpr {} _)) _ _ ->
+        space >> pretty body
+      GHC.Hs.OpApp _ (L _ (GHC.Hs.HsDo _ GHC.Hs.MDoExpr {} _)) _ _ ->
+        space >> pretty body
       _ ->
         let hor = space >> pretty body
             ver = newline >> indentedBlock (pretty body)
@@ -1345,7 +1394,7 @@ instance Pretty GRHSExpr where
         pretty qDo
         newline
         indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
-  pretty' (GRHSExpr {grhsExpr = (GRHS _ guards body), ..}) = do
+  pretty' (GRHSExpr {grhsExpr = (GHC.Hs.GRHS _ guards body), ..}) = do
     unless (grhsExprType == GRHSExprMultiWayIf) newline
     (if grhsExprType == GRHSExprMultiWayIf
        then id
@@ -1354,8 +1403,9 @@ instance Pretty GRHSExpr where
       space
       rhsSeparator grhsExprType
       printCommentsAnd body $ \case
-        HsDo _ (DoExpr m) stmts -> doExpr (QualifiedDo m Do) stmts
-        HsDo _ (MDoExpr m) stmts -> doExpr (QualifiedDo m Mdo) stmts
+        GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) stmts -> doExpr (QualifiedDo m Do) stmts
+        GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) stmts ->
+          doExpr (QualifiedDo m Mdo) stmts
         x ->
           let hor = space >> pretty x
               ver = newline >> indentedBlock (pretty x)
@@ -1368,7 +1418,7 @@ instance Pretty GRHSExpr where
         indentedBlock (printCommentsAnd stmts (lined . fmap pretty))
 
 instance Pretty GRHSProc where
-  pretty' (GRHSProc (GRHS _ guards body)) =
+  pretty' (GRHSProc (GHC.Hs.GRHS _ guards body)) =
     if null guards
       then bodyPrinter
       else do
@@ -1381,7 +1431,7 @@ instance Pretty GRHSProc where
       bodyPrinter = do
         string "->"
         printCommentsAnd body $ \case
-          HsCmdDo _ stmts ->
+          GHC.Hs.HsCmdDo _ stmts ->
             let hor = space >> printCommentsAnd stmts (lined . fmap pretty)
                 ver = do
                   newline
@@ -1392,9 +1442,9 @@ instance Pretty GRHSProc where
                 ver = newline >> indentedBlock (pretty x)
              in hor <-|> ver
 
-instance Pretty EpaCommentTok where
-  pretty' (EpaLineComment c) = string c
-  pretty' (EpaBlockComment c) =
+instance Pretty GHC.Hs.EpaCommentTok where
+  pretty' (GHC.Hs.EpaLineComment c) = string c
+  pretty' (GHC.Hs.EpaBlockComment c) =
     case lines c of
       [] -> pure ()
       [x] -> string x
@@ -1406,16 +1456,17 @@ instance Pretty EpaCommentTok where
         indentedWithFixedLevel 0 $ lined $ fmap string xs
   pretty' _ = docNode
 
-instance Pretty (SpliceDecl GhcPs) where
-  pretty' (SpliceDecl _ sp _) = pretty sp
+instance Pretty (GHC.Hs.SpliceDecl GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.SpliceDecl _ sp _) = pretty sp
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-instance Pretty (HsSplice GhcPs) where
-  pretty' (HsTypedSplice _ _ _ body) = string "$$" >> pretty body
-  pretty' (HsUntypedSplice _ DollarSplice _ body) = string "$" >> pretty body
-  pretty' (HsUntypedSplice _ BareSplice _ body) = pretty body
+instance Pretty (GHC.Hs.HsSplice GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.HsTypedSplice _ _ _ body) = string "$$" >> pretty body
+  pretty' (GHC.Hs.HsUntypedSplice _ GHC.Hs.DollarSplice _ body) =
+    string "$" >> pretty body
+  pretty' (GHC.Hs.HsUntypedSplice _ GHC.Hs.BareSplice _ body) = pretty body
   -- The body of a quasi-quote must not be changed by a formatter.
   -- Changing it will modify the actual behavior of the code.
-  pretty' (HsQuasiQuote _ _ l _ r) =
+  pretty' (GHC.Hs.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
       wrapWithBars
@@ -1428,35 +1479,37 @@ instance Pretty (HsSplice GhcPs) where
       printers ps s ('\n':xs) =
         printers (newline : string (reverse s) : ps) "" xs
       printers ps s (x:xs) = printers ps (x : s) xs
-  pretty' HsSpliced {} = notGeneratedByParser
+  pretty' GHC.Hs.HsSpliced {} = notGeneratedByParser
 #endif
-instance Pretty (Pat GhcPs) where
+instance Pretty (GHC.Hs.Pat GHC.Hs.GhcPs) where
   pretty' = prettyPat
 
 instance Pretty PatInsidePatDecl where
-  pretty' (PatInsidePatDecl (ConPat {pat_args = (InfixCon l r), ..})) =
+  pretty' (PatInsidePatDecl (GHC.Hs.ConPat { pat_args = (GHC.Hs.InfixCon l r)
+                                           , ..
+                                           })) =
     spaced [pretty l, pretty $ fmap InfixOp pat_con, pretty r]
   pretty' (PatInsidePatDecl x) = pretty x
 
-prettyPat :: Pat GhcPs -> Printer ()
-prettyPat WildPat {} = string "_"
-prettyPat (VarPat _ x) = pretty x
-prettyPat (LazyPat _ x) = string "~" >> pretty x
+prettyPat :: GHC.Hs.Pat GHC.Hs.GhcPs -> Printer ()
+prettyPat GHC.Hs.WildPat {} = string "_"
+prettyPat (GHC.Hs.VarPat _ x) = pretty x
+prettyPat (GHC.Hs.LazyPat _ x) = string "~" >> pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPat (AsPat _ a _ b) = pretty a >> string "@" >> pretty b
 #else
-prettyPat (AsPat _ a b) = pretty a >> string "@" >> pretty b
+prettyPat (GHC.Hs.AsPat _ a b) = pretty a >> string "@" >> pretty b
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyPat (ParPat _ _ inner _) = parens $ pretty inner
 #else
-prettyPat (ParPat _ inner) = parens $ pretty inner
+prettyPat (GHC.Hs.ParPat _ inner) = parens $ pretty inner
 #endif
-prettyPat (BangPat _ x) = string "!" >> pretty x
-prettyPat (ListPat _ xs) = hList $ fmap pretty xs
-prettyPat (TuplePat _ pats Boxed) = hTuple $ fmap pretty pats
-prettyPat (TuplePat _ pats Unboxed) = hUnboxedTuple $ fmap pretty pats
-prettyPat (SumPat _ x position numElem) = do
+prettyPat (GHC.Hs.BangPat _ x) = string "!" >> pretty x
+prettyPat (GHC.Hs.ListPat _ xs) = hList $ fmap pretty xs
+prettyPat (GHC.Hs.TuplePat _ pats Boxed) = hTuple $ fmap pretty pats
+prettyPat (GHC.Hs.TuplePat _ pats Unboxed) = hUnboxedTuple $ fmap pretty pats
+prettyPat (GHC.Hs.SumPat _ x position numElem) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
     if idx == position
@@ -1464,27 +1517,27 @@ prettyPat (SumPat _ x position numElem) = do
       else string " "
     when (idx < numElem) $ string "|"
   string "#)"
-prettyPat ConPat {..} =
+prettyPat GHC.Hs.ConPat {..} =
   case pat_args of
-    PrefixCon _ as -> do
+    GHC.Hs.PrefixCon _ as -> do
       pretty $ fmap PrefixOp pat_con
       spacePrefixed $ fmap pretty as
-    RecCon rec -> (pretty pat_con >> space) |=> pretty (RecConPat rec)
-    InfixCon a b -> do
+    GHC.Hs.RecCon rec -> (pretty pat_con >> space) |=> pretty (RecConPat rec)
+    GHC.Hs.InfixCon a b -> do
       pretty a
       unlessSpecialOp (unLoc pat_con) space
       pretty $ fmap InfixOp pat_con
       unlessSpecialOp (unLoc pat_con) space
       pretty b
-prettyPat (ViewPat _ l r) = spaced [pretty l, string "->", pretty r]
-prettyPat (SplicePat _ x) = pretty x
-prettyPat (LitPat _ x) = pretty x
-prettyPat (NPat _ x _ _) = pretty x
-prettyPat (NPlusKPat _ n k _ _ _) = pretty n >> string "+" >> pretty k
-prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
+prettyPat (GHC.Hs.ViewPat _ l r) = spaced [pretty l, string "->", pretty r]
+prettyPat (GHC.Hs.SplicePat _ x) = pretty x
+prettyPat (GHC.Hs.LitPat _ x) = pretty x
+prettyPat (GHC.Hs.NPat _ x _ _) = pretty x
+prettyPat (GHC.Hs.NPlusKPat _ n k _ _ _) = pretty n >> string "+" >> pretty k
+prettyPat (GHC.Hs.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 
 instance Pretty RecConPat where
-  pretty' (RecConPat HsRecFields {..}) =
+  pretty' (RecConPat GHC.Hs.HsRecFields {..}) =
     case fieldPrinters of
       [] -> string "{}"
       [x] -> braces x
@@ -1494,16 +1547,18 @@ instance Pretty RecConPat where
         fmap (pretty . fmap RecConField) rec_flds
           ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-instance Pretty (HsBracket GhcPs) where
-  pretty' (ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
-  pretty' (PatBr _ expr) = brackets $ string "p" >> wrapWithBars (pretty expr)
-  pretty' (DecBrL _ decls) =
+instance Pretty (GHC.Hs.HsBracket GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
+  pretty' (GHC.Hs.PatBr _ expr) =
+    brackets $ string "p" >> wrapWithBars (pretty expr)
+  pretty' (GHC.Hs.DecBrL _ decls) =
     brackets $ string "d| " |=> lined (fmap pretty decls) >> string " |"
-  pretty' DecBrG {} = notGeneratedByParser
-  pretty' (TypBr _ expr) = brackets $ string "t" >> wrapWithBars (pretty expr)
-  pretty' (VarBr _ True var) = string "'" >> pretty var
-  pretty' (VarBr _ False var) = string "''" >> pretty var
-  pretty' (TExpBr _ x) = typedBrackets $ pretty x
+  pretty' GHC.Hs.DecBrG {} = notGeneratedByParser
+  pretty' (GHC.Hs.TypBr _ expr) =
+    brackets $ string "t" >> wrapWithBars (pretty expr)
+  pretty' (GHC.Hs.VarBr _ True var) = string "'" >> pretty var
+  pretty' (GHC.Hs.VarBr _ False var) = string "''" >> pretty var
+  pretty' (GHC.Hs.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
   pretty' (Sig x) = pretty x
@@ -1512,26 +1567,26 @@ instance Pretty SigBindFamily where
   pretty' (TyFamInst x) = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
-instance Pretty EpaComment where
-  pretty' EpaComment {..} = pretty ac_tok
+instance Pretty GHC.Hs.EpaComment where
+  pretty' GHC.Hs.EpaComment {..} = pretty ac_tok
 
-instance Pretty (HsLocalBindsLR GhcPs GhcPs) where
-  pretty' (HsValBinds _ lr) = pretty lr
-  pretty' (HsIPBinds _ x) = pretty x
-  pretty' EmptyLocalBinds {} =
+instance Pretty (GHC.Hs.HsLocalBindsLR GHC.Hs.GhcPs GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.HsValBinds _ lr) = pretty lr
+  pretty' (GHC.Hs.HsIPBinds _ x) = pretty x
+  pretty' GHC.Hs.EmptyLocalBinds {} =
     error
       "This branch indicates that the bind is empty, but since calling this code means that let or where has already been output, it cannot be handled here. It should be handled higher up in the AST."
 
-instance Pretty (HsValBindsLR GhcPs GhcPs) where
-  pretty' (ValBinds _ methods sigs) = lined $ fmap pretty sigsAndMethods
+instance Pretty (GHC.Hs.HsValBindsLR GHC.Hs.GhcPs GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.ValBinds _ methods sigs) = lined $ fmap pretty sigsAndMethods
     where
       sigsAndMethods =
         mkSortedLSigBindFamilyList sigs (bagToList methods) [] [] []
-  pretty' XValBindsLR {} = notUsedInParsedStage
+  pretty' GHC.Hs.XValBindsLR {} = notUsedInParsedStage
 
-instance Pretty (HsTupArg GhcPs) where
-  pretty' (Present _ e) = pretty e
-  pretty' Missing {} = pure () -- This appears in a tuple section.
+instance Pretty (GHC.Hs.HsTupArg GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.Present _ e) = pretty e
+  pretty' GHC.Hs.Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1542,14 +1597,18 @@ instance Pretty RecConField where
 #else
 -- | For pattern matching against a record.
 instance Pretty
-           (HsRecField' (FieldOcc GhcPs) (GenLocated SrcSpanAnnA (Pat GhcPs))) where
-  pretty' HsRecField {..} =
+           (GHC.Hs.HsRecField'
+              (GHC.Hs.FieldOcc GHC.Hs.GhcPs)
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.Pat GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.HsRecField {..} =
     (pretty hsRecFieldLbl >> string " = ") |=> pretty hsRecFieldArg
 
 -- | For record updates.
 instance Pretty
-           (HsRecField' (FieldOcc GhcPs) (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
-  pretty' HsRecField {..} = do
+           (GHC.Hs.HsRecField'
+              (GHC.Hs.FieldOcc GHC.Hs.GhcPs)
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsExpr GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.HsRecField {..} = do
     pretty hsRecFieldLbl
     unless hsRecPun $ do
       string " ="
@@ -1581,7 +1640,7 @@ instance Pretty
       vertical = newline >> indentedBlock (pretty hfbRHS)
 #else
 instance Pretty RecConField where
-  pretty' (RecConField HsRecField {..}) = do
+  pretty' (RecConField GHC.Hs.HsRecField {..}) = do
     pretty hsRecFieldLbl
     unless hsRecPun $ do
       string " = "
@@ -1591,34 +1650,38 @@ instance Pretty RecConField where
 instance Pretty (FieldOcc GhcPs) where
   pretty' FieldOcc {..} = pretty foLabel
 #else
-instance Pretty (FieldOcc GhcPs) where
-  pretty' FieldOcc {..} = pretty rdrNameFieldOcc
+instance Pretty (GHC.Hs.FieldOcc GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.FieldOcc {..} = pretty rdrNameFieldOcc
 #endif
 -- HsConDeclH98Details
 instance Pretty
-           (HsConDetails
+           (GHC.Hs.HsConDetails
               Void
-              (HsScaled GhcPs (GenLocated SrcSpanAnnA (BangType GhcPs)))
+              (GHC.Hs.HsScaled
+                 GHC.Hs.GhcPs
+                 (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.BangType GHC.Hs.GhcPs)))
               (GenLocated
-                 SrcSpanAnnL
-                 [GenLocated SrcSpanAnnA (ConDeclField GhcPs)])) where
-  pretty' (PrefixCon _ xs) = horizontal <-|> vertical
+                 GHC.Hs.SrcSpanAnnL
+                 [GenLocated
+                    GHC.Hs.SrcSpanAnnA
+                    (GHC.Hs.ConDeclField GHC.Hs.GhcPs)])) where
+  pretty' (GHC.Hs.PrefixCon _ xs) = horizontal <-|> vertical
     where
       horizontal = spacePrefixed $ fmap pretty xs
       vertical = indentedBlock $ newlinePrefixed $ fmap pretty xs
-  pretty' (RecCon x) =
+  pretty' (GHC.Hs.RecCon x) =
     printCommentsAnd x $ \rec -> do
       newline
       indentedBlock $ vFields $ fmap pretty rec
-  pretty' InfixCon {} =
+  pretty' GHC.Hs.InfixCon {} =
     error
       "Cannot handle here because 'InfixCon' does not have the information of its constructor."
 
-instance Pretty a => Pretty (HsScaled GhcPs a) where
-  pretty' (HsScaled _ x) = pretty x
+instance Pretty a => Pretty (GHC.Hs.HsScaled GHC.Hs.GhcPs a) where
+  pretty' (GHC.Hs.HsScaled _ x) = pretty x
 
-instance Pretty (ConDeclField GhcPs) where
-  pretty' ConDeclField {..}
+instance Pretty (GHC.Hs.ConDeclField GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.ConDeclField {..}
     -- Here, we *ignore* the 'cd_fld_doc' field because doc strings are
     -- also stored as comments, and printing both results in duplicated
     -- comments.
@@ -1628,7 +1691,7 @@ instance Pretty (ConDeclField GhcPs) where
     pretty cd_fld_type
 
 instance Pretty InfixExpr where
-  pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
+  pretty' (InfixExpr (L _ (GHC.Hs.HsVar _ bind))) = pretty $ fmap InfixOp bind
   pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
@@ -1643,20 +1706,20 @@ instance Pretty InfixApp where
       leftAssoc = prettyOps allOperantsAndOperatorsLeftAssoc
       rightAssoc = prettyOps allOperantsAndOperatorsRightAssoc
       noAssoc
-        | L _ (OpApp _ _ o _) <- lhs
+        | L _ (GHC.Hs.OpApp _ _ o _) <- lhs
         , isSameAssoc o = leftAssoc
         | otherwise = rightAssoc
-      prettyOps [l, o, L _ (HsDo _ (DoExpr m) xs)] = do
+      prettyOps [l, o, L _ (GHC.Hs.HsDo _ (GHC.Hs.DoExpr m) xs)] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty $ QualifiedDo m Do]
         newline
         indentedBlock $ printCommentsAnd xs (lined . fmap pretty)
-      prettyOps [l, o, L _ (HsDo _ (MDoExpr m) xs)] = do
+      prettyOps [l, o, L _ (GHC.Hs.HsDo _ (GHC.Hs.MDoExpr m) xs)] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty $ QualifiedDo m Mdo]
         newline
         indentedBlock $ printCommentsAnd xs (lined . fmap pretty)
-      prettyOps [l, o, r@(L _ HsLam {})] = do
+      prettyOps [l, o, r@(L _ GHC.Hs.HsLam {})] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty r]
-      prettyOps [l, o, r@(L _ HsLamCase {})] = do
+      prettyOps [l, o, r@(L _ GHC.Hs.HsLamCase {})] = do
         spaced [pretty l, pretty $ InfixExpr o, pretty r]
       prettyOps (l:xs) = do
         pretty l
@@ -1675,14 +1738,16 @@ instance Pretty InfixApp where
       findFixity o = fromMaybe defaultFixity $ lookup (varToStr o) fixities
       allOperantsAndOperatorsLeftAssoc = reverse $ rhs : op : collect lhs
         where
-          collect :: LHsExpr GhcPs -> [LHsExpr GhcPs]
-          collect (L _ (OpApp _ l o r))
+          collect ::
+               GHC.Hs.LHsExpr GHC.Hs.GhcPs -> [GHC.Hs.LHsExpr GHC.Hs.GhcPs]
+          collect (L _ (GHC.Hs.OpApp _ l o r))
             | isSameAssoc o = r : o : collect l
           collect x = [x]
       allOperantsAndOperatorsRightAssoc = lhs : op : collect rhs
         where
-          collect :: LHsExpr GhcPs -> [LHsExpr GhcPs]
-          collect (L _ (OpApp _ l o r))
+          collect ::
+               GHC.Hs.LHsExpr GHC.Hs.GhcPs -> [GHC.Hs.LHsExpr GHC.Hs.GhcPs]
+          collect (L _ (GHC.Hs.OpApp _ l o r))
             | isSameAssoc o = l : o : collect r
           collect x = [x]
       isSameAssoc (findFixity -> Fixity _ lv d) = lv == level && d == dir
@@ -1694,28 +1759,28 @@ instance Pretty a => Pretty (BooleanFormula a) where
   pretty' (Or xs) = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
-instance Pretty (FieldLabelStrings GhcPs) where
-  pretty' (FieldLabelStrings xs) = hDotSep $ fmap pretty xs
+instance Pretty (GHC.Hs.FieldLabelStrings GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.FieldLabelStrings xs) = hDotSep $ fmap pretty xs
 
-instance Pretty (AmbiguousFieldOcc GhcPs) where
-  pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name) = pretty name
+instance Pretty (GHC.Hs.AmbiguousFieldOcc GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.Unambiguous _ name) = pretty name
+  pretty' (GHC.Hs.Ambiguous _ name) = pretty name
 
-instance Pretty (HsDerivingClause GhcPs) where
-  pretty' HsDerivingClause { deriv_clause_strategy = Just strategy@(L _ ViaStrategy {})
-                           , ..
-                           } =
+instance Pretty (GHC.Hs.HsDerivingClause GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsDerivingClause { deriv_clause_strategy = Just strategy@(L _ GHC.Hs.ViaStrategy {})
+                                  , ..
+                                  } =
     spaced [string "deriving", pretty deriv_clause_tys, pretty strategy]
-  pretty' HsDerivingClause {..} = do
+  pretty' GHC.Hs.HsDerivingClause {..} = do
     string "deriving "
     whenJust deriv_clause_strategy $ \x -> do
       pretty x
       space
     pretty deriv_clause_tys
 
-instance Pretty (DerivClauseTys GhcPs) where
-  pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
+instance Pretty (GHC.Hs.DerivClauseTys GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.DctSingle _ ty) = parens $ pretty ty
+  pretty' (GHC.Hs.DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
   pretty' NoOverlap {} = notUsedInParsedStage
@@ -1728,21 +1793,21 @@ instance Pretty StringLiteral where
   pretty' = output
 
 -- | This instance is for type family declarations inside a class declaration.
-instance Pretty (FamilyDecl GhcPs) where
-  pretty' FamilyDecl {..} = do
+instance Pretty (GHC.Hs.FamilyDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.FamilyDecl {..} = do
     string
       $ case fdInfo of
-          DataFamily -> "data"
-          OpenTypeFamily -> "type"
-          ClosedTypeFamily {} -> "type"
+          GHC.Hs.DataFamily -> "data"
+          GHC.Hs.OpenTypeFamily -> "type"
+          GHC.Hs.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
       TopLevel -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
     case unLoc fdResultSig of
-      NoSig {} -> pure ()
-      TyVarSig {} -> do
+      GHC.Hs.NoSig {} -> pure ()
+      GHC.Hs.TyVarSig {} -> do
         string " = "
         pretty fdResultSig
       _ -> do
@@ -1752,42 +1817,42 @@ instance Pretty (FamilyDecl GhcPs) where
       string " | "
       pretty x
     case fdInfo of
-      ClosedTypeFamily (Just xs) -> do
+      GHC.Hs.ClosedTypeFamily (Just xs) -> do
         string " where"
         newline
         indentedBlock $ lined $ fmap pretty xs
       _ -> pure ()
 
-instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {} = pure ()
-  pretty' (KindSig _ x) = string ":: " >> pretty x
-  pretty' (TyVarSig _ x) = pretty x
+instance Pretty (GHC.Hs.FamilyResultSig GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.NoSig {} = pure ()
+  pretty' (GHC.Hs.KindSig _ x) = string ":: " >> pretty x
+  pretty' (GHC.Hs.TyVarSig _ x) = pretty x
 
-instance Pretty (HsTyVarBndr a GhcPs) where
-  pretty' (UserTyVar _ _ x) = pretty x
-  pretty' (KindedTyVar _ _ name ty) =
+instance Pretty (GHC.Hs.HsTyVarBndr a GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.UserTyVar _ _ x) = pretty x
+  pretty' (GHC.Hs.KindedTyVar _ _ name ty) =
     parens $ spaced [pretty name, string "::", pretty ty]
 
-instance Pretty (InjectivityAnn GhcPs) where
-  pretty' (InjectivityAnn _ from to) =
+instance Pretty (GHC.Hs.InjectivityAnn GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.InjectivityAnn _ from to) =
     spaced $ pretty from : string "->" : fmap pretty to
 
-instance Pretty (ArithSeqInfo GhcPs) where
-  pretty' (From from) = brackets $ spaced [pretty from, string ".."]
-  pretty' (FromThen from next) =
+instance Pretty (GHC.Hs.ArithSeqInfo GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.From from) = brackets $ spaced [pretty from, string ".."]
+  pretty' (GHC.Hs.FromThen from next) =
     brackets $ spaced [pretty from >> comma >> pretty next, string ".."]
-  pretty' (FromTo from to) =
+  pretty' (GHC.Hs.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
-  pretty' (FromThenTo from next to) =
+  pretty' (GHC.Hs.FromThenTo from next to) =
     brackets
       $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
-instance Pretty (HsForAllTelescope GhcPs) where
-  pretty' HsForAllVis {..} = do
+instance Pretty (GHC.Hs.HsForAllTelescope GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsForAllVis {..} = do
     string "forall "
     spaced $ fmap pretty hsf_vis_bndrs
     dot
-  pretty' HsForAllInvis {..} = do
+  pretty' GHC.Hs.HsForAllInvis {..} = do
     string "forall "
     spaced $ fmap pretty hsf_invis_bndrs
     dot
@@ -1864,41 +1929,45 @@ instance Pretty ModuleName where
 instance Pretty ModuleNameWithPrefix where
   pretty' (ModuleNameWithPrefix name) = spaced [string "module", pretty name]
 
-instance Pretty (IE GhcPs) where
-  pretty' (IEVar _ name) = pretty name
-  pretty' (IEThingAbs _ name) = pretty name
-  pretty' (IEThingAll _ name) = do
+instance Pretty (GHC.Hs.IE GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.IEVar _ name) = pretty name
+  pretty' (GHC.Hs.IEThingAbs _ name) = pretty name
+  pretty' (GHC.Hs.IEThingAll _ name) = do
     pretty name
     string "(..)"
   -- FIXME: Currently, pretty-printing a 'IEThingWith' uses
   -- 'ghc-lib-parser''s pretty-printer. However, we should avoid it because
   -- 'ghc-lib-parser' may suddenly change how it prints, resulting in
   -- unexpected test failures.
-  pretty' x@IEThingWith {} =
+  pretty' x@GHC.Hs.IEThingWith {} =
     case lines $ showOutputable x of
       [] -> pure ()
       [x'] -> string x'
       xs -> do
         string $ head xs
         indentedWithFixedLevel 0 $ newlinePrefixed $ string <$> tail xs
-  pretty' (IEModuleContents _ name) = pretty $ fmap ModuleNameWithPrefix name
-  pretty' IEGroup {} = docNode
-  pretty' IEDoc {} = docNode
-  pretty' IEDocNamed {} = docNode
+  pretty' (GHC.Hs.IEModuleContents _ name) =
+    pretty $ fmap ModuleNameWithPrefix name
+  pretty' GHC.Hs.IEGroup {} = docNode
+  pretty' GHC.Hs.IEDoc {} = docNode
+  pretty' GHC.Hs.IEDocNamed {} = docNode
 
-instance Pretty (FamEqn GhcPs (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' FamEqn {..} = do
+instance Pretty
+           (GHC.Hs.FamEqn
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.FamEqn {..} = do
     pretty feqn_tycon
     spacePrefixed $ fmap pretty feqn_pats
     string " = "
     pretty feqn_rhs
 
 -- | Pretty-print a data instance.
-instance Pretty (FamEqn GhcPs (HsDataDefn GhcPs)) where
+instance Pretty (GHC.Hs.FamEqn GHC.Hs.GhcPs (GHC.Hs.HsDataDefn GHC.Hs.GhcPs)) where
   pretty' = pretty' . FamEqnTopLevel
 
 instance Pretty FamEqn' where
-  pretty' FamEqn' {famEqn = FamEqn {..}, ..} = do
+  pretty' FamEqn' {famEqn = GHC.Hs.FamEqn {..}, ..} = do
     spaced $ string prefix : pretty feqn_tycon : fmap pretty feqn_pats
     pretty feqn_rhs
     where
@@ -1918,12 +1987,12 @@ instance Pretty
   pretty' HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
-           (HsArg
-              (GenLocated SrcSpanAnnA (HsType GhcPs))
-              (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
-  pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+           (GHC.Hs.HsArg
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))) where
+  pretty' (GHC.Hs.HsValArg x) = pretty x
+  pretty' (GHC.Hs.HsTypeArg _ x) = string "@" >> pretty x
+  pretty' GHC.Hs.HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
@@ -1940,8 +2009,8 @@ instance Pretty (HsQuote GhcPs) where
 instance Pretty (WarnDecls GhcPs) where
   pretty' (Warnings _ x) = lined $ fmap pretty x
 #else
-instance Pretty (WarnDecls GhcPs) where
-  pretty' (Warnings _ _ x) = lined $ fmap pretty x
+instance Pretty (GHC.Hs.WarnDecls GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.Warnings _ _ x) = lined $ fmap pretty x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty (WarnDecl GhcPs) where
@@ -1958,8 +2027,8 @@ instance Pretty (WarnDecl GhcPs) where
           , string " #-}"
           ]
 #else
-instance Pretty (WarnDecl GhcPs) where
-  pretty' (Warning _ names deprecatedOrWarning) =
+instance Pretty (GHC.Hs.WarnDecl GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
       WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
@@ -1985,10 +2054,10 @@ instance Pretty (IEWrappedName GhcPs) where
   pretty' (IEType _ name) = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
-instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name) = pretty name
-  pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+instance Pretty (GHC.Hs.IEWrappedName RdrName) where
+  pretty' (GHC.Hs.IEName name) = pretty name
+  pretty' (GHC.Hs.IEPattern _ name) = spaced [string "pattern", pretty name]
+  pretty' (GHC.Hs.IEType _ name) = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -1997,11 +2066,12 @@ instance Pretty (DotFieldOcc GhcPs) where
 instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel (string . unpackFS)
 #else
-instance Pretty (HsFieldLabel GhcPs) where
-  pretty' HsFieldLabel {..} = printCommentsAnd hflLabel (string . unpackFS)
+instance Pretty (GHC.Hs.HsFieldLabel GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsFieldLabel {..} =
+    printCommentsAnd hflLabel (string . unpackFS)
 #endif
-instance Pretty (RuleDecls GhcPs) where
-  pretty' HsRules {..} =
+instance Pretty (GHC.Hs.RuleDecls GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsRules {..} =
     lined $ string "{-# RULES" : fmap pretty rds_rules ++ [string " #-}"]
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (RuleDecl GhcPs) where
@@ -2023,8 +2093,8 @@ instance Pretty (RuleDecl GhcPs) where
             space
             pretty rd_lhs
 #else
-instance Pretty (RuleDecl GhcPs) where
-  pretty' HsRule {..} =
+instance Pretty (GHC.Hs.RuleDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsRule {..} =
     spaced
       [ printCommentsAnd rd_name (doubleQuotes . string . unpackFS . snd)
       , lhs
@@ -2045,17 +2115,17 @@ instance Pretty (RuleDecl GhcPs) where
 instance Pretty OccName where
   pretty' = output
 
-instance Pretty (DerivDecl GhcPs) where
-  pretty' DerivDecl { deriv_strategy = (Just deriv_strategy@(L _ ViaStrategy {}))
-                    , ..
-                    } =
+instance Pretty (GHC.Hs.DerivDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.DerivDecl { deriv_strategy = (Just deriv_strategy@(L _ GHC.Hs.ViaStrategy {}))
+                           , ..
+                           } =
     spaced
       [ string "deriving"
       , pretty deriv_strategy
       , string "instance"
       , pretty deriv_type
       ]
-  pretty' DerivDecl {..} = do
+  pretty' GHC.Hs.DerivDecl {..} = do
     string "deriving "
     whenJust deriv_strategy $ \x -> do
       pretty x
@@ -2065,23 +2135,28 @@ instance Pretty (DerivDecl GhcPs) where
 
 -- | 'Pretty' for 'LHsSigWcType GhcPs'.
 instance Pretty
-           (HsWildCardBndrs GhcPs (GenLocated SrcSpanAnnA (HsSigType GhcPs))) where
-  pretty' HsWC {..} = pretty hswc_body
+           (GHC.Hs.HsWildCardBndrs
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsSigType GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.HsWC {..} = pretty hswc_body
 
 -- | 'Pretty' for 'LHsWcType'
-instance Pretty (HsWildCardBndrs GhcPs (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' HsWC {..} = pretty hswc_body
+instance Pretty
+           (GHC.Hs.HsWildCardBndrs
+              GHC.Hs.GhcPs
+              (GenLocated GHC.Hs.SrcSpanAnnA (GHC.Hs.HsType GHC.Hs.GhcPs))) where
+  pretty' GHC.Hs.HsWC {..} = pretty hswc_body
 
-instance Pretty (StandaloneKindSig GhcPs) where
-  pretty' (StandaloneKindSig _ name kind) =
+instance Pretty (GHC.Hs.StandaloneKindSig GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.StandaloneKindSig _ name kind) =
     spaced [string "type", pretty name, string "::", pretty kind]
 
-instance Pretty (DefaultDecl GhcPs) where
-  pretty' (DefaultDecl _ xs) =
+instance Pretty (GHC.Hs.DefaultDecl GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.DefaultDecl _ xs) =
     spaced [string "default", hTuple $ fmap pretty xs]
 
-instance Pretty (ForeignDecl GhcPs) where
-  pretty' ForeignImport {..} =
+instance Pretty (GHC.Hs.ForeignDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.ForeignImport {..} =
     spaced
       [ string "foreign import"
       , pretty fd_fi
@@ -2089,7 +2164,7 @@ instance Pretty (ForeignDecl GhcPs) where
       , string "::"
       , pretty fd_sig_ty
       ]
-  pretty' ForeignExport {..} =
+  pretty' GHC.Hs.ForeignExport {..} =
     spaced
       [ string "foreign export"
       , pretty fd_fe
@@ -2108,10 +2183,11 @@ instance Pretty (ForeignImport GhcPs) where
     spaced [pretty conv, pretty safety, string s]
   pretty' (CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #else
-instance Pretty ForeignImport where
-  pretty' (CImport conv safety _ _ (L _ (SourceText s))) =
+instance Pretty GHC.Hs.ForeignImport where
+  pretty' (GHC.Hs.CImport conv safety _ _ (L _ (SourceText s))) =
     spaced [pretty conv, pretty safety, string s]
-  pretty' (CImport conv safety _ _ _) = spaced [pretty conv, pretty safety]
+  pretty' (GHC.Hs.CImport conv safety _ _ _) =
+    spaced [pretty conv, pretty safety]
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
@@ -2123,9 +2199,10 @@ instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
   pretty' (CExport _ conv) = pretty conv
 #else
-instance Pretty ForeignExport where
-  pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _) = pretty conv
+instance Pretty GHC.Hs.ForeignExport where
+  pretty' (GHC.Hs.CExport conv (L _ (SourceText s))) =
+    spaced [pretty conv, string s]
+  pretty' (GHC.Hs.CExport conv _) = pretty conv
 #endif
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
@@ -2143,16 +2220,16 @@ instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
 #else
-instance Pretty (AnnDecl GhcPs) where
-  pretty' (HsAnnotation _ _ (ValueAnnProvenance name) expr) =
+instance Pretty (GHC.Hs.AnnDecl GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.HsAnnotation _ _ (GHC.Hs.ValueAnnProvenance name) expr) =
     spaced [string "{-# ANN", pretty name, pretty expr, string "#-}"]
-  pretty' (HsAnnotation _ _ (TypeAnnProvenance name) expr) =
+  pretty' (GHC.Hs.HsAnnotation _ _ (GHC.Hs.TypeAnnProvenance name) expr) =
     spaced [string "{-# ANN type", pretty name, pretty expr, string "#-}"]
-  pretty' (HsAnnotation _ _ ModuleAnnProvenance expr) =
+  pretty' (GHC.Hs.HsAnnotation _ _ GHC.Hs.ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
 #endif
-instance Pretty (RoleAnnotDecl GhcPs) where
-  pretty' (RoleAnnotDecl _ name roles) =
+instance Pretty (GHC.Hs.RoleAnnotDecl GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.RoleAnnotDecl _ name roles) =
     spaced
       $ [string "type role", pretty name]
           ++ fmap (maybe (string "_") pretty . unLoc) roles
@@ -2162,51 +2239,52 @@ instance Pretty Role where
   pretty' Representational = string "representational"
   pretty' Phantom = string "phantom"
 
-instance Pretty (TyFamInstDecl GhcPs) where
-  pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
+instance Pretty (GHC.Hs.TyFamInstDecl GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
 
 instance Pretty TopLevelTyFamInstDecl where
-  pretty' (TopLevelTyFamInstDecl TyFamInstDecl {..}) =
+  pretty' (TopLevelTyFamInstDecl GHC.Hs.TyFamInstDecl {..}) =
     string "type instance " >> pretty tfid_eqn
 
-instance Pretty (DataFamInstDecl GhcPs) where
+instance Pretty (GHC.Hs.DataFamInstDecl GHC.Hs.GhcPs) where
   pretty' = pretty' . DataFamInstDeclTopLevel
 
 instance Pretty DataFamInstDecl' where
-  pretty' DataFamInstDecl' {dataFamInstDecl = DataFamInstDecl {..}, ..} =
+  pretty' DataFamInstDecl' {dataFamInstDecl = GHC.Hs.DataFamInstDecl {..}, ..} =
     pretty $ FamEqn' dataFamInstDeclFor dfid_eqn
 
-instance Pretty (PatSynBind GhcPs GhcPs) where
-  pretty' PSB {..} = do
+instance Pretty (GHC.Hs.PatSynBind GHC.Hs.GhcPs GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.PSB {..} = do
     string "pattern "
     case psb_args of
-      InfixCon l r -> spaced [pretty l, pretty $ fmap InfixOp psb_id, pretty r]
-      PrefixCon _ [] -> pretty psb_id
+      GHC.Hs.InfixCon l r ->
+        spaced [pretty l, pretty $ fmap InfixOp psb_id, pretty r]
+      GHC.Hs.PrefixCon _ [] -> pretty psb_id
       _ -> spaced [pretty psb_id, pretty psb_args]
     spacePrefixed [pretty psb_dir, pretty $ fmap PatInsidePatDecl psb_def]
     case psb_dir of
-      ExplicitBidirectional matches -> do
+      GHC.Hs.ExplicitBidirectional matches -> do
         newline
         indentedBlock $ string "where " |=> pretty matches
       _ -> pure ()
 
 -- | 'Pretty' for 'HsPatSynDetails'.
 instance Pretty
-           (HsConDetails
+           (GHC.Hs.HsConDetails
               Void
-              (GenLocated SrcSpanAnnN RdrName)
-              [RecordPatSynField GhcPs]) where
-  pretty' (PrefixCon _ xs) = spaced $ fmap pretty xs
-  pretty' (RecCon rec) = hFields $ fmap pretty rec
-  pretty' InfixCon {} =
+              (GenLocated GHC.Hs.SrcSpanAnnN RdrName)
+              [GHC.Hs.RecordPatSynField GHC.Hs.GhcPs]) where
+  pretty' (GHC.Hs.PrefixCon _ xs) = spaced $ fmap pretty xs
+  pretty' (GHC.Hs.RecCon rec) = hFields $ fmap pretty rec
+  pretty' GHC.Hs.InfixCon {} =
     error
       "Cannot handle here because `InfixCon` does not have the information of the constructor."
 
-instance Pretty (FixitySig GhcPs) where
-  pretty' (FixitySig _ names fixity) =
+instance Pretty (GHC.Hs.FixitySig GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.FixitySig _ names fixity) =
     spaced [pretty fixity, hCommaSep $ fmap (pretty . fmap InfixOp) names]
 
-instance Pretty Fixity where
+instance Pretty GHC.Hs.Fixity where
   pretty' (Fixity _ level dir) = spaced [pretty dir, string $ show level]
 
 instance Pretty FixityDirection where
@@ -2235,18 +2313,18 @@ prettyInlineSpec NoUserInlinePrag =
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
-instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional = string "<-"
-  pretty' ImplicitBidirectional = string "="
-  pretty' ExplicitBidirectional {} = string "<-"
+instance Pretty (GHC.Hs.HsPatSynDir GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.Unidirectional = string "<-"
+  pretty' GHC.Hs.ImplicitBidirectional = string "="
+  pretty' GHC.Hs.ExplicitBidirectional {} = string "<-"
 
-instance Pretty (HsOverLit GhcPs) where
-  pretty' OverLit {..} = pretty ol_val
+instance Pretty (GHC.Hs.HsOverLit GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.OverLit {..} = pretty ol_val
 
-instance Pretty OverLitVal where
-  pretty' (HsIntegral x) = pretty x
-  pretty' (HsFractional x) = pretty x
-  pretty' (HsIsString _ x) = string $ unpackFS x
+instance Pretty GHC.Hs.OverLitVal where
+  pretty' (GHC.Hs.HsIntegral x) = pretty x
+  pretty' (GHC.Hs.HsFractional x) = pretty x
+  pretty' (GHC.Hs.HsIsString _ x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
@@ -2259,22 +2337,22 @@ instance Pretty IntegralLit where
 instance Pretty FractionalLit where
   pretty' = output
 
-instance Pretty (HsLit GhcPs) where
-  pretty' x@(HsChar _ _) = output x
-  pretty' x@HsCharPrim {} = output x
-  pretty' HsInt {} = notUsedInParsedStage
-  pretty' (HsIntPrim _ x) = string $ show x ++ "#"
-  pretty' HsWordPrim {} = notUsedInParsedStage
-  pretty' HsInt64Prim {} = notUsedInParsedStage
-  pretty' HsWord64Prim {} = notUsedInParsedStage
-  pretty' HsInteger {} = notUsedInParsedStage
-  pretty' HsRat {} = notUsedInParsedStage
-  pretty' (HsFloatPrim _ x) = pretty x >> string "#"
-  pretty' HsDoublePrim {} = notUsedInParsedStage
+instance Pretty (GHC.Hs.HsLit GHC.Hs.GhcPs) where
+  pretty' x@(GHC.Hs.HsChar _ _) = output x
+  pretty' x@GHC.Hs.HsCharPrim {} = output x
+  pretty' GHC.Hs.HsInt {} = notUsedInParsedStage
+  pretty' (GHC.Hs.HsIntPrim _ x) = string $ show x ++ "#"
+  pretty' GHC.Hs.HsWordPrim {} = notUsedInParsedStage
+  pretty' GHC.Hs.HsInt64Prim {} = notUsedInParsedStage
+  pretty' GHC.Hs.HsWord64Prim {} = notUsedInParsedStage
+  pretty' GHC.Hs.HsInteger {} = notUsedInParsedStage
+  pretty' GHC.Hs.HsRat {} = notUsedInParsedStage
+  pretty' (GHC.Hs.HsFloatPrim _ x) = pretty x >> string "#"
+  pretty' GHC.Hs.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {} -> prettyString
-      HsStringPrim {} -> prettyString
+      GHC.Hs.HsString {} -> prettyString
+      GHC.Hs.HsStringPrim {} -> prettyString
     where
       prettyString =
         case lines $ showOutputable x of
@@ -2291,77 +2369,78 @@ instance Pretty (HsLit GhcPs) where
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
 #else
-instance Pretty (HsPragE GhcPs) where
-  pretty' (HsPragSCC _ _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
+instance Pretty (GHC.Hs.HsPragE GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.HsPragSCC _ _ x) =
+    spaced [string "{-# SCC", pretty x, string "#-}"]
 #endif
-instance Pretty HsIPName where
-  pretty' (HsIPName x) = string $ unpackFS x
+instance Pretty GHC.Hs.HsIPName where
+  pretty' (GHC.Hs.HsIPName x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
   pretty' (HsNumTy _ x) = string $ show x
   pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
-instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
-  pretty' (HsCharTy _ x) = string $ show x
+instance Pretty GHC.Hs.HsTyLit where
+  pretty' (GHC.Hs.HsNumTy _ x) = string $ show x
+  pretty' (GHC.Hs.HsStrTy _ x) = string $ ushow x
+  pretty' (GHC.Hs.HsCharTy _ x) = string $ show x
 #endif
-instance Pretty (HsPatSigType GhcPs) where
-  pretty' HsPS {..} = pretty hsps_body
+instance Pretty (GHC.Hs.HsPatSigType GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsPS {..} = pretty hsps_body
 
-instance Pretty (HsIPBinds GhcPs) where
-  pretty' (IPBinds _ xs) = lined $ fmap pretty xs
+instance Pretty (GHC.Hs.HsIPBinds GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.IPBinds _ xs) = lined $ fmap pretty xs
 
-instance Pretty (IPBind GhcPs) where
+instance Pretty (GHC.Hs.IPBind GHC.Hs.GhcPs) where
   pretty' = prettyIPBind
 
-prettyIPBind :: IPBind GhcPs -> Printer ()
+prettyIPBind :: GHC.Hs.IPBind GHC.Hs.GhcPs -> Printer ()
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyIPBind (IPBind _ l r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #else
-prettyIPBind (IPBind _ (Right _) _) = notUsedInParsedStage
-prettyIPBind (IPBind _ (Left l) r) =
+prettyIPBind (GHC.Hs.IPBind _ (Right _) _) = notUsedInParsedStage
+prettyIPBind (GHC.Hs.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
-instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {} = string "stock"
-  pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {} = string "newtype"
-  pretty' (ViaStrategy x) = string "via " >> pretty x
+instance Pretty (GHC.Hs.DerivStrategy GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.StockStrategy {} = string "stock"
+  pretty' GHC.Hs.AnyclassStrategy {} = string "anyclass"
+  pretty' GHC.Hs.NewtypeStrategy {} = string "newtype"
+  pretty' (GHC.Hs.ViaStrategy x) = string "via " >> pretty x
 
-instance Pretty XViaStrategyPs where
-  pretty' (XViaStrategyPs _ ty) = pretty ty
+instance Pretty GHC.Hs.XViaStrategyPs where
+  pretty' (GHC.Hs.XViaStrategyPs _ ty) = pretty ty
 
-instance Pretty (RecordPatSynField GhcPs) where
-  pretty' RecordPatSynField {..} = pretty recordPatSynField
+instance Pretty (GHC.Hs.RecordPatSynField GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.RecordPatSynField {..} = pretty recordPatSynField
 
-instance Pretty (HsCmdTop GhcPs) where
-  pretty' (HsCmdTop _ cmd) = pretty cmd
+instance Pretty (GHC.Hs.HsCmdTop GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.HsCmdTop _ cmd) = pretty cmd
 
-instance Pretty (HsCmd GhcPs) where
+instance Pretty (GHC.Hs.HsCmd GHC.Hs.GhcPs) where
   pretty' = prettyHsCmd
 
-prettyHsCmd :: HsCmd GhcPs -> Printer ()
-prettyHsCmd (HsCmdArrApp _ f arg HsHigherOrderApp True) =
+prettyHsCmd :: GHC.Hs.HsCmd GHC.Hs.GhcPs -> Printer ()
+prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsHigherOrderApp True) =
   spaced [pretty f, string "-<<", pretty arg]
-prettyHsCmd (HsCmdArrApp _ f arg HsHigherOrderApp False) =
+prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsHigherOrderApp False) =
   spaced [pretty arg, string ">>-", pretty f]
-prettyHsCmd (HsCmdArrApp _ f arg HsFirstOrderApp True) =
+prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsFirstOrderApp True) =
   spaced [pretty f, string "-<", pretty arg]
-prettyHsCmd (HsCmdArrApp _ f arg HsFirstOrderApp False) =
+prettyHsCmd (GHC.Hs.HsCmdArrApp _ f arg GHC.Hs.HsFirstOrderApp False) =
   spaced [pretty arg, string ">-", pretty f]
-prettyHsCmd (HsCmdArrForm _ f _ _ args) =
+prettyHsCmd (GHC.Hs.HsCmdArrForm _ f _ _ args) =
   bananaBrackets $ spaced $ pretty f : fmap pretty args
-prettyHsCmd (HsCmdApp _ f arg) = spaced [pretty f, pretty arg]
-prettyHsCmd (HsCmdLam _ x) = pretty x
+prettyHsCmd (GHC.Hs.HsCmdApp _ f arg) = spaced [pretty f, pretty arg]
+prettyHsCmd (GHC.Hs.HsCmdLam _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsCmd (HsCmdPar _ _ x _) = parens $ pretty x
 #else
-prettyHsCmd (HsCmdPar _ x) = parens $ pretty x
+prettyHsCmd (GHC.Hs.HsCmdPar _ x) = parens $ pretty x
 #endif
-prettyHsCmd (HsCmdCase _ cond arms) = do
+prettyHsCmd (GHC.Hs.HsCmdCase _ cond arms) = do
   spaced [string "case", pretty cond, string "of"]
   newline
   indentedBlock $ pretty arms
@@ -2371,12 +2450,12 @@ prettyHsCmd (HsCmdLamCase _ _ arms) = do
   newline
   indentedBlock $ pretty arms
 #else
-prettyHsCmd (HsCmdLamCase _ arms) = do
+prettyHsCmd (GHC.Hs.HsCmdLamCase _ arms) = do
   string "\\case"
   newline
   indentedBlock $ pretty arms
 #endif
-prettyHsCmd (HsCmdIf _ _ cond t f) = do
+prettyHsCmd (GHC.Hs.HsCmdIf _ _ cond t f) = do
   string "if "
   pretty cond
   newline
@@ -2385,10 +2464,10 @@ prettyHsCmd (HsCmdIf _ _ cond t f) = do
 prettyHsCmd (HsCmdLet _ _ binds _ expr) =
   lined [string "let " |=> pretty binds, string " in " |=> pretty expr]
 #else
-prettyHsCmd (HsCmdLet _ binds expr) =
+prettyHsCmd (GHC.Hs.HsCmdLet _ binds expr) =
   lined [string "let " |=> pretty binds, string " in " |=> pretty expr]
 #endif
-prettyHsCmd (HsCmdDo _ stmts) = do
+prettyHsCmd (GHC.Hs.HsCmdDo _ stmts) = do
   string "do"
   newline
   indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
@@ -2434,9 +2513,9 @@ instance Pretty LetIn where
   pretty' LetIn {..} =
     lined [string "let " |=> pretty letBinds, string " in " |=> pretty inExpr]
 
-instance Pretty (RuleBndr GhcPs) where
-  pretty' (RuleBndr _ name) = pretty name
-  pretty' (RuleBndrSig _ name sig) =
+instance Pretty (GHC.Hs.RuleBndr GHC.Hs.GhcPs) where
+  pretty' (GHC.Hs.RuleBndr _ name) = pretty name
+  pretty' (GHC.Hs.RuleBndrSig _ name sig) =
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
@@ -2446,25 +2525,25 @@ instance Pretty CCallConv where
   pretty' PrimCallConv = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 
-instance Pretty HsSrcBang where
-  pretty' (HsSrcBang _ unpack strictness) = do
+instance Pretty GHC.Hs.HsSrcBang where
+  pretty' (GHC.Hs.HsSrcBang _ unpack strictness) = do
     pretty unpack
-    unless (unpack == NoSrcUnpack) space
+    unless (unpack == GHC.Hs.NoSrcUnpack) space
     pretty strictness
 
-instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack = string "{-# UNPACK #-}"
-  pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
-  pretty' NoSrcUnpack = pure ()
+instance Pretty GHC.Hs.SrcUnpackedness where
+  pretty' GHC.Hs.SrcUnpack = string "{-# UNPACK #-}"
+  pretty' GHC.Hs.SrcNoUnpack = string "{-# NOUNPACK #-}"
+  pretty' GHC.Hs.NoSrcUnpack = pure ()
 
-instance Pretty SrcStrictness where
-  pretty' SrcLazy = string "~"
-  pretty' SrcStrict = string "!"
-  pretty' NoSrcStrict = pure ()
+instance Pretty GHC.Hs.SrcStrictness where
+  pretty' GHC.Hs.SrcLazy = string "~"
+  pretty' GHC.Hs.SrcStrict = string "!"
+  pretty' GHC.Hs.NoSrcStrict = pure ()
 
-instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
-  pretty' HsOuterImplicit {} = pure ()
-  pretty' HsOuterExplicit {..} = do
+instance Pretty (GHC.Hs.HsOuterSigTyVarBndrs GHC.Hs.GhcPs) where
+  pretty' GHC.Hs.HsOuterImplicit {} = pure ()
+  pretty' GHC.Hs.HsOuterExplicit {..} = do
     string "forall"
     spacePrefixed $ fmap pretty hso_bndrs
     dot

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1898,7 +1898,7 @@ instance Pretty VerticalContext where
 #endif
 -- Wrap a value of this type with 'ModulenameWithPrefix' to print it with
 -- the "module " prefix.
-instance Pretty ModuleName where
+instance Pretty GHC.Unit.ModuleName where
   pretty' = output
 
 instance Pretty ModuleNameWithPrefix where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -34,7 +34,7 @@ import           GHC.Stack
 import qualified GHC.Types.Basic                             as GHC
 import qualified GHC.Types.Fixity                            as GHC
 import qualified GHC.Types.ForeignCall                       as GHC
-import           GHC.Types.Name
+import qualified GHC.Types.Name                              as GHC
 import qualified GHC.Types.Name.Reader                       as GHC
 import qualified GHC.Types.SourceText                        as GHC
 import qualified GHC.Types.SrcLoc                            as GHC
@@ -1842,7 +1842,7 @@ instance Pretty InfixOp where
   pretty' (InfixOp GHC.Orig {}) = notUsedInParsedStage
   pretty' (InfixOp (GHC.Exact name)) = backticksIfNotSymbol occ $ pretty occ
     where
-      occ = GHC.Types.Name.occName name
+      occ = GHC.occName name
 
 instance Pretty PrefixOp where
   pretty' (PrefixOp (GHC.Unqual name)) = parensIfSymbol name $ pretty name
@@ -1854,7 +1854,7 @@ instance Pretty PrefixOp where
   pretty' (PrefixOp GHC.Orig {}) = notUsedInParsedStage
   pretty' (PrefixOp (GHC.Exact name)) = parensIfSymbol occ $ output name
     where
-      occ = GHC.Types.Name.occName name
+      occ = GHC.occName name
 
 instance Pretty Context where
   pretty' (Context xs) =
@@ -2087,7 +2087,7 @@ instance Pretty (GHC.RuleDecl GHC.GhcPs) where
             space
             pretty rd_lhs
 #endif
-instance Pretty GHC.Types.Name.OccName where
+instance Pretty GHC.OccName where
   pretty' = output
 
 instance Pretty (GHC.DerivDecl GHC.GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -33,7 +33,7 @@ import qualified GHC.Hs                                      as GHC
 import           GHC.Stack
 import qualified GHC.Types.Basic                             as GHC
 import qualified GHC.Types.Fixity                            as GHC
-import           GHC.Types.ForeignCall
+import qualified GHC.Types.ForeignCall                       as GHC
 import           GHC.Types.Name
 import           GHC.Types.Name.Reader
 import           GHC.Types.SourceText
@@ -2171,13 +2171,13 @@ instance Pretty GHC.ForeignExport where
     spaced [pretty conv, string s]
   pretty' (GHC.CExport conv _) = pretty conv
 #endif
-instance Pretty GHC.Types.ForeignCall.CExportSpec where
-  pretty' (GHC.Types.ForeignCall.CExportStatic _ _ x) = pretty x
+instance Pretty GHC.CExportSpec where
+  pretty' (GHC.CExportStatic _ _ x) = pretty x
 
-instance Pretty GHC.Types.ForeignCall.Safety where
-  pretty' GHC.Types.ForeignCall.PlaySafe          = string "safe"
-  pretty' GHC.Types.ForeignCall.PlayInterruptible = string "interruptible"
-  pretty' GHC.Types.ForeignCall.PlayRisky         = string "unsafe"
+instance Pretty GHC.Safety where
+  pretty' GHC.PlaySafe          = string "safe"
+  pretty' GHC.PlayInterruptible = string "interruptible"
+  pretty' GHC.PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2481,12 +2481,12 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
   pretty' (GHC.RuleBndrSig _ name sig) =
     parens $ spaced [pretty name, string "::", pretty sig]
 
-instance Pretty GHC.Types.ForeignCall.CCallConv where
-  pretty' GHC.Types.ForeignCall.CCallConv          = string "ccall"
-  pretty' GHC.Types.ForeignCall.CApiConv           = string "capi"
-  pretty' GHC.Types.ForeignCall.StdCallConv        = string "stdcall"
-  pretty' GHC.Types.ForeignCall.PrimCallConv       = string "prim"
-  pretty' GHC.Types.ForeignCall.JavaScriptCallConv = string "javascript"
+instance Pretty GHC.CCallConv where
+  pretty' GHC.CCallConv          = string "ccall"
+  pretty' GHC.CApiConv           = string "capi"
+  pretty' GHC.StdCallConv        = string "stdcall"
+  pretty' GHC.PrimCallConv       = string "prim"
+  pretty' GHC.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
   pretty' (GHC.HsSrcBang _ unpack strictness) = do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -25,7 +25,7 @@ import           Control.Monad
 import           Control.Monad.RWS
 import           Data.Maybe
 import           Data.Void
-import           GHC.Core.Coercion
+import qualified GHC.Core.Coercion                           as GHC
 import qualified GHC.Data.Bag                                as GHC
 import qualified GHC.Data.BooleanFormula                     as GHC
 import qualified GHC.Data.FastString                         as GHC
@@ -2208,10 +2208,10 @@ instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
     [string "type role", pretty name] ++
     fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
-instance Pretty GHC.Core.Coercion.Role where
-  pretty' GHC.Core.Coercion.Nominal          = string "nominal"
-  pretty' GHC.Core.Coercion.Representational = string "representational"
-  pretty' GHC.Core.Coercion.Phantom          = string "phantom"
+instance Pretty GHC.Role where
+  pretty' GHC.Nominal          = string "nominal"
+  pretty' GHC.Representational = string "representational"
+  pretty' GHC.Phantom          = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1758,7 +1758,7 @@ instance Pretty GHC.OverlapMode where
   pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
   pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
 
-instance Pretty StringLiteral where
+instance Pretty GHC.Types.SourceText.StringLiteral where
   pretty' = output
 
 -- | This instance is for type family declarations inside a class declaration.
@@ -2152,7 +2152,7 @@ instance Pretty (ForeignImport GhcPs) where
   pretty' (CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #else
 instance Pretty GHC.ForeignImport where
-  pretty' (GHC.CImport conv safety _ _ (L _ (SourceText s))) =
+  pretty' (GHC.CImport conv safety _ _ (L _ (GHC.Types.SourceText.SourceText s))) =
     spaced [pretty conv, pretty safety, string s]
   pretty' (GHC.CImport conv safety _ _ _) = spaced [pretty conv, pretty safety]
 #endif
@@ -2167,7 +2167,7 @@ instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport _ conv)                    = pretty conv
 #else
 instance Pretty GHC.ForeignExport where
-  pretty' (GHC.CExport conv (L _ (SourceText s))) =
+  pretty' (GHC.CExport conv (L _ (GHC.Types.SourceText.SourceText s))) =
     spaced [pretty conv, string s]
   pretty' (GHC.CExport conv _) = pretty conv
 #endif
@@ -2297,11 +2297,12 @@ instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
   pretty' IL {..}                     = string $ show il_value
 #else
-instance Pretty IntegralLit where
-  pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..}                     = string $ show il_value
+instance Pretty GHC.Types.SourceText.IntegralLit where
+  pretty' GHC.Types.SourceText.IL {il_text = GHC.Types.SourceText.SourceText s} =
+    string s
+  pretty' GHC.Types.SourceText.IL {..} = string $ show il_value
 #endif
-instance Pretty FractionalLit where
+instance Pretty GHC.Types.SourceText.FractionalLit where
   pretty' = output
 
 instance Pretty (GHC.HsLit GHC.GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2004,8 +2004,10 @@ instance Pretty (WarnDecl GhcPs) where
 instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
-      DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      GHC.Unit.Module.Warnings.DeprecatedTxt _ reasons ->
+        prettyWithTitleReasons "DEPRECATED" reasons
+      GHC.Unit.Module.Warnings.WarningTxt _ reasons ->
+        prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1711,7 +1711,9 @@ instance Pretty InfixApp where
             error
               "The number of the sum of operants and operators should be odd."
       prettyOps _ = error "Too short list."
-      findFixity o = fromMaybe GHC.defaultFixity $ lookup (varToStr o) fixities
+      findFixity o =
+        fromMaybe GHC.defaultFixity $
+        lookup (Language.Haskell.GhclibParserEx.GHC.Hs.Expr.varToStr o) fixities
       allOperantsAndOperatorsLeftAssoc = reverse $ rhs : op : collect lhs
         where
           collect :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -26,7 +26,7 @@ import           Control.Monad.RWS
 import           Data.Maybe
 import           Data.Void
 import           GHC.Core.Coercion
-import           GHC.Data.Bag
+import qualified GHC.Data.Bag                                as GHC
 import qualified GHC.Data.BooleanFormula                     as GHC
 import qualified GHC.Data.FastString                         as GHC
 import qualified GHC.Hs                                      as GHC
@@ -260,12 +260,7 @@ prettyTyClDecl GHC.ClassDecl {..} = do
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
-      mkSortedLSigBindFamilyList
-        tcdSigs
-        (GHC.Data.Bag.bagToList tcdMeths)
-        tcdATs
-        []
-        []
+      mkSortedLSigBindFamilyList tcdSigs (GHC.bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
   pretty' GHC.ClsInstD {..}     = pretty cid_inst
@@ -513,7 +508,7 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       sigsAndMethods =
         mkSortedLSigBindFamilyList
           cid_sigs
-          (GHC.Data.Bag.bagToList cid_binds)
+          (GHC.bagToList cid_binds)
           []
           cid_tyfam_insts
           cid_datafam_insts
@@ -1564,12 +1559,7 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
   pretty' (GHC.ValBinds _ methods sigs) = lined $ fmap pretty sigsAndMethods
     where
       sigsAndMethods =
-        mkSortedLSigBindFamilyList
-          sigs
-          (GHC.Data.Bag.bagToList methods)
-          []
-          []
-          []
+        mkSortedLSigBindFamilyList sigs (GHC.bagToList methods) [] [] []
   pretty' GHC.XValBindsLR {} = notUsedInParsedStage
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -27,7 +27,7 @@ import           Data.Maybe
 import           Data.Void
 import           GHC.Core.Coercion
 import           GHC.Data.Bag
-import           GHC.Data.BooleanFormula
+import qualified GHC.Data.BooleanFormula                     as GHC
 import qualified GHC.Data.FastString                         as GHC
 import qualified GHC.Hs                                      as GHC
 import           GHC.Stack
@@ -1728,11 +1728,11 @@ instance Pretty InfixApp where
       isSameAssoc (findFixity -> GHC.Fixity _ lv d) = lv == level && d == dir
       GHC.Fixity _ level dir = findFixity op
 
-instance Pretty a => Pretty (GHC.Data.BooleanFormula.BooleanFormula a) where
-  pretty' (GHC.Data.BooleanFormula.Var x)    = pretty x
-  pretty' (GHC.Data.BooleanFormula.And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (GHC.Data.BooleanFormula.Or xs)    = hvBarSep $ fmap pretty xs
-  pretty' (GHC.Data.BooleanFormula.Parens x) = parens $ pretty x
+instance Pretty a => Pretty (GHC.BooleanFormula a) where
+  pretty' (GHC.Var x)    = pretty x
+  pretty' (GHC.And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
   pretty' (GHC.FieldLabelStrings xs) = hDotSep $ fmap pretty xs

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -28,7 +28,7 @@ import           Data.Void
 import           GHC.Core.Coercion
 import           GHC.Data.Bag
 import           GHC.Data.BooleanFormula
-import           GHC.Data.FastString
+import qualified GHC.Data.FastString                         as GHC
 import qualified GHC.Hs                                      as GHC
 import           GHC.Stack
 import qualified GHC.Types.Basic                             as GHC
@@ -534,8 +534,7 @@ prettyHsExpr (GHC.HsUnboundVar _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsOverLabel _ _ l) = string "#" >> string (unpackFS l)
 #else
-prettyHsExpr (GHC.HsOverLabel _ l) =
-  string "#" >> string (GHC.Data.FastString.unpackFS l)
+prettyHsExpr (GHC.HsOverLabel _ l) = string "#" >> string (GHC.unpackFS l)
 #endif
 prettyHsExpr (GHC.HsIPVar _ var) = string "?" >> pretty var
 prettyHsExpr (GHC.HsOverLit _ x) = pretty x
@@ -1454,8 +1453,7 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
     brackets $ do
       pretty l
       wrapWithBars $
-        indentedWithFixedLevel 0 $
-        sequence_ $ printers [] "" $ GHC.Data.FastString.unpackFS r
+        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ GHC.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -2045,7 +2043,7 @@ instance Pretty (DotFieldOcc GhcPs) where
 #else
 instance Pretty (GHC.HsFieldLabel GHC.GhcPs) where
   pretty' GHC.HsFieldLabel {..} =
-    printCommentsAnd hflLabel (string . GHC.Data.FastString.unpackFS)
+    printCommentsAnd hflLabel (string . GHC.unpackFS)
 #endif
 instance Pretty (GHC.RuleDecls GHC.GhcPs) where
   pretty' GHC.HsRules {..} =
@@ -2073,9 +2071,7 @@ instance Pretty (RuleDecl GhcPs) where
 instance Pretty (GHC.RuleDecl GHC.GhcPs) where
   pretty' GHC.HsRule {..} =
     spaced
-      [ printCommentsAnd
-          rd_name
-          (doubleQuotes . string . GHC.Data.FastString.unpackFS . snd)
+      [ printCommentsAnd rd_name (doubleQuotes . string . GHC.unpackFS . snd)
       , lhs
       , string "="
       , pretty rd_rhs
@@ -2302,7 +2298,7 @@ instance Pretty (GHC.HsOverLit GHC.GhcPs) where
 instance Pretty GHC.OverLitVal where
   pretty' (GHC.HsIntegral x)   = pretty x
   pretty' (GHC.HsFractional x) = pretty x
-  pretty' (GHC.HsIsString _ x) = string $ GHC.Data.FastString.unpackFS x
+  pretty' (GHC.HsIsString _ x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
@@ -2351,7 +2347,7 @@ instance Pretty (GHC.HsPragE GHC.GhcPs) where
     spaced [string "{-# SCC", pretty x, string "#-}"]
 #endif
 instance Pretty GHC.HsIPName where
-  pretty' (GHC.HsIPName x) = string $ GHC.Data.FastString.unpackFS x
+  pretty' (GHC.HsIPName x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
   pretty' (HsNumTy _ x)  = string $ show x

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1342,7 +1342,7 @@ instance Pretty ParStmtBlockInsideVerticalList where
   pretty' (ParStmtBlockInsideVerticalList (GHC.ParStmtBlock _ xs _ _)) =
     vCommaSep $ fmap pretty xs
 
-instance Pretty RdrName where
+instance Pretty GHC.Types.Name.Reader.RdrName where
   pretty' = pretty . PrefixOp
 
 instance Pretty
@@ -1827,26 +1827,30 @@ instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
     dot
 
 instance Pretty InfixOp where
-  pretty' (InfixOp (Unqual name)) = backticksIfNotSymbol name $ pretty name
-  pretty' (InfixOp (Qual modName name)) =
+  pretty' (InfixOp (GHC.Types.Name.Reader.Unqual name)) =
+    backticksIfNotSymbol name $ pretty name
+  pretty' (InfixOp (GHC.Types.Name.Reader.Qual modName name)) =
     backticksIfNotSymbol name $ do
       pretty modName
       string "."
       pretty name
-  pretty' (InfixOp Orig {}) = notUsedInParsedStage
-  pretty' (InfixOp (Exact name)) = backticksIfNotSymbol occ $ pretty occ
+  pretty' (InfixOp GHC.Types.Name.Reader.Orig {}) = notUsedInParsedStage
+  pretty' (InfixOp (GHC.Types.Name.Reader.Exact name)) =
+    backticksIfNotSymbol occ $ pretty occ
     where
       occ = GHC.Types.Name.occName name
 
 instance Pretty PrefixOp where
-  pretty' (PrefixOp (Unqual name)) = parensIfSymbol name $ pretty name
-  pretty' (PrefixOp (Qual modName name)) =
+  pretty' (PrefixOp (GHC.Types.Name.Reader.Unqual name)) =
+    parensIfSymbol name $ pretty name
+  pretty' (PrefixOp (GHC.Types.Name.Reader.Qual modName name)) =
     parensIfSymbol name $ do
       pretty modName
       string "."
       pretty name
-  pretty' (PrefixOp Orig {}) = notUsedInParsedStage
-  pretty' (PrefixOp (Exact name)) = parensIfSymbol occ $ output name
+  pretty' (PrefixOp GHC.Types.Name.Reader.Orig {}) = notUsedInParsedStage
+  pretty' (PrefixOp (GHC.Types.Name.Reader.Exact name)) =
+    parensIfSymbol occ $ output name
     where
       occ = GHC.Types.Name.occName name
 
@@ -2023,7 +2027,7 @@ instance Pretty (IEWrappedName GhcPs) where
   pretty' (IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
-instance Pretty (GHC.IEWrappedName RdrName) where
+instance Pretty (GHC.IEWrappedName GHC.Types.Name.Reader.RdrName) where
   pretty' (GHC.IEName name)      = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
   pretty' (GHC.IEType _ name)    = string "type " >> pretty name
@@ -2239,7 +2243,7 @@ instance Pretty (GHC.PatSynBind GHC.GhcPs GHC.GhcPs) where
 instance Pretty
            (GHC.HsConDetails
               Void
-              (GenLocated GHC.SrcSpanAnnN RdrName)
+              (GenLocated GHC.SrcSpanAnnN GHC.Types.Name.Reader.RdrName)
               [GHC.RecordPatSynField GHC.GhcPs]) where
   pretty' (GHC.PrefixCon _ xs) = spaced $ fmap pretty xs
   pretty' (GHC.RecCon rec) = hFields $ fmap pretty rec

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1836,7 +1836,7 @@ instance Pretty InfixOp where
   pretty' (InfixOp Orig {}) = notUsedInParsedStage
   pretty' (InfixOp (Exact name)) = backticksIfNotSymbol occ $ pretty occ
     where
-      occ = occName name
+      occ = GHC.Types.Name.occName name
 
 instance Pretty PrefixOp where
   pretty' (PrefixOp (Unqual name)) = parensIfSymbol name $ pretty name
@@ -1848,7 +1848,7 @@ instance Pretty PrefixOp where
   pretty' (PrefixOp Orig {}) = notUsedInParsedStage
   pretty' (PrefixOp (Exact name)) = parensIfSymbol occ $ output name
     where
-      occ = occName name
+      occ = GHC.Types.Name.occName name
 
 instance Pretty Context where
   pretty' (Context xs) =
@@ -2080,7 +2080,7 @@ instance Pretty (GHC.RuleDecl GHC.GhcPs) where
             space
             pretty rd_lhs
 #endif
-instance Pretty OccName where
+instance Pretty GHC.Types.Name.OccName where
   pretty' = output
 
 instance Pretty (GHC.DerivDecl GHC.GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Pretty printing.
 --
@@ -21,41 +21,41 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
-import           Data.Maybe
-import           Data.Void
-import qualified GHC.Core.Coercion                           as GHC
-import qualified GHC.Data.Bag                                as GHC
-import qualified GHC.Data.BooleanFormula                     as GHC
-import qualified GHC.Data.FastString                         as GHC
-import qualified GHC.Hs                                      as GHC
-import           GHC.Stack
-import qualified GHC.Types.Basic                             as GHC
-import qualified GHC.Types.Fixity                            as GHC
-import qualified GHC.Types.ForeignCall                       as GHC
-import qualified GHC.Types.Name                              as GHC
-import qualified GHC.Types.Name.Reader                       as GHC
-import qualified GHC.Types.SourceText                        as GHC
-import qualified GHC.Types.SrcLoc                            as GHC
-import qualified GHC.Unit.Module.Warnings                    as GHC
-import           HIndent.Applicative
-import           HIndent.Ast.NodeComments
-import           HIndent.Config
-import           HIndent.Fixity
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
-import           HIndent.Pretty.SigBindFamily
-import           HIndent.Pretty.Types
-import           HIndent.Printer
+import Control.Monad
+import Control.Monad.RWS
+import Data.Maybe
+import Data.Void
+import qualified GHC.Core.Coercion as GHC
+import qualified GHC.Data.Bag as GHC
+import qualified GHC.Data.BooleanFormula as GHC
+import qualified GHC.Data.FastString as GHC
+import qualified GHC.Hs as GHC
+import GHC.Stack
+import qualified GHC.Types.Basic as GHC
+import qualified GHC.Types.Fixity as GHC
+import qualified GHC.Types.ForeignCall as GHC
+import qualified GHC.Types.Name as GHC
+import qualified GHC.Types.Name.Reader as GHC
+import qualified GHC.Types.SourceText as GHC
+import qualified GHC.Types.SrcLoc as GHC
+import qualified GHC.Unit.Module.Warnings as GHC
+import HIndent.Applicative
+import HIndent.Ast.NodeComments
+import HIndent.Config
+import HIndent.Fixity
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+import HIndent.Pretty.SigBindFamily
+import HIndent.Pretty.Types
+import HIndent.Printer
 import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr as GHC
-import           Text.Show.Unicode
+import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable                               as NonEmpty
-import qualified GHC.Core.DataCon                            as GHC
+import qualified Data.Foldable as NonEmpty
+import qualified GHC.Core.DataCon as GHC
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified GHC.Unit                                    as GHC
+import qualified GHC.Unit as GHC
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -92,8 +92,10 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -129,19 +131,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GHC.GenLocated l e) where
   pretty' (GHC.L _ e) = pretty e
 
 instance Pretty (GHC.HsDecl GHC.GhcPs) where
-  pretty' (GHC.TyClD _ d)      = pretty d
-  pretty' (GHC.InstD _ inst)   = pretty inst
-  pretty' (GHC.DerivD _ x)     = pretty x
-  pretty' (GHC.ValD _ bind)    = pretty bind
-  pretty' (GHC.SigD _ s)       = pretty s
-  pretty' (GHC.KindSigD _ x)   = pretty x
-  pretty' (GHC.DefD _ x)       = pretty x
-  pretty' (GHC.ForD _ x)       = pretty x
-  pretty' (GHC.WarningD _ x)   = pretty x
-  pretty' (GHC.AnnD _ x)       = pretty x
-  pretty' (GHC.RuleD _ x)      = pretty x
-  pretty' (GHC.SpliceD _ sp)   = pretty sp
-  pretty' GHC.DocD {}          = docNode
+  pretty' (GHC.TyClD _ d) = pretty d
+  pretty' (GHC.InstD _ inst) = pretty inst
+  pretty' (GHC.DerivD _ x) = pretty x
+  pretty' (GHC.ValD _ bind) = pretty bind
+  pretty' (GHC.SigD _ s) = pretty s
+  pretty' (GHC.KindSigD _ x) = pretty x
+  pretty' (GHC.DefD _ x) = pretty x
+  pretty' (GHC.ForD _ x) = pretty x
+  pretty' (GHC.WarningD _ x) = pretty x
+  pretty' (GHC.AnnD _ x) = pretty x
+  pretty' (GHC.RuleD _ x) = pretty x
+  pretty' (GHC.SpliceD _ sp) = pretty sp
+  pretty' GHC.DocD {} = docNode
   pretty' (GHC.RoleAnnotD _ x) = pretty x
 
 instance Pretty (GHC.TyClDecl GHC.GhcPs) where
@@ -180,7 +182,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_cons tcdDataDefn of
         DataTypeCons {} -> string "data "
-        NewTypeCon {}   -> string "newtype "
+        NewTypeCon {} -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -195,7 +197,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType  -> string "newtype "
+        GHC.NewType -> string "newtype "
 #else
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -210,7 +212,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType  -> string "newtype "
+        GHC.NewType -> string "newtype "
 #endif
 prettyTyClDecl GHC.ClassDecl {..} = do
   if isJust tcdCtxt
@@ -231,20 +233,21 @@ prettyTyClDecl GHC.ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            []  -> string "()"
+            [] -> string "()"
             [x] -> pretty x
-            xs  -> hvTuple $ fmap pretty xs
+            xs -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock $
-          string "| " |=>
-          vCommaSep
-            (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
-               printCommentsAnd x $ \(GHC.FunDep _ from to) ->
-                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock
+          $ string "| "
+              |=> vCommaSep
+                    (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
+                       printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                         spaced
+                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -255,27 +258,27 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         GHC.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens $
-                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens
+                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (GHC.bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
-  pretty' GHC.ClsInstD {..}     = pretty cid_inst
+  pretty' GHC.ClsInstD {..} = pretty cid_inst
   pretty' GHC.DataFamInstD {..} = pretty dfid_inst
-  pretty' GHC.TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' GHC.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (GHC.HsBind GHC.GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: GHC.HsBind GHC.GhcPs -> Printer ()
-prettyHsBind GHC.FunBind {..}     = pretty fun_matches
-prettyHsBind GHC.PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind GHC.VarBind {}       = notGeneratedByParser
+prettyHsBind GHC.FunBind {..} = pretty fun_matches
+prettyHsBind GHC.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind GHC.AbsBinds {}      = notGeneratedByParser
+prettyHsBind GHC.AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (GHC.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -292,13 +295,14 @@ instance Pretty (Sig GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=>
-               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space
+                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -318,9 +322,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -360,13 +364,14 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=>
-               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space
+                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -386,9 +391,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' GHC.IdSig {} = notGeneratedByParser
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
@@ -447,12 +452,12 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       cons =
         case dd_cons of
-          NewTypeCon x      -> [x]
+          NewTypeCon x -> [x]
           DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
-          _                                       -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -488,7 +493,7 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
       isGADT =
         case dd_cons of
           (GHC.L _ GHC.ConDeclGADT {}:_) -> True
-          _                              -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -499,8 +504,8 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -554,17 +559,18 @@ prettyHsExpr (GHC.HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              []         -> error "Invalid function application."
+              [] -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col' - col -
-            if col == 0
-              then spaces
-              else 0
+            col'
+              - col
+              - if col == 0
+                  then spaces
+                  else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -603,11 +609,11 @@ prettyHsExpr (GHC.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens $
-      prefixedLined "," $
-      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens
+        $ prefixedLined ","
+        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing GHC.Missing {} = True
-    isMissing _              = False
+    isMissing _ = False
 prettyHsExpr (GHC.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -643,8 +649,8 @@ prettyHsExpr (GHC.HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (GHC.HsMultiIf _ guards) =
-  string "if " |=>
-  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if "
+    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (GHC.HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -708,9 +714,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsFieldBind a b)]
@@ -738,9 +744,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsRecField' a b)]
@@ -767,10 +773,11 @@ prettyHsExpr (GHC.HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr GHC.HsProjection {..} =
-  parens $
-  forM_ proj_flds $ \x -> do
-    string "."
-    pretty x
+  parens
+    $ forM_ proj_flds
+    $ \x -> do
+        string "."
+        pretty x
 prettyHsExpr (GHC.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -782,8 +789,8 @@ prettyHsExpr (GHC.HsSpliceE _ x) = pretty x
 prettyHsExpr (GHC.HsProc _ pat x@(GHC.L _ (GHC.HsCmdTop _ (GHC.L _ (GHC.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock $
-    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock
+    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (GHC.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -817,7 +824,7 @@ prettyHsExpr (HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case  -> string "\\case"
+      Case -> string "\\case"
       Cases -> string "\\cases"
     if null $ GHC.unLoc $ GHC.mg_alts matches
       then string " {}"
@@ -844,10 +851,12 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do hor <-|> ver
-                     newline
-                     prefixed "=> " $
-                       prefixedLined "-> " $ pretty <$> flatten hst_body
+               in do
+                    hor <-|> ver
+                    newline
+                    prefixed "=> "
+                      $ prefixedLined "-> "
+                      $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -857,7 +866,7 @@ instance Pretty HsSigType' where
     where
       flatten :: GHC.LHsType GHC.GhcPs -> [GHC.LHsType GHC.GhcPs]
       flatten (GHC.L _ (GHC.HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x                               = [x]
+      flatten x = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig GHC.HsSig {..}) =
     case sig_bndrs of
       GHC.HsOuterExplicit _ xs -> do
@@ -866,8 +875,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           GHC.HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
-              (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt))
+              <-|> (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -897,10 +906,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -911,19 +920,19 @@ prettyConDecl ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     forallNeeded =
@@ -941,10 +950,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -955,52 +964,52 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
-
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt)) <-|>
-        (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt))
+        <-|> (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
-      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
+        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-
+    
     forallNeeded =
       case GHC.unLoc con_bndrs of
         GHC.HsOuterImplicit {} -> False
@@ -1008,26 +1017,30 @@ prettyConDecl GHC.ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \c -> do
-        pretty $ Context c
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \c -> do
+             pretty $ Context c
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #else
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \_ -> do
-        pretty $ Context con_mb_cxt
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \_ -> do
+             pretty $ Context con_mb_cxt
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #endif
 prettyConDecl GHC.ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1046,11 +1059,11 @@ instance Pretty
 prettyMatchExpr :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Printer ()
 prettyMatchExpr GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case GHC.unLoc $ head m_pats of
-      GHC.LazyPat {} -> space
-      GHC.BangPat {} -> space
-      _              -> return ()
+  unless (null m_pats)
+    $ case GHC.unLoc $ head m_pats of
+        GHC.LazyPat {} -> space
+        GHC.BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr GHC.Match {m_ctxt = GHC.CaseAlt, ..} = do
@@ -1070,8 +1083,9 @@ prettyMatchExpr GHC.Match {..} =
     GHC.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
-          spaced $
-            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
+          spaced
+            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
+                ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1084,11 +1098,11 @@ instance Pretty
 prettyMatchProc :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Printer ()
 prettyMatchProc GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case GHC.unLoc $ head m_pats of
-      GHC.LazyPat {} -> space
-      GHC.BangPat {} -> space
-      _              -> return ()
+  unless (null m_pats)
+    $ case GHC.unLoc $ head m_pats of
+        GHC.LazyPat {} -> space
+        GHC.BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc GHC.Match {m_ctxt = GHC.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1159,7 +1173,7 @@ instance Pretty
     where
       horizontal =
         case rec_dotdot of
-          Just _  -> braces $ string ".."
+          Just _ -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1171,8 +1185,8 @@ instance Pretty
   pretty' GHC.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (GHC.HsType GHC.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1279,7 +1293,7 @@ prettyHsType (GHC.HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (GHC.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _  -> hvPromotedList $ fmap pretty xs
+    _ -> hvPromotedList $ fmap pretty xs
 prettyHsType (GHC.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (GHC.HsTyLit _ x) = pretty x
 prettyHsType GHC.HsWildCardTy {} = string "_"
@@ -1300,11 +1314,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (GHC.HsValBinds epa lr, _) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty
@@ -1315,11 +1329,11 @@ instance Pretty
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (GHC.HsValBinds epa lr) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (GHC.HsMatchContext GHC.GhcPs) where
@@ -1454,8 +1468,11 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
   pretty' (GHC.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars $
-        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ GHC.unpackFS r
+      wrapWithBars
+        $ indentedWithFixedLevel 0
+        $ sequence_
+        $ printers [] ""
+        $ GHC.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1519,13 +1536,13 @@ prettyPat (GHC.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat GHC.HsRecFields {..}) =
     case fieldPrinters of
-      []  -> string "{}"
+      [] -> string "{}"
       [x] -> braces x
-      xs  -> hvFields xs
+      xs -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1541,10 +1558,10 @@ instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x)         = pretty x
-  pretty' (Bind x)        = pretty x
-  pretty' (TypeFamily x)  = pretty x
-  pretty' (TyFamInst x)   = pretty x
+  pretty' (Sig x) = pretty x
+  pretty' (Bind x) = pretty x
+  pretty' (TypeFamily x) = pretty x
+  pretty' (TyFamInst x) = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty GHC.EpaComment where
@@ -1566,7 +1583,7 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where
   pretty' (GHC.Present _ e) = pretty e
-  pretty' GHC.Missing {}    = pure () -- This appears in a tuple section.
+  pretty' GHC.Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField GHC.HsFieldBind {..}) = do
@@ -1671,7 +1688,7 @@ instance Pretty (GHC.ConDeclField GHC.GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (GHC.L _ (GHC.HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x)                            = pretty' x
+  pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1732,9 +1749,9 @@ instance Pretty InfixApp where
       GHC.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (GHC.BooleanFormula a) where
-  pretty' (GHC.Var x)    = pretty x
-  pretty' (GHC.And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (GHC.Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Var x) = pretty x
+  pretty' (GHC.And xs) = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Or xs) = hvBarSep $ fmap pretty xs
   pretty' (GHC.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
@@ -1742,7 +1759,7 @@ instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
 
 instance Pretty (GHC.AmbiguousFieldOcc GHC.GhcPs) where
   pretty' (GHC.Unambiguous _ name) = pretty name
-  pretty' (GHC.Ambiguous _ name)   = pretty name
+  pretty' (GHC.Ambiguous _ name) = pretty name
 
 instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
   pretty' GHC.HsDerivingClause { deriv_clause_strategy = Just strategy@(GHC.L _ GHC.ViaStrategy {})
@@ -1758,14 +1775,14 @@ instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
 
 instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
   pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
-  pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
+  pretty' (GHC.DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty GHC.OverlapMode where
-  pretty' GHC.NoOverlap {}    = notUsedInParsedStage
+  pretty' GHC.NoOverlap {} = notUsedInParsedStage
   pretty' GHC.Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' GHC.Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
+  pretty' GHC.Overlapping {} = string "{-# OVERLAPPING #-}"
+  pretty' GHC.Overlaps {} = string "{-# OVERLAPS #-}"
+  pretty' GHC.Incoherent {} = string "{-# INCOHERENT #-}"
 
 instance Pretty GHC.StringLiteral where
   pretty' = output
@@ -1773,13 +1790,13 @@ instance Pretty GHC.StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
   pretty' GHC.FamilyDecl {..} = do
-    string $
-      case fdInfo of
-        GHC.DataFamily          -> "data"
-        GHC.OpenTypeFamily      -> "type"
-        GHC.ClosedTypeFamily {} -> "type"
+    string
+      $ case fdInfo of
+          GHC.DataFamily -> "data"
+          GHC.OpenTypeFamily -> "type"
+          GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      GHC.TopLevel    -> string " family "
+      GHC.TopLevel -> string " family "
       GHC.NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
@@ -1802,8 +1819,8 @@ instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
       _ -> pure ()
 
 instance Pretty (GHC.FamilyResultSig GHC.GhcPs) where
-  pretty' GHC.NoSig {}       = pure ()
-  pretty' (GHC.KindSig _ x)  = string ":: " >> pretty x
+  pretty' GHC.NoSig {} = pure ()
+  pretty' (GHC.KindSig _ x) = string ":: " >> pretty x
   pretty' (GHC.TyVarSig _ x) = pretty x
 
 instance Pretty (GHC.HsTyVarBndr a GHC.GhcPs) where
@@ -1822,8 +1839,8 @@ instance Pretty (GHC.ArithSeqInfo GHC.GhcPs) where
   pretty' (GHC.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (GHC.FromThenTo from next to) =
-    brackets $
-    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets
+      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
   pretty' GHC.HsForAllVis {..} = do
@@ -1869,9 +1886,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (GHC.L _ [])  -> parens
+          (GHC.L _ []) -> parens
           (GHC.L _ [_]) -> id
-          _             -> parens
+          _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(GHC.L _ [])) =
@@ -1886,10 +1903,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing            -> id
-          Just (GHC.L _ [])  -> parens
+          Nothing -> id
+          Just (GHC.L _ []) -> parens
           Just (GHC.L _ [_]) -> id
-          Just _             -> parens
+          Just _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1951,7 +1968,7 @@ instance Pretty FamEqn' where
     where
       prefix =
         case famEqnFor of
-          DataFamInstDeclForTopLevel        -> "data instance"
+          DataFamInstDeclForTopLevel -> "data instance"
           DataFamInstDeclForInsideClassInst -> "data"
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
@@ -1960,17 +1977,17 @@ instance Pretty
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x)    = pretty x
+  pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {}     = notUsedInParsedStage
+  pretty' HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
            (GHC.HsArg
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x)    = pretty x
+  pretty' (GHC.HsValArg x) = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
+  pretty' GHC.HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsQuote GHC.GhcPs) where
@@ -1995,7 +2012,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2009,7 +2026,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2027,15 +2044,15 @@ instance Pretty (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
-  pretty' (IEName _ name)    = pretty name
+  pretty' (IEName _ name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name)    = string "type " >> pretty name
+  pretty' (IEType _ name) = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.RdrName) where
-  pretty' (GHC.IEName name)      = pretty name
+  pretty' (GHC.IEName name) = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
+  pretty' (GHC.IEType _ name) = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -2171,11 +2188,11 @@ instance Pretty GHC.ForeignImport where
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, output s]
-  pretty' (CExport _ conv)                    = pretty conv
+  pretty' (CExport _ conv) = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv)                    = pretty conv
+  pretty' (CExport _ conv) = pretty conv
 #else
 instance Pretty GHC.ForeignExport where
   pretty' (GHC.CExport conv (GHC.L _ (GHC.SourceText s))) =
@@ -2186,9 +2203,9 @@ instance Pretty GHC.CExportSpec where
   pretty' (GHC.CExportStatic _ _ x) = pretty x
 
 instance Pretty GHC.Safety where
-  pretty' GHC.PlaySafe          = string "safe"
+  pretty' GHC.PlaySafe = string "safe"
   pretty' GHC.PlayInterruptible = string "interruptible"
-  pretty' GHC.PlayRisky         = string "unsafe"
+  pretty' GHC.PlayRisky = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2208,14 +2225,14 @@ instance Pretty (GHC.AnnDecl GHC.GhcPs) where
 #endif
 instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
   pretty' (GHC.RoleAnnotDecl _ name roles) =
-    spaced $
-    [string "type role", pretty name] ++
-    fmap (maybe (string "_") pretty . GHC.unLoc) roles
+    spaced
+      $ [string "type role", pretty name]
+          ++ fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
 instance Pretty GHC.Role where
-  pretty' GHC.Nominal          = string "nominal"
+  pretty' GHC.Nominal = string "nominal"
   pretty' GHC.Representational = string "representational"
-  pretty' GHC.Phantom          = string "phantom"
+  pretty' GHC.Phantom = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2275,8 +2292,8 @@ instance Pretty GHC.InlinePragma where
     pretty inl_inline
     case inl_act of
       GHC.ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      GHC.ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                    -> pure ()
+      GHC.ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
 instance Pretty GHC.InlineSpec where
   pretty' = prettyInlineSpec
@@ -2292,25 +2309,25 @@ prettyInlineSpec GHC.NoUserInlinePrag =
 prettyInlineSpec GHC.Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
-  pretty' GHC.Unidirectional           = string "<-"
-  pretty' GHC.ImplicitBidirectional    = string "="
+  pretty' GHC.Unidirectional = string "<-"
+  pretty' GHC.ImplicitBidirectional = string "="
   pretty' GHC.ExplicitBidirectional {} = string "<-"
 
 instance Pretty (GHC.HsOverLit GHC.GhcPs) where
   pretty' GHC.OverLit {..} = pretty ol_val
 
 instance Pretty GHC.OverLitVal where
-  pretty' (GHC.HsIntegral x)   = pretty x
+  pretty' (GHC.HsIntegral x) = pretty x
   pretty' (GHC.HsFractional x) = pretty x
   pretty' (GHC.HsIsString _ x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
-  pretty' IL {..}                     = string $ show il_value
+  pretty' IL {..} = string $ show il_value
 #else
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = string s
-  pretty' GHC.IL {..}                         = string $ show il_value
+  pretty' GHC.IL {..} = string $ show il_value
 #endif
 instance Pretty GHC.FractionalLit where
   pretty' = output
@@ -2329,7 +2346,7 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
   pretty' GHC.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      GHC.HsString {}     -> prettyString
+      GHC.HsString {} -> prettyString
       GHC.HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2340,8 +2357,9 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1) $
-                lined $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1)
+                $ lined
+                $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
@@ -2354,13 +2372,13 @@ instance Pretty GHC.HsIPName where
   pretty' (GHC.HsIPName x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
-  pretty' (HsNumTy _ x)  = string $ show x
-  pretty' (HsStrTy _ x)  = string $ ushow x
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
 instance Pretty GHC.HsTyLit where
-  pretty' (GHC.HsNumTy _ x)  = string $ show x
-  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
+  pretty' (GHC.HsNumTy _ x) = string $ show x
+  pretty' (GHC.HsStrTy _ x) = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (GHC.HsPatSigType GHC.GhcPs) where
@@ -2382,10 +2400,10 @@ prettyIPBind (GHC.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (GHC.DerivStrategy GHC.GhcPs) where
-  pretty' GHC.StockStrategy {}    = string "stock"
+  pretty' GHC.StockStrategy {} = string "stock"
   pretty' GHC.AnyclassStrategy {} = string "anyclass"
-  pretty' GHC.NewtypeStrategy {}  = string "newtype"
-  pretty' (GHC.ViaStrategy x)     = string "via " >> pretty x
+  pretty' GHC.NewtypeStrategy {} = string "newtype"
+  pretty' (GHC.ViaStrategy x) = string "via " >> pretty x
 
 instance Pretty GHC.XViaStrategyPs where
   pretty' (GHC.XViaStrategyPs _ ty) = pretty ty
@@ -2453,9 +2471,12 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets $
-        spaced
-          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
+        brackets
+          $ spaced
+              [ pretty listCompLhs
+              , string "|"
+              , hCommaSep $ fmap pretty listCompRhs
+              ]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2473,7 +2494,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do  = string "do"
+  pretty' Do = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2493,10 +2514,10 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty GHC.CCallConv where
-  pretty' GHC.CCallConv          = string "ccall"
-  pretty' GHC.CApiConv           = string "capi"
-  pretty' GHC.StdCallConv        = string "stdcall"
-  pretty' GHC.PrimCallConv       = string "prim"
+  pretty' GHC.CCallConv = string "ccall"
+  pretty' GHC.CApiConv = string "capi"
+  pretty' GHC.StdCallConv = string "stdcall"
+  pretty' GHC.PrimCallConv = string "prim"
   pretty' GHC.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
@@ -2506,13 +2527,13 @@ instance Pretty GHC.HsSrcBang where
     pretty strictness
 
 instance Pretty GHC.SrcUnpackedness where
-  pretty' GHC.SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' GHC.SrcUnpack = string "{-# UNPACK #-}"
   pretty' GHC.SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' GHC.NoSrcUnpack = pure ()
 
 instance Pretty GHC.SrcStrictness where
-  pretty' GHC.SrcLazy     = string "~"
-  pretty' GHC.SrcStrict   = string "!"
+  pretty' GHC.SrcLazy = string "~"
+  pretty' GHC.SrcStrict = string "!"
   pretty' GHC.NoSrcStrict = pure ()
 
 instance Pretty (GHC.HsOuterSigTyVarBndrs GHC.GhcPs) where
@@ -2536,8 +2557,11 @@ instance Pretty (HsUntypedSplice GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars .
-         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
+        (wrapWithBars
+           . indentedWithFixedLevel 0
+           . sequence_
+           . printers [] ""
+           . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -32,7 +32,7 @@ import           GHC.Data.FastString
 import qualified GHC.Hs                                      as GHC
 import           GHC.Stack
 import qualified GHC.Types.Basic                             as GHC
-import           GHC.Types.Fixity
+import qualified GHC.Types.Fixity                            as GHC
 import           GHC.Types.ForeignCall
 import           GHC.Types.Name
 import           GHC.Types.Name.Reader
@@ -149,9 +149,9 @@ prettyTyClDecl (GHC.FamDecl _ x) = pretty x
 prettyTyClDecl GHC.SynDecl {..} = do
   string "type "
   case tcdFixity of
-    GHC.Types.Fixity.Prefix ->
+    GHC.Prefix ->
       spaced $ pretty tcdLName : fmap pretty (GHC.hsq_explicit tcdTyVars)
-    GHC.Types.Fixity.Infix ->
+    GHC.Infix ->
       case GHC.hsq_explicit tcdTyVars of
         (l:r:xs) -> do
           spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
@@ -247,9 +247,9 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         indentedBlock $ string "where"
     printNameAndTypeVariables =
       case tcdFixity of
-        GHC.Types.Fixity.Prefix ->
+        GHC.Prefix ->
           spaced $ pretty tcdLName : fmap pretty (GHC.hsq_explicit tcdTyVars)
-        GHC.Types.Fixity.Infix ->
+        GHC.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
               parens $
@@ -1057,11 +1057,11 @@ prettyMatchExpr Match {m_ctxt = LamCaseAlt {}, ..} = do
 #endif
 prettyMatchExpr GHC.Match {..} =
   case GHC.mc_fixity m_ctxt of
-    GHC.Types.Fixity.Prefix -> do
+    GHC.Prefix -> do
       pretty m_ctxt
       spacePrefixed $ fmap pretty m_pats
       pretty m_grhss
-    GHC.Types.Fixity.Infix -> do
+    GHC.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
           spaced $
@@ -1671,9 +1671,9 @@ instance Pretty InfixApp where
       horizontal = spaced [pretty lhs, pretty (InfixExpr op), pretty rhs]
       vertical =
         case findFixity op of
-          GHC.Types.Fixity.Fixity _ _ GHC.Types.Fixity.InfixL -> leftAssoc
-          GHC.Types.Fixity.Fixity _ _ GHC.Types.Fixity.InfixR -> rightAssoc
-          GHC.Types.Fixity.Fixity _ _ GHC.Types.Fixity.InfixN -> noAssoc
+          GHC.Fixity _ _ GHC.InfixL -> leftAssoc
+          GHC.Fixity _ _ GHC.InfixR -> rightAssoc
+          GHC.Fixity _ _ GHC.InfixN -> noAssoc
       leftAssoc = prettyOps allOperantsAndOperatorsLeftAssoc
       rightAssoc = prettyOps allOperantsAndOperatorsRightAssoc
       noAssoc
@@ -1706,8 +1706,7 @@ instance Pretty InfixApp where
             error
               "The number of the sum of operants and operators should be odd."
       prettyOps _ = error "Too short list."
-      findFixity o =
-        fromMaybe GHC.Types.Fixity.defaultFixity $ lookup (varToStr o) fixities
+      findFixity o = fromMaybe GHC.defaultFixity $ lookup (varToStr o) fixities
       allOperantsAndOperatorsLeftAssoc = reverse $ rhs : op : collect lhs
         where
           collect :: GHC.LHsExpr GHC.GhcPs -> [GHC.LHsExpr GHC.GhcPs]
@@ -1720,9 +1719,8 @@ instance Pretty InfixApp where
           collect (L _ (GHC.OpApp _ l o r))
             | isSameAssoc o = l : o : collect r
           collect x = [x]
-      isSameAssoc (findFixity -> GHC.Types.Fixity.Fixity _ lv d) =
-        lv == level && d == dir
-      GHC.Types.Fixity.Fixity _ level dir = findFixity op
+      isSameAssoc (findFixity -> GHC.Fixity _ lv d) = lv == level && d == dir
+      GHC.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
   pretty' (Var x)    = pretty x
@@ -2253,14 +2251,13 @@ instance Pretty (GHC.FixitySig GHC.GhcPs) where
   pretty' (GHC.FixitySig _ names fixity) =
     spaced [pretty fixity, hCommaSep $ fmap (pretty . fmap InfixOp) names]
 
-instance Pretty GHC.Types.Fixity.Fixity where
-  pretty' (GHC.Types.Fixity.Fixity _ level dir) =
-    spaced [pretty dir, string $ show level]
+instance Pretty GHC.Fixity where
+  pretty' (GHC.Fixity _ level dir) = spaced [pretty dir, string $ show level]
 
-instance Pretty GHC.Types.Fixity.FixityDirection where
-  pretty' GHC.Types.Fixity.InfixL = string "infixl"
-  pretty' GHC.Types.Fixity.InfixR = string "infixr"
-  pretty' GHC.Types.Fixity.InfixN = string "infix"
+instance Pretty GHC.FixityDirection where
+  pretty' GHC.InfixL = string "infixl"
+  pretty' GHC.InfixR = string "infixr"
+  pretty' GHC.InfixN = string "infix"
 
 instance Pretty GHC.InlinePragma where
   pretty' GHC.InlinePragma {..} = do


### PR DESCRIPTION
### Description of the PR

#819

This is the preparation for moving all `Pretty` instances into `HIndent.Pretty`. While moving the instances is not necessary, without moving them, it is impossible to remove existing `Pretty` instances for GHC's AST types because of the recursive structure of `HsDecl`.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
