### PR TITLE
Move `Pretty` instances into `HIndent.Pretty`

### DIFF
--- a/src/HIndent/Ast/Context.hs
+++ b/src/HIndent/Ast/Context.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Context
-  ( Context
+  ( Context(..)
   , mkContext
   ) where
 
@@ -9,7 +9,6 @@ import           HIndent.Ast.NodeComments
 import           HIndent.Ast.Type
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
 
 newtype Context =

--- a/src/HIndent/Ast/Context.hs
+++ b/src/HIndent/Ast/Context.hs
@@ -5,11 +5,11 @@ module HIndent.Ast.Context
   , mkContext
   ) where
 
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type
-import           HIndent.Ast.WithComments
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 newtype Context =
   Context [WithComments Type]

--- a/src/HIndent/Ast/Context.hs
+++ b/src/HIndent/Ast/Context.hs
@@ -5,34 +5,18 @@ module HIndent.Ast.Context
   , mkContext
   ) where
 
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type
-import HIndent.Ast.WithComments
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type
+import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 newtype Context =
   Context [WithComments Type]
 
 instance CommentExtraction Context where
   nodeComments (Context _) = NodeComments [] [] []
-
-instance Pretty Context where
-  pretty' (Context xs) = hor <-|> ver
-    where
-      hor = parensConditional $ hCommaSep $ fmap pretty xs
-        where
-          parensConditional =
-            case xs of
-              [_] -> id
-              _ -> parens
-      ver =
-        case xs of
-          [] -> string "()"
-          [x] -> pretty x
-          _ -> vTuple $ fmap pretty xs
 
 mkContext :: GHC.HsContext GHC.GhcPs -> Context
 mkContext = Context . fmap (fmap mkType . fromGenLocated)

--- a/src/HIndent/Ast/Declaration.hs
+++ b/src/HIndent/Ast/Declaration.hs
@@ -4,16 +4,16 @@ module HIndent.Ast.Declaration
   , isSignature
   ) where
 
-import           Control.Applicative
-import           Data.Maybe
-import           HIndent.Ast.Declaration.Data
+import Control.Applicative
+import Data.Maybe
+import HIndent.Ast.Declaration.Data
 import qualified HIndent.Ast.Declaration.Family.Data
 import qualified HIndent.Ast.Declaration.Family.Type
 import qualified HIndent.Ast.Declaration.Instance.Class
 import qualified HIndent.Ast.Declaration.TypeSynonym
-import           HIndent.Ast.NodeComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs     as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Ast.NodeComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pretty.NodeComments
 
 data Declaration
   = DataFamily HIndent.Ast.Declaration.Family.Data.DataFamily
@@ -36,30 +36,30 @@ data Declaration
   | RoleAnnotDecl (GHC.RoleAnnotDecl GHC.GhcPs)
 
 instance CommentExtraction Declaration where
-  nodeComments DataFamily {}      = NodeComments [] [] []
-  nodeComments TypeFamily {}      = NodeComments [] [] []
+  nodeComments DataFamily {} = NodeComments [] [] []
+  nodeComments TypeFamily {} = NodeComments [] [] []
   nodeComments DataDeclaration {} = NodeComments [] [] []
-  nodeComments TypeSynonym {}     = NodeComments [] [] []
-  nodeComments TyClDecl {}        = NodeComments [] [] []
-  nodeComments ClassInstance {}   = NodeComments [] [] []
-  nodeComments InstDecl {}        = NodeComments [] [] []
-  nodeComments DerivDecl {}       = NodeComments [] [] []
-  nodeComments ValDecl {}         = NodeComments [] [] []
-  nodeComments SigDecl {}         = NodeComments [] [] []
-  nodeComments KindSigDecl {}     = NodeComments [] [] []
-  nodeComments DefDecl {}         = NodeComments [] [] []
-  nodeComments ForDecl {}         = NodeComments [] [] []
-  nodeComments WarningDecl {}     = NodeComments [] [] []
-  nodeComments AnnDecl {}         = NodeComments [] [] []
-  nodeComments RuleDecl {}        = NodeComments [] [] []
-  nodeComments SpliceDecl {}      = NodeComments [] [] []
-  nodeComments RoleAnnotDecl {}   = NodeComments [] [] []
+  nodeComments TypeSynonym {} = NodeComments [] [] []
+  nodeComments TyClDecl {} = NodeComments [] [] []
+  nodeComments ClassInstance {} = NodeComments [] [] []
+  nodeComments InstDecl {} = NodeComments [] [] []
+  nodeComments DerivDecl {} = NodeComments [] [] []
+  nodeComments ValDecl {} = NodeComments [] [] []
+  nodeComments SigDecl {} = NodeComments [] [] []
+  nodeComments KindSigDecl {} = NodeComments [] [] []
+  nodeComments DefDecl {} = NodeComments [] [] []
+  nodeComments ForDecl {} = NodeComments [] [] []
+  nodeComments WarningDecl {} = NodeComments [] [] []
+  nodeComments AnnDecl {} = NodeComments [] [] []
+  nodeComments RuleDecl {} = NodeComments [] [] []
+  nodeComments SpliceDecl {} = NodeComments [] [] []
+  nodeComments RoleAnnotDecl {} = NodeComments [] [] []
 
 mkDeclaration :: GHC.HsDecl GHC.GhcPs -> Declaration
 mkDeclaration (GHC.TyClD _ (GHC.FamDecl _ x)) =
-  fromMaybe (error "Unreachable.") $
-  DataFamily <$> HIndent.Ast.Declaration.Family.Data.mkDataFamily x <|>
-  TypeFamily <$> HIndent.Ast.Declaration.Family.Type.mkTypeFamily x
+  fromMaybe (error "Unreachable.")
+    $ DataFamily <$> HIndent.Ast.Declaration.Family.Data.mkDataFamily x
+        <|> TypeFamily <$> HIndent.Ast.Declaration.Family.Type.mkTypeFamily x
 mkDeclaration (GHC.TyClD _ x@GHC.SynDecl {}) =
   TypeSynonym $ HIndent.Ast.Declaration.TypeSynonym.mkTypeSynonym x
 mkDeclaration (GHC.TyClD _ x@(GHC.DataDecl {}))
@@ -86,4 +86,4 @@ mkDeclaration GHC.DocD {} =
 
 isSignature :: Declaration -> Bool
 isSignature SigDecl {} = True
-isSignature _          = False
+isSignature _ = False

--- a/src/HIndent/Ast/Declaration.hs
+++ b/src/HIndent/Ast/Declaration.hs
@@ -4,17 +4,16 @@ module HIndent.Ast.Declaration
   , isSignature
   ) where
 
-import Control.Applicative
-import Data.Maybe
-import HIndent.Ast.Declaration.Data
-import HIndent.Ast.Declaration.Family.Data
-import HIndent.Ast.Declaration.Family.Type
-import HIndent.Ast.Declaration.Instance.Class
-import HIndent.Ast.Declaration.TypeSynonym
-import HIndent.Ast.NodeComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.NodeComments
+import           Control.Applicative
+import           Data.Maybe
+import           HIndent.Ast.Declaration.Data
+import           HIndent.Ast.Declaration.Family.Data
+import           HIndent.Ast.Declaration.Family.Type
+import           HIndent.Ast.Declaration.Instance.Class
+import           HIndent.Ast.Declaration.TypeSynonym
+import           HIndent.Ast.NodeComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs     as GHC
+import           HIndent.Pretty.NodeComments
 
 data Declaration
   = DataFamily DataFamily
@@ -37,49 +36,29 @@ data Declaration
   | RoleAnnotDecl (GHC.RoleAnnotDecl GHC.GhcPs)
 
 instance CommentExtraction Declaration where
-  nodeComments DataFamily {} = NodeComments [] [] []
-  nodeComments TypeFamily {} = NodeComments [] [] []
+  nodeComments DataFamily {}      = NodeComments [] [] []
+  nodeComments TypeFamily {}      = NodeComments [] [] []
   nodeComments DataDeclaration {} = NodeComments [] [] []
-  nodeComments TypeSynonym {} = NodeComments [] [] []
-  nodeComments TyClDecl {} = NodeComments [] [] []
-  nodeComments ClassInstance {} = NodeComments [] [] []
-  nodeComments InstDecl {} = NodeComments [] [] []
-  nodeComments DerivDecl {} = NodeComments [] [] []
-  nodeComments ValDecl {} = NodeComments [] [] []
-  nodeComments SigDecl {} = NodeComments [] [] []
-  nodeComments KindSigDecl {} = NodeComments [] [] []
-  nodeComments DefDecl {} = NodeComments [] [] []
-  nodeComments ForDecl {} = NodeComments [] [] []
-  nodeComments WarningDecl {} = NodeComments [] [] []
-  nodeComments AnnDecl {} = NodeComments [] [] []
-  nodeComments RuleDecl {} = NodeComments [] [] []
-  nodeComments SpliceDecl {} = NodeComments [] [] []
-  nodeComments RoleAnnotDecl {} = NodeComments [] [] []
-
-instance Pretty Declaration where
-  pretty' (DataFamily x) = pretty x
-  pretty' (TypeFamily x) = pretty x
-  pretty' (DataDeclaration x) = pretty x
-  pretty' (TypeSynonym x) = pretty x
-  pretty' (TyClDecl x) = pretty x
-  pretty' (ClassInstance x) = pretty x
-  pretty' (InstDecl x) = pretty x
-  pretty' (DerivDecl x) = pretty x
-  pretty' (ValDecl x) = pretty x
-  pretty' (SigDecl x) = pretty x
-  pretty' (KindSigDecl x) = pretty x
-  pretty' (DefDecl x) = pretty x
-  pretty' (ForDecl x) = pretty x
-  pretty' (WarningDecl x) = pretty x
-  pretty' (AnnDecl x) = pretty x
-  pretty' (RuleDecl x) = pretty x
-  pretty' (SpliceDecl x) = pretty x
-  pretty' (RoleAnnotDecl x) = pretty x
+  nodeComments TypeSynonym {}     = NodeComments [] [] []
+  nodeComments TyClDecl {}        = NodeComments [] [] []
+  nodeComments ClassInstance {}   = NodeComments [] [] []
+  nodeComments InstDecl {}        = NodeComments [] [] []
+  nodeComments DerivDecl {}       = NodeComments [] [] []
+  nodeComments ValDecl {}         = NodeComments [] [] []
+  nodeComments SigDecl {}         = NodeComments [] [] []
+  nodeComments KindSigDecl {}     = NodeComments [] [] []
+  nodeComments DefDecl {}         = NodeComments [] [] []
+  nodeComments ForDecl {}         = NodeComments [] [] []
+  nodeComments WarningDecl {}     = NodeComments [] [] []
+  nodeComments AnnDecl {}         = NodeComments [] [] []
+  nodeComments RuleDecl {}        = NodeComments [] [] []
+  nodeComments SpliceDecl {}      = NodeComments [] [] []
+  nodeComments RoleAnnotDecl {}   = NodeComments [] [] []
 
 mkDeclaration :: GHC.HsDecl GHC.GhcPs -> Declaration
 mkDeclaration (GHC.TyClD _ (GHC.FamDecl _ x)) =
-  fromMaybe (error "Unreachable.")
-    $ DataFamily <$> mkDataFamily x <|> TypeFamily <$> mkTypeFamily x
+  fromMaybe (error "Unreachable.") $
+  DataFamily <$> mkDataFamily x <|> TypeFamily <$> mkTypeFamily x
 mkDeclaration (GHC.TyClD _ x@GHC.SynDecl {}) = TypeSynonym $ mkTypeSynonym x
 mkDeclaration (GHC.TyClD _ x@(GHC.DataDecl {}))
   | Just decl <- mkDataDeclaration x = DataDeclaration decl
@@ -104,4 +83,4 @@ mkDeclaration GHC.DocD {} =
 
 isSignature :: Declaration -> Bool
 isSignature SigDecl {} = True
-isSignature _ = False
+isSignature _          = False

--- a/src/HIndent/Ast/Declaration/Data.hs
+++ b/src/HIndent/Ast/Declaration/Data.hs
@@ -3,21 +3,18 @@
 {-# LANGUAGE ViewPatterns    #-}
 
 module HIndent.Ast.Declaration.Data
-  ( DataDeclaration
+  ( DataDeclaration(..)
   , mkDataDeclaration
   ) where
 
-import           Control.Monad
 import           Data.Maybe
 import qualified GHC.Types.SrcLoc                              as GHC
-import           HIndent.Applicative
 import           HIndent.Ast.Declaration.Data.GADT.Constructor
 import           HIndent.Ast.Declaration.Data.Header
 import           HIndent.Ast.NodeComments
 import           HIndent.Ast.Type
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs            as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
 
 data DataDeclaration

--- a/src/HIndent/Ast/Declaration/Data.hs
+++ b/src/HIndent/Ast/Declaration/Data.hs
@@ -1,64 +1,64 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns    #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module HIndent.Ast.Declaration.Data
   ( DataDeclaration(..)
   , mkDataDeclaration
   ) where
 
-import           Data.Maybe
-import qualified GHC.Types.SrcLoc                              as GHC
-import           HIndent.Ast.Declaration.Data.GADT.Constructor
-import           HIndent.Ast.Declaration.Data.Header
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type
-import           HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs            as GHC
-import           HIndent.Pretty.NodeComments
+import Data.Maybe
+import qualified GHC.Types.SrcLoc as GHC
+import HIndent.Ast.Declaration.Data.GADT.Constructor
+import HIndent.Ast.Declaration.Data.Header
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pretty.NodeComments
 
 data DataDeclaration
   = GADT
-      { header       :: Header
-      , kind         :: Maybe (WithComments Type)
+      { header :: Header
+      , kind :: Maybe (WithComments Type)
       , constructors :: [WithComments GADTConstructor]
       }
   | Record
-      { header    :: Header
-      , dd_cons   :: [GHC.LConDecl GHC.GhcPs]
+      { header :: Header
+      , dd_cons :: [GHC.LConDecl GHC.GhcPs]
       , dd_derivs :: GHC.HsDeriving GHC.GhcPs
       }
 
 instance CommentExtraction DataDeclaration where
-  nodeComments GADT {}   = NodeComments [] [] []
+  nodeComments GADT {} = NodeComments [] [] []
   nodeComments Record {} = NodeComments [] [] []
 
 mkDataDeclaration :: GHC.TyClDecl GHC.GhcPs -> Maybe DataDeclaration
 mkDataDeclaration decl@GHC.DataDecl {tcdDataDefn = defn@GHC.HsDataDefn {..}}
   | Just header <- mkHeader decl =
-    Just $
-    if isGADT defn
-      then GADT
-             { constructors =
-                 fromMaybe (error "Some constructors are not GADT ones.") $
-                 mapM (traverse mkGADTConstructor . fromGenLocated) $
-                 getConDecls defn
-             , ..
-             }
-      else Record {dd_cons = getConDecls defn, ..}
+    Just
+      $ if isGADT defn
+          then GADT
+                 { constructors =
+                     fromMaybe (error "Some constructors are not GADT ones.")
+                       $ mapM (traverse mkGADTConstructor . fromGenLocated)
+                       $ getConDecls defn
+                 , ..
+                 }
+          else Record {dd_cons = getConDecls defn, ..}
   where
     kind = fmap mkType . fromGenLocated <$> dd_kindSig
 mkDataDeclaration _ = Nothing
 
 isGADT :: GHC.HsDataDefn GHC.GhcPs -> Bool
 isGADT (getConDecls -> (GHC.L _ GHC.ConDeclGADT {}:_)) = True
-isGADT _                                               = False
+isGADT _ = False
 
 getConDecls :: GHC.HsDataDefn GHC.GhcPs -> [GHC.LConDecl GHC.GhcPs]
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
 getConDecls GHC.HsDataDefn {..} =
   case dd_cons of
-    GHC.NewTypeCon x      -> [x]
+    GHC.NewTypeCon x -> [x]
     GHC.DataTypeCons _ xs -> xs
 #else
 getConDecls GHC.HsDataDefn {..} = dd_cons

--- a/src/HIndent/Ast/Declaration/Data.hs
+++ b/src/HIndent/Ast/Declaration/Data.hs
@@ -1,98 +1,67 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns    #-}
 
 module HIndent.Ast.Declaration.Data
   ( DataDeclaration
   , mkDataDeclaration
   ) where
 
-import Control.Monad
-import Data.Maybe
-import qualified GHC.Types.SrcLoc as GHC
-import HIndent.Applicative
-import HIndent.Ast.Declaration.Data.GADT.Constructor
-import HIndent.Ast.Declaration.Data.Header
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type
-import HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           Control.Monad
+import           Data.Maybe
+import qualified GHC.Types.SrcLoc                              as GHC
+import           HIndent.Applicative
+import           HIndent.Ast.Declaration.Data.GADT.Constructor
+import           HIndent.Ast.Declaration.Data.Header
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type
+import           HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs            as GHC
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data DataDeclaration
   = GADT
-      { header :: Header
-      , kind :: Maybe (WithComments Type)
+      { header       :: Header
+      , kind         :: Maybe (WithComments Type)
       , constructors :: [WithComments GADTConstructor]
       }
   | Record
-      { header :: Header
-      , dd_cons :: [GHC.LConDecl GHC.GhcPs]
+      { header    :: Header
+      , dd_cons   :: [GHC.LConDecl GHC.GhcPs]
       , dd_derivs :: GHC.HsDeriving GHC.GhcPs
       }
 
 instance CommentExtraction DataDeclaration where
-  nodeComments GADT {} = NodeComments [] [] []
+  nodeComments GADT {}   = NodeComments [] [] []
   nodeComments Record {} = NodeComments [] [] []
-
-instance Pretty DataDeclaration where
-  pretty' GADT {..} = do
-    pretty header
-    whenJust kind $ \x -> string " :: " >> pretty x
-    string " where"
-    indentedBlock $ newlinePrefixed $ fmap pretty constructors
-  pretty' Record {..} = do
-    pretty header
-    case dd_cons of
-      [] -> indentedBlock derivingsAfterNewline
-      [x@(GHC.L _ GHC.ConDeclH98 {con_args = GHC.RecCon {}})] -> do
-        string " = "
-        pretty x
-        unless (null dd_derivs) $ space |=> printDerivings
-      [x] -> do
-        string " ="
-        newline
-        indentedBlock $ do
-          pretty x
-          derivingsAfterNewline
-      _ ->
-        indentedBlock $ do
-          newline
-          string "= " |=> vBarSep (fmap pretty dd_cons)
-          derivingsAfterNewline
-    where
-      derivingsAfterNewline =
-        unless (null dd_derivs) $ newline >> printDerivings
-      printDerivings = lined $ fmap pretty dd_derivs
 
 mkDataDeclaration :: GHC.TyClDecl GHC.GhcPs -> Maybe DataDeclaration
 mkDataDeclaration decl@GHC.DataDecl {tcdDataDefn = defn@GHC.HsDataDefn {..}}
   | Just header <- mkHeader decl =
-    Just
-      $ if isGADT defn
-          then GADT
-                 { constructors =
-                     fromMaybe (error "Some constructors are not GADT ones.")
-                       $ mapM (traverse mkGADTConstructor . fromGenLocated)
-                       $ getConDecls defn
-                 , ..
-                 }
-          else Record {dd_cons = getConDecls defn, ..}
+    Just $
+    if isGADT defn
+      then GADT
+             { constructors =
+                 fromMaybe (error "Some constructors are not GADT ones.") $
+                 mapM (traverse mkGADTConstructor . fromGenLocated) $
+                 getConDecls defn
+             , ..
+             }
+      else Record {dd_cons = getConDecls defn, ..}
   where
     kind = fmap mkType . fromGenLocated <$> dd_kindSig
 mkDataDeclaration _ = Nothing
 
 isGADT :: GHC.HsDataDefn GHC.GhcPs -> Bool
 isGADT (getConDecls -> (GHC.L _ GHC.ConDeclGADT {}:_)) = True
-isGADT _ = False
+isGADT _                                               = False
 
 getConDecls :: GHC.HsDataDefn GHC.GhcPs -> [GHC.LConDecl GHC.GhcPs]
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
 getConDecls GHC.HsDataDefn {..} =
   case dd_cons of
-    GHC.NewTypeCon x -> [x]
+    GHC.NewTypeCon x      -> [x]
     GHC.DataTypeCons _ xs -> xs
 #else
 getConDecls GHC.HsDataDefn {..} = dd_cons

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -2,13 +2,12 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.GADT.Constructor
-  ( GADTConstructor
+  ( GADTConstructor(..)
   , mkGADTConstructor
   ) where
 
 import           Data.Maybe
 import qualified GHC.Types.SrcLoc                                        as GHC
-import           HIndent.Ast.Context
 import           HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
 import           HIndent.Ast.NodeComments
 import           HIndent.Ast.WithComments

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.GADT.Constructor
@@ -6,23 +6,23 @@ module HIndent.Ast.Declaration.Data.GADT.Constructor
   , mkGADTConstructor
   ) where
 
-import           Data.Maybe
-import qualified GHC.Types.SrcLoc                                        as GHC
-import           HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs                      as GHC
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import Data.Maybe
+import qualified GHC.Types.SrcLoc as GHC
+import HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
+import HIndent.Ast.NodeComments
+import HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
-import qualified Data.List.NonEmpty                                      as NE
+import qualified Data.List.NonEmpty as NE
 #endif
 data GADTConstructor = GADTConstructor
-  { names        :: [WithComments String]
+  { names :: [WithComments String]
   , forallNeeded :: Bool
-  , bindings     :: WithComments (GHC.HsOuterSigTyVarBndrs GHC.GhcPs)
-  , con_mb_cxt   :: Maybe (GHC.LHsContext GHC.GhcPs)
-  , signature    :: ConstructorSignature
+  , bindings :: WithComments (GHC.HsOuterSigTyVarBndrs GHC.GhcPs)
+  , con_mb_cxt :: Maybe (GHC.LHsContext GHC.GhcPs)
+  , signature :: ConstructorSignature
   }
 
 instance CommentExtraction GADTConstructor where

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.GADT.Constructor
@@ -6,60 +6,28 @@ module HIndent.Ast.Declaration.Data.GADT.Constructor
   , mkGADTConstructor
   ) where
 
-import Data.Maybe
-import qualified GHC.Types.SrcLoc as GHC
-import HIndent.Ast.Context
-import HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
-import HIndent.Ast.NodeComments
-import HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           Data.Maybe
+import qualified GHC.Types.SrcLoc                                        as GHC
+import           HIndent.Ast.Context
+import           HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs                      as GHC
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List.NonEmpty                                      as NE
 #endif
 data GADTConstructor = GADTConstructor
-  { names :: [WithComments String]
+  { names        :: [WithComments String]
   , forallNeeded :: Bool
-  , bindings :: WithComments (GHC.HsOuterSigTyVarBndrs GHC.GhcPs)
-  , con_mb_cxt :: Maybe (GHC.LHsContext GHC.GhcPs)
-  , signature :: ConstructorSignature
+  , bindings     :: WithComments (GHC.HsOuterSigTyVarBndrs GHC.GhcPs)
+  , con_mb_cxt   :: Maybe (GHC.LHsContext GHC.GhcPs)
+  , signature    :: ConstructorSignature
   }
 
 instance CommentExtraction GADTConstructor where
   nodeComments GADTConstructor {} = NodeComments [] [] []
-
-instance Pretty GADTConstructor where
-  pretty' (GADTConstructor {..}) = do
-    hCommaSep $ fmap (`prettyWith` string) names
-    hor <-|> ver
-    where
-      hor = string " :: " |=> body
-      ver = newline >> indentedBlock (string ":: " |=> body)
-      body =
-        case (forallNeeded, con_mb_cxt) of
-          (True, Just ctx) -> withForallCtx ctx
-          (True, Nothing) -> withForallOnly
-          (False, Just ctx) -> withCtxOnly ctx
-          (False, Nothing) -> noForallCtx
-      withForallCtx ctx = do
-        pretty bindings
-        (space >> pretty (mkContext <$> fromGenLocated ctx))
-          <-|> (newline >> pretty (mkContext <$> fromGenLocated ctx))
-        newline
-        prefixed "=> " $ prettyVertically signature
-      withForallOnly = do
-        pretty bindings
-        (space >> prettyHorizontally signature)
-          <-|> (newline >> prettyVertically signature)
-      withCtxOnly ctx =
-        (pretty (mkContext <$> fromGenLocated ctx)
-           >> string " => "
-           >> prettyHorizontally signature)
-          <-|> (pretty (mkContext <$> fromGenLocated ctx)
-                  >> prefixed "=> " (prettyVertically signature))
-      noForallCtx = prettyHorizontally signature <-|> prettyVertically signature
 
 mkGADTConstructor :: GHC.ConDecl GHC.GhcPs -> Maybe GADTConstructor
 mkGADTConstructor decl@GHC.ConDeclGADT {..} = Just $ GADTConstructor {..}

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
@@ -10,9 +10,7 @@ import           HIndent.Ast.NodeComments
 import           HIndent.Ast.Type
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
-import           HIndent.Printer
 
 data ConstructorSignature
   = ByArrows

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
@@ -1,26 +1,23 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
   ( ConstructorSignature(..)
   , mkConstructorSignature
-  , prettyHorizontally
-  , prettyVertically
   ) where
 
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type
-import HIndent.Ast.WithComments
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type
+import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Printer
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Printer
 
 data ConstructorSignature
   = ByArrows
       { parameters :: [WithComments Type]
-      , result :: WithComments Type
+      , result     :: WithComments Type
       }
   | Record
       { fields :: WithComments [GHC.LConDeclField GHC.GhcPs]
@@ -29,45 +26,24 @@ data ConstructorSignature
 
 instance CommentExtraction ConstructorSignature where
   nodeComments (ByArrows {}) = NodeComments [] [] []
-  nodeComments (Record {}) = NodeComments [] [] []
-
-prettyHorizontally :: ConstructorSignature -> Printer ()
-prettyHorizontally (ByArrows {..}) =
-  inter (string " -> ") $ fmap pretty parameters ++ [pretty result]
-prettyHorizontally (Record {..}) =
-  inter
-    (string " -> ")
-    [prettyWith fields (vFields' . fmap pretty), pretty result]
-
-prettyVertically :: ConstructorSignature -> Printer ()
-prettyVertically (ByArrows {..}) =
-  prefixedLined "-> " $ fmap pretty parameters ++ [pretty result]
-prettyVertically (Record {..}) =
-  prefixedLined
-    "-> "
-    [prettyWith fields (vFields' . fmap pretty), pretty result]
+  nodeComments (Record {})   = NodeComments [] [] []
 
 mkConstructorSignature :: GHC.ConDecl GHC.GhcPs -> Maybe ConstructorSignature
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.PrefixConGADT xs, ..} =
-  Just
-    $ ByArrows
-        { parameters =
-            fmap (fmap mkType . fromGenLocated . GHC.hsScaledThing) xs
-        , result = mkType <$> fromGenLocated con_res_ty
-        }
+  Just $
+  ByArrows
+    { parameters = fmap (fmap mkType . fromGenLocated . GHC.hsScaledThing) xs
+    , result = mkType <$> fromGenLocated con_res_ty
+    }
 #if MIN_VERSION_ghc_lib_parser(9, 4, 0)
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT xs _, ..} =
-  Just
-    $ Record
-        { fields = fromGenLocated xs
-        , result = mkType <$> fromGenLocated con_res_ty
-        }
+  Just $
+  Record
+    {fields = fromGenLocated xs, result = mkType <$> fromGenLocated con_res_ty}
 #else
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT xs, ..} =
-  Just
-    $ Record
-        { fields = fromGenLocated xs
-        , result = mkType <$> fromGenLocated con_res_ty
-        }
+  Just $
+  Record
+    {fields = fromGenLocated xs, result = mkType <$> fromGenLocated con_res_ty}
 #endif
 mkConstructorSignature GHC.ConDeclH98 {} = Nothing

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
@@ -6,16 +6,16 @@ module HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
   , mkConstructorSignature
   ) where
 
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type
-import           HIndent.Ast.WithComments
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 data ConstructorSignature
   = ByArrows
       { parameters :: [WithComments Type]
-      , result     :: WithComments Type
+      , result :: WithComments Type
       }
   | Record
       { fields :: WithComments [GHC.LConDeclField GHC.GhcPs]
@@ -24,24 +24,29 @@ data ConstructorSignature
 
 instance CommentExtraction ConstructorSignature where
   nodeComments (ByArrows {}) = NodeComments [] [] []
-  nodeComments (Record {})   = NodeComments [] [] []
+  nodeComments (Record {}) = NodeComments [] [] []
 
 mkConstructorSignature :: GHC.ConDecl GHC.GhcPs -> Maybe ConstructorSignature
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.PrefixConGADT xs, ..} =
-  Just $
-  ByArrows
-    { parameters = fmap (fmap mkType . fromGenLocated . GHC.hsScaledThing) xs
-    , result = mkType <$> fromGenLocated con_res_ty
-    }
+  Just
+    $ ByArrows
+        { parameters =
+            fmap (fmap mkType . fromGenLocated . GHC.hsScaledThing) xs
+        , result = mkType <$> fromGenLocated con_res_ty
+        }
 #if MIN_VERSION_ghc_lib_parser(9, 4, 0)
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT xs _, ..} =
-  Just $
-  Record
-    {fields = fromGenLocated xs, result = mkType <$> fromGenLocated con_res_ty}
+  Just
+    $ Record
+        { fields = fromGenLocated xs
+        , result = mkType <$> fromGenLocated con_res_ty
+        }
 #else
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT xs, ..} =
-  Just $
-  Record
-    {fields = fromGenLocated xs, result = mkType <$> fromGenLocated con_res_ty}
+  Just
+    $ Record
+        { fields = fromGenLocated xs
+        , result = mkType <$> fromGenLocated con_res_ty
+        }
 #endif
 mkConstructorSignature GHC.ConDeclH98 {} = Nothing

--- a/src/HIndent/Ast/Declaration/Data/Header.hs
+++ b/src/HIndent/Ast/Declaration/Data/Header.hs
@@ -5,18 +5,18 @@ module HIndent.Ast.Declaration.Data.Header
   , mkHeader
   ) where
 
-import           HIndent.Ast.Context
-import           HIndent.Ast.Declaration.Data.NewOrData
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type.Variable
-import           HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs     as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Ast.Context
+import HIndent.Ast.Declaration.Data.NewOrData
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type.Variable
+import HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pretty.NodeComments
 
 data Header = Header
-  { newOrData     :: NewOrData
-  , name          :: WithComments (GHC.IdP GHC.GhcPs)
-  , context       :: Maybe (WithComments Context)
+  { newOrData :: NewOrData
+  , name :: WithComments (GHC.IdP GHC.GhcPs)
+  , context :: Maybe (WithComments Context)
   , typeVariables :: [WithComments TypeVariable]
   }
 

--- a/src/HIndent/Ast/Declaration/Data/Header.hs
+++ b/src/HIndent/Ast/Declaration/Data/Header.hs
@@ -1,18 +1,16 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.Header
-  ( Header
+  ( Header(..)
   , mkHeader
   ) where
 
-import           HIndent.Applicative
 import           HIndent.Ast.Context
 import           HIndent.Ast.Declaration.Data.NewOrData
 import           HIndent.Ast.NodeComments
 import           HIndent.Ast.Type.Variable
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs     as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
 
 data Header = Header

--- a/src/HIndent/Ast/Declaration/Data/Header.hs
+++ b/src/HIndent/Ast/Declaration/Data/Header.hs
@@ -5,33 +5,25 @@ module HIndent.Ast.Declaration.Data.Header
   , mkHeader
   ) where
 
-import HIndent.Applicative
-import HIndent.Ast.Context
-import HIndent.Ast.Declaration.Data.NewOrData
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type.Variable
-import HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           HIndent.Applicative
+import           HIndent.Ast.Context
+import           HIndent.Ast.Declaration.Data.NewOrData
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type.Variable
+import           HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs     as GHC
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data Header = Header
-  { newOrData :: NewOrData
-  , name :: WithComments (GHC.IdP GHC.GhcPs)
-  , context :: Maybe (WithComments Context)
+  { newOrData     :: NewOrData
+  , name          :: WithComments (GHC.IdP GHC.GhcPs)
+  , context       :: Maybe (WithComments Context)
   , typeVariables :: [WithComments TypeVariable]
   }
 
 instance CommentExtraction Header where
   nodeComments Header {} = NodeComments [] [] []
-
-instance Pretty Header where
-  pretty' Header {..} = do
-    (pretty newOrData >> space) |=> do
-      whenJust context $ \c -> pretty c >> string " =>" >> newline
-      pretty name
-    spacePrefixed $ fmap pretty typeVariables
 
 mkHeader :: GHC.TyClDecl GHC.GhcPs -> Maybe Header
 mkHeader GHC.DataDecl {tcdDataDefn = defn@GHC.HsDataDefn {..}, ..} =

--- a/src/HIndent/Ast/Declaration/Data/NewOrData.hs
+++ b/src/HIndent/Ast/Declaration/Data/NewOrData.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.NewOrData
@@ -6,11 +6,10 @@ module HIndent.Ast.Declaration.Data.NewOrData
   , mkNewOrData
   ) where
 
-import HIndent.Ast.NodeComments
+import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data NewOrData
   = Newtype
@@ -18,11 +17,7 @@ data NewOrData
 
 instance CommentExtraction NewOrData where
   nodeComments Newtype = NodeComments [] [] []
-  nodeComments Data = NodeComments [] [] []
-
-instance Pretty NewOrData where
-  pretty' Newtype = string "newtype"
-  pretty' Data = string "data"
+  nodeComments Data    = NodeComments [] [] []
 
 mkNewOrData :: GHC.HsDataDefn GHC.GhcPs -> NewOrData
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)

--- a/src/HIndent/Ast/Declaration/Data/NewOrData.hs
+++ b/src/HIndent/Ast/Declaration/Data/NewOrData.hs
@@ -2,13 +2,12 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.NewOrData
-  ( NewOrData
+  ( NewOrData(..)
   , mkNewOrData
   ) where
 
 import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
 
 data NewOrData

--- a/src/HIndent/Ast/Declaration/Data/NewOrData.hs
+++ b/src/HIndent/Ast/Declaration/Data/NewOrData.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.NewOrData
@@ -6,9 +6,9 @@ module HIndent.Ast.Declaration.Data.NewOrData
   , mkNewOrData
   ) where
 
-import           HIndent.Ast.NodeComments
+import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 data NewOrData
   = Newtype
@@ -16,7 +16,7 @@ data NewOrData
 
 instance CommentExtraction NewOrData where
   nodeComments Newtype = NodeComments [] [] []
-  nodeComments Data    = NodeComments [] [] []
+  nodeComments Data = NodeComments [] [] []
 
 mkNewOrData :: GHC.HsDataDefn GHC.GhcPs -> NewOrData
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -5,36 +5,27 @@ module HIndent.Ast.Declaration.Family.Data
   , mkDataFamily
   ) where
 
-import Control.Monad
-import qualified GHC.Types.Basic as GHC
-import qualified GHC.Types.SrcLoc as GHC
-import HIndent.Applicative
-import HIndent.Ast.NodeComments hiding (fromEpAnn)
-import HIndent.Ast.Type
-import HIndent.Ast.Type.Variable
-import HIndent.Ast.WithComments
+import           Control.Monad
+import qualified GHC.Types.Basic                    as GHC
+import qualified GHC.Types.SrcLoc                   as GHC
+import           HIndent.Applicative
+import           HIndent.Ast.NodeComments           hiding (fromEpAnn)
+import           HIndent.Ast.Type
+import           HIndent.Ast.Type.Variable
+import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data DataFamily = DataFamily
-  { isTopLevel :: Bool
-  , name :: String
+  { isTopLevel    :: Bool
+  , name          :: String
   , typeVariables :: [WithComments TypeVariable]
-  , signature :: Maybe (WithComments Type)
+  , signature     :: Maybe (WithComments Type)
   }
 
 instance CommentExtraction DataFamily where
   nodeComments DataFamily {} = NodeComments [] [] []
-
-instance Pretty DataFamily where
-  pretty' DataFamily {..} = do
-    string "data "
-    when isTopLevel $ string "family "
-    string name
-    spacePrefixed $ fmap pretty typeVariables
-    whenJust signature $ \sig -> space >> pretty sig
 
 mkDataFamily :: GHC.FamilyDecl GHC.GhcPs -> Maybe DataFamily
 mkDataFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
@@ -44,7 +35,7 @@ mkDataFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
   where
     isTopLevel =
       case fdTopLevel of
-        GHC.TopLevel -> True
+        GHC.TopLevel    -> True
         GHC.NotTopLevel -> False
     name = showOutputable fdLName
     typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Family.Data
-  ( DataFamily
+  ( DataFamily(..)
   , mkDataFamily
   ) where
 
-import           Control.Monad
 import qualified GHC.Types.Basic                    as GHC
 import qualified GHC.Types.SrcLoc                   as GHC
-import           HIndent.Applicative
 import           HIndent.Ast.NodeComments           hiding (fromEpAnn)
 import           HIndent.Ast.Type
 import           HIndent.Ast.Type.Variable

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -5,21 +5,21 @@ module HIndent.Ast.Declaration.Family.Data
   , mkDataFamily
   ) where
 
-import qualified GHC.Types.Basic                    as GHC
-import qualified GHC.Types.SrcLoc                   as GHC
-import           HIndent.Ast.NodeComments           hiding (fromEpAnn)
-import           HIndent.Ast.Type
-import           HIndent.Ast.Type.Variable
-import           HIndent.Ast.WithComments
+import qualified GHC.Types.Basic as GHC
+import qualified GHC.Types.SrcLoc as GHC
+import HIndent.Ast.NodeComments hiding (fromEpAnn)
+import HIndent.Ast.Type
+import HIndent.Ast.Type.Variable
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 data DataFamily = DataFamily
-  { isTopLevel    :: Bool
-  , name          :: String
+  { isTopLevel :: Bool
+  , name :: String
   , typeVariables :: [WithComments TypeVariable]
-  , signature     :: Maybe (WithComments Type)
+  , signature :: Maybe (WithComments Type)
   }
 
 instance CommentExtraction DataFamily where
@@ -33,7 +33,7 @@ mkDataFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
   where
     isTopLevel =
       case fdTopLevel of
-        GHC.TopLevel    -> True
+        GHC.TopLevel -> True
         GHC.NotTopLevel -> False
     name = showOutputable fdLName
     typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -5,44 +5,30 @@ module HIndent.Ast.Declaration.Family.Type
   , mkTypeFamily
   ) where
 
-import Control.Monad
-import qualified GHC.Types.Basic as GHC
-import HIndent.Applicative
-import HIndent.Ast.Declaration.Family.Type.Injectivity
-import HIndent.Ast.Declaration.Family.Type.ResultSignature
-import HIndent.Ast.NodeComments hiding (fromEpAnn)
-import HIndent.Ast.Type.Variable
-import HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           Control.Monad
+import qualified GHC.Types.Basic                                     as GHC
+import           HIndent.Applicative
+import           HIndent.Ast.Declaration.Family.Type.Injectivity
+import           HIndent.Ast.Declaration.Family.Type.ResultSignature
+import           HIndent.Ast.NodeComments                            hiding
+                                                                     (fromEpAnn)
+import           HIndent.Ast.Type.Variable
+import           HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs                  as GHC
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data TypeFamily = TypeFamily
-  { isTopLevel :: Bool
-  , name :: String
+  { isTopLevel    :: Bool
+  , name          :: String
   , typeVariables :: [WithComments TypeVariable]
-  , signature :: WithComments ResultSignature
-  , injectivity :: Maybe (WithComments Injectivity)
-  , equations :: Maybe [GHC.LTyFamInstEqn GHC.GhcPs]
+  , signature     :: WithComments ResultSignature
+  , injectivity   :: Maybe (WithComments Injectivity)
+  , equations     :: Maybe [GHC.LTyFamInstEqn GHC.GhcPs]
   }
 
 instance CommentExtraction TypeFamily where
   nodeComments TypeFamily {} = NodeComments [] [] []
-
-instance Pretty TypeFamily where
-  pretty' TypeFamily {..} = do
-    string "type "
-    when isTopLevel $ string "family "
-    string name
-    spacePrefixed $ fmap pretty typeVariables
-    case getNode signature of
-      ResultSignature GHC.NoSig {} -> pure ()
-      ResultSignature GHC.TyVarSig {} -> string " = " >> pretty signature
-      _ -> space >> pretty signature
-    whenJust injectivity $ \x -> string " | " >> pretty x
-    whenJust equations $ \xs ->
-      string " where" >> newline >> indentedBlock (lined $ fmap pretty xs)
 
 mkTypeFamily :: GHC.FamilyDecl GHC.GhcPs -> Maybe TypeFamily
 mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
@@ -51,7 +37,7 @@ mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
   where
     isTopLevel =
       case fdTopLevel of
-        GHC.TopLevel -> True
+        GHC.TopLevel    -> True
         GHC.NotTopLevel -> False
     name = showOutputable fdLName
     typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit
@@ -59,7 +45,7 @@ mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
     injectivity = fmap (fmap Injectivity . fromGenLocated) fdInjectivityAnn
     equations =
       case fdInfo of
-        GHC.DataFamily -> error "Not a TypeFamily"
-        GHC.OpenTypeFamily -> Nothing
-        GHC.ClosedTypeFamily Nothing -> Just []
+        GHC.DataFamily                 -> error "Not a TypeFamily"
+        GHC.OpenTypeFamily             -> Nothing
+        GHC.ClosedTypeFamily Nothing   -> Just []
         GHC.ClosedTypeFamily (Just xs) -> Just xs

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Family.Type
-  ( TypeFamily
+  ( TypeFamily(..)
   , mkTypeFamily
   ) where
 
-import           Control.Monad
 import qualified GHC.Types.Basic                                     as GHC
-import           HIndent.Applicative
 import           HIndent.Ast.Declaration.Family.Type.Injectivity
 import           HIndent.Ast.Declaration.Family.Type.ResultSignature
 import           HIndent.Ast.NodeComments                            hiding

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -5,24 +5,23 @@ module HIndent.Ast.Declaration.Family.Type
   , mkTypeFamily
   ) where
 
-import qualified GHC.Types.Basic                                     as GHC
-import           HIndent.Ast.Declaration.Family.Type.Injectivity
-import           HIndent.Ast.Declaration.Family.Type.ResultSignature
-import           HIndent.Ast.NodeComments                            hiding
-                                                                     (fromEpAnn)
-import           HIndent.Ast.Type.Variable
-import           HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs                  as GHC
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import qualified GHC.Types.Basic as GHC
+import HIndent.Ast.Declaration.Family.Type.Injectivity
+import HIndent.Ast.Declaration.Family.Type.ResultSignature
+import HIndent.Ast.NodeComments hiding (fromEpAnn)
+import HIndent.Ast.Type.Variable
+import HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 data TypeFamily = TypeFamily
-  { isTopLevel    :: Bool
-  , name          :: String
+  { isTopLevel :: Bool
+  , name :: String
   , typeVariables :: [WithComments TypeVariable]
-  , signature     :: WithComments ResultSignature
-  , injectivity   :: Maybe (WithComments Injectivity)
-  , equations     :: Maybe [GHC.LTyFamInstEqn GHC.GhcPs]
+  , signature :: WithComments ResultSignature
+  , injectivity :: Maybe (WithComments Injectivity)
+  , equations :: Maybe [GHC.LTyFamInstEqn GHC.GhcPs]
   }
 
 instance CommentExtraction TypeFamily where
@@ -35,7 +34,7 @@ mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
   where
     isTopLevel =
       case fdTopLevel of
-        GHC.TopLevel    -> True
+        GHC.TopLevel -> True
         GHC.NotTopLevel -> False
     name = showOutputable fdLName
     typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit
@@ -43,7 +42,7 @@ mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
     injectivity = fmap (fmap Injectivity . fromGenLocated) fdInjectivityAnn
     equations =
       case fdInfo of
-        GHC.DataFamily                 -> error "Not a TypeFamily"
-        GHC.OpenTypeFamily             -> Nothing
-        GHC.ClosedTypeFamily Nothing   -> Just []
+        GHC.DataFamily -> error "Not a TypeFamily"
+        GHC.OpenTypeFamily -> Nothing
+        GHC.ClosedTypeFamily Nothing -> Just []
         GHC.ClosedTypeFamily (Just xs) -> Just xs

--- a/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
@@ -2,9 +2,9 @@ module HIndent.Ast.Declaration.Family.Type.Injectivity
   ( Injectivity(..)
   ) where
 
-import           HIndent.Ast.NodeComments
+import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 newtype Injectivity =
   Injectivity (GHC.InjectivityAnn GHC.GhcPs)

--- a/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
@@ -2,16 +2,12 @@ module HIndent.Ast.Declaration.Family.Type.Injectivity
   ( Injectivity(..)
   ) where
 
-import HIndent.Ast.NodeComments
+import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty.NodeComments
 
 newtype Injectivity =
   Injectivity (GHC.InjectivityAnn GHC.GhcPs)
 
 instance CommentExtraction Injectivity where
   nodeComments (Injectivity _) = NodeComments [] [] []
-
-instance Pretty Injectivity where
-  pretty' (Injectivity x) = pretty x

--- a/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
@@ -2,9 +2,9 @@ module HIndent.Ast.Declaration.Family.Type.ResultSignature
   ( ResultSignature(..)
   ) where
 
-import           HIndent.Ast.NodeComments
+import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 newtype ResultSignature =
   ResultSignature (GHC.FamilyResultSig GHC.GhcPs)

--- a/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
@@ -2,16 +2,12 @@ module HIndent.Ast.Declaration.Family.Type.ResultSignature
   ( ResultSignature(..)
   ) where
 
-import HIndent.Ast.NodeComments
+import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty.NodeComments
 
 newtype ResultSignature =
   ResultSignature (GHC.FamilyResultSig GHC.GhcPs)
 
 instance CommentExtraction ResultSignature where
   nodeComments (ResultSignature _) = NodeComments [] [] []
-
-instance Pretty ResultSignature where
-  pretty' (ResultSignature x) = pretty x

--- a/src/HIndent/Ast/Declaration/Instance/Class.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class.hs
@@ -5,16 +5,15 @@ module HIndent.Ast.Declaration.Instance.Class
   , mkClassInstance
   ) where
 
-import Control.Monad
-import GHC.Data.Bag
-import HIndent.Applicative
-import HIndent.Ast.NodeComments
+import           Control.Monad
+import           GHC.Data.Bag
+import           HIndent.Applicative
+import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
 
 newtype ClassInstance =
   ClassInstance (GHC.ClsInstDecl GHC.GhcPs)
@@ -22,26 +21,6 @@ newtype ClassInstance =
 instance CommentExtraction ClassInstance where
   nodeComments ClassInstance {} = NodeComments [] [] []
 
-instance Pretty ClassInstance where
-  pretty' (ClassInstance GHC.ClsInstDecl {..}) = do
-    string "instance " |=> do
-      whenJust cid_overlap_mode $ \x -> do
-        pretty x
-        space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
-    unless (null sigsAndMethods) $ do
-      newline
-      indentedBlock $ lined $ fmap pretty sigsAndMethods
-    where
-      sigsAndMethods =
-        mkSortedLSigBindFamilyList
-          cid_sigs
-          (bagToList cid_binds)
-          []
-          cid_tyfam_insts
-          cid_datafam_insts
-
 mkClassInstance :: GHC.InstDecl GHC.GhcPs -> Maybe ClassInstance
 mkClassInstance GHC.ClsInstD {..} = Just $ ClassInstance cid_inst
-mkClassInstance _ = Nothing
+mkClassInstance _                 = Nothing

--- a/src/HIndent/Ast/Declaration/Instance/Class.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class.hs
@@ -5,9 +5,9 @@ module HIndent.Ast.Declaration.Instance.Class
   , mkClassInstance
   ) where
 
-import           HIndent.Ast.NodeComments
+import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 newtype ClassInstance =
   ClassInstance (GHC.ClsInstDecl GHC.GhcPs)
@@ -17,4 +17,4 @@ instance CommentExtraction ClassInstance where
 
 mkClassInstance :: GHC.InstDecl GHC.GhcPs -> Maybe ClassInstance
 mkClassInstance GHC.ClsInstD {..} = Just $ ClassInstance cid_inst
-mkClassInstance _                 = Nothing
+mkClassInstance _ = Nothing

--- a/src/HIndent/Ast/Declaration/Instance/Class.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class.hs
@@ -1,19 +1,13 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Class
-  ( ClassInstance
+  ( ClassInstance(..)
   , mkClassInstance
   ) where
 
-import           Control.Monad
-import           GHC.Data.Bag
-import           HIndent.Applicative
 import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
-import           HIndent.Pretty.SigBindFamily
-import           HIndent.Pretty.Types
 
 newtype ClassInstance =
   ClassInstance (GHC.ClsInstDecl GHC.GhcPs)

--- a/src/HIndent/Ast/Declaration/TypeSynonym.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.TypeSynonym
-  ( TypeSynonym
+  ( TypeSynonym(..)
   , mkTypeSynonym
   ) where
 
@@ -10,7 +10,6 @@ import           HIndent.Ast.NodeComments
 import           HIndent.Ast.Type
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs      as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
 
 data TypeSynonym = TypeSynonym

--- a/src/HIndent/Ast/Declaration/TypeSynonym.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym.hs
@@ -5,12 +5,12 @@ module HIndent.Ast.Declaration.TypeSynonym
   , mkTypeSynonym
   ) where
 
-import           HIndent.Ast.Declaration.TypeSynonym.Lhs
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type
-import           HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs      as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Ast.Declaration.TypeSynonym.Lhs
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pretty.NodeComments
 
 data TypeSynonym = TypeSynonym
   { lhs :: TypeSynonymLhs

--- a/src/HIndent/Ast/Declaration/TypeSynonym.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym.hs
@@ -5,14 +5,13 @@ module HIndent.Ast.Declaration.TypeSynonym
   , mkTypeSynonym
   ) where
 
-import HIndent.Ast.Declaration.TypeSynonym.Lhs
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type
-import HIndent.Ast.WithComments
-import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           HIndent.Ast.Declaration.TypeSynonym.Lhs
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type
+import           HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs      as GHC
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data TypeSynonym = TypeSynonym
   { lhs :: TypeSynonymLhs
@@ -21,15 +20,6 @@ data TypeSynonym = TypeSynonym
 
 instance CommentExtraction TypeSynonym where
   nodeComments TypeSynonym {} = NodeComments [] [] []
-
-instance Pretty TypeSynonym where
-  pretty' TypeSynonym {..} = do
-    string "type "
-    pretty lhs
-    hor <-|> ver
-    where
-      hor = string " = " >> pretty rhs
-      ver = newline >> indentedBlock (string "= " |=> pretty rhs)
 
 mkTypeSynonym :: GHC.TyClDecl GHC.GhcPs -> TypeSynonym
 mkTypeSynonym synonym@GHC.SynDecl {..} = TypeSynonym {..}

--- a/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
@@ -5,35 +5,29 @@ module HIndent.Ast.Declaration.TypeSynonym.Lhs
   , mkTypeSynonymLhs
   ) where
 
-import qualified GHC.Types.Fixity as GHC
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type.Variable
-import HIndent.Ast.WithComments
+import qualified GHC.Types.Fixity                   as GHC
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type.Variable
+import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.Types
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.Types
 
 data TypeSynonymLhs
   = Prefix
-      { name :: GHC.LIdP GHC.GhcPs
+      { name          :: GHC.LIdP GHC.GhcPs
       , typeVariables :: [WithComments TypeVariable]
       }
   | Infix
-      { left :: WithComments TypeVariable
-      , name :: GHC.LIdP GHC.GhcPs
+      { left  :: WithComments TypeVariable
+      , name  :: GHC.LIdP GHC.GhcPs
       , right :: WithComments TypeVariable
       }
 
 instance CommentExtraction TypeSynonymLhs where
   nodeComments Prefix {} = NodeComments [] [] []
-  nodeComments Infix {} = NodeComments [] [] []
-
-instance Pretty TypeSynonymLhs where
-  pretty' Prefix {..} = spaced $ pretty name : fmap pretty typeVariables
-  pretty' Infix {..} =
-    spaced [pretty left, pretty $ fmap InfixOp name, pretty right]
+  nodeComments Infix {}  = NodeComments [] [] []
 
 mkTypeSynonymLhs :: GHC.TyClDecl GHC.GhcPs -> TypeSynonymLhs
 mkTypeSynonymLhs GHC.SynDecl {tcdFixity = GHC.Prefix, ..} =

--- a/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.TypeSynonym.Lhs
-  ( TypeSynonymLhs
+  ( TypeSynonymLhs(..)
   , mkTypeSynonymLhs
   ) where
 
@@ -10,9 +10,7 @@ import           HIndent.Ast.NodeComments
 import           HIndent.Ast.Type.Variable
 import           HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
-import           HIndent.Pretty.Types
 
 data TypeSynonymLhs
   = Prefix

--- a/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
@@ -5,27 +5,27 @@ module HIndent.Ast.Declaration.TypeSynonym.Lhs
   , mkTypeSynonymLhs
   ) where
 
-import qualified GHC.Types.Fixity                   as GHC
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type.Variable
-import           HIndent.Ast.WithComments
+import qualified GHC.Types.Fixity as GHC
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type.Variable
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 data TypeSynonymLhs
   = Prefix
-      { name          :: GHC.LIdP GHC.GhcPs
+      { name :: GHC.LIdP GHC.GhcPs
       , typeVariables :: [WithComments TypeVariable]
       }
   | Infix
-      { left  :: WithComments TypeVariable
-      , name  :: GHC.LIdP GHC.GhcPs
+      { left :: WithComments TypeVariable
+      , name :: GHC.LIdP GHC.GhcPs
       , right :: WithComments TypeVariable
       }
 
 instance CommentExtraction TypeSynonymLhs where
   nodeComments Prefix {} = NodeComments [] [] []
-  nodeComments Infix {}  = NodeComments [] [] []
+  nodeComments Infix {} = NodeComments [] [] []
 
 mkTypeSynonymLhs :: GHC.TyClDecl GHC.GhcPs -> TypeSynonymLhs
 mkTypeSynonymLhs GHC.SynDecl {tcdFixity = GHC.Prefix, ..} =

--- a/src/HIndent/Ast/Type.hs
+++ b/src/HIndent/Ast/Type.hs
@@ -3,19 +3,15 @@ module HIndent.Ast.Type
   , mkType
   ) where
 
-import HIndent.Ast.NodeComments
+import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pretty
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty.NodeComments
 
 newtype Type =
   Type (GHC.HsType GHC.GhcPs)
 
 instance CommentExtraction Type where
   nodeComments (Type _) = NodeComments [] [] []
-
-instance Pretty Type where
-  pretty' (Type x) = pretty x
 
 mkType :: GHC.HsType GHC.GhcPs -> Type
 mkType = Type

--- a/src/HIndent/Ast/Type.hs
+++ b/src/HIndent/Ast/Type.hs
@@ -3,9 +3,9 @@ module HIndent.Ast.Type
   , mkType
   ) where
 
-import           HIndent.Ast.NodeComments
+import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty.NodeComments
 
 newtype Type =
   Type (GHC.HsType GHC.GhcPs)

--- a/src/HIndent/Ast/Type.hs
+++ b/src/HIndent/Ast/Type.hs
@@ -1,5 +1,5 @@
 module HIndent.Ast.Type
-  ( Type
+  ( Type(..)
   , mkType
   ) where
 

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Type.Variable
-  ( TypeVariable
+  ( TypeVariable(..)
   , mkTypeVariable
   ) where
 

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -5,12 +5,12 @@ module HIndent.Ast.Type.Variable
   , mkTypeVariable
   ) where
 
-import qualified GHC.Hs                      as GHC
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type
-import           HIndent.Ast.WithComments
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import qualified GHC.Hs as GHC
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.WithComments
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 data TypeVariable = TypeVariable
   { name :: WithComments String

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module HIndent.Ast.Type.Variable
   ( TypeVariable(..)
   , mkTypeVariable
@@ -21,10 +19,10 @@ instance CommentExtraction TypeVariable where
   nodeComments TypeVariable {} = NodeComments [] [] []
 
 mkTypeVariable :: GHC.HsTyVarBndr a GHC.GhcPs -> TypeVariable
-mkTypeVariable (GHC.UserTyVar _ _ name) =
-  TypeVariable {name = showOutputable <$> fromGenLocated name, kind = Nothing}
-mkTypeVariable (GHC.KindedTyVar _ _ name kind) =
+mkTypeVariable (GHC.UserTyVar _ _ n) =
+  TypeVariable {name = showOutputable <$> fromGenLocated n, kind = Nothing}
+mkTypeVariable (GHC.KindedTyVar _ _ n k) =
   TypeVariable
-    { name = showOutputable <$> fromGenLocated name
-    , kind = Just $ mkType <$> fromGenLocated kind
+    { name = showOutputable <$> fromGenLocated n
+    , kind = Just $ mkType <$> fromGenLocated k
     }

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -5,13 +5,12 @@ module HIndent.Ast.Type.Variable
   , mkTypeVariable
   ) where
 
-import qualified GHC.Hs as GHC
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type
-import HIndent.Ast.WithComments
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import qualified GHC.Hs                      as GHC
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type
+import           HIndent.Ast.WithComments
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 data TypeVariable = TypeVariable
   { name :: WithComments String
@@ -20,11 +19,6 @@ data TypeVariable = TypeVariable
 
 instance CommentExtraction TypeVariable where
   nodeComments TypeVariable {} = NodeComments [] [] []
-
-instance Pretty TypeVariable where
-  pretty' TypeVariable {kind = Just kind, ..} =
-    parens $ prettyWith name string >> string " :: " >> pretty kind
-  pretty' TypeVariable {kind = Nothing, ..} = prettyWith name string
 
 mkTypeVariable :: GHC.HsTyVarBndr a GHC.GhcPs -> TypeVariable
 mkTypeVariable (GHC.UserTyVar _ _ name) =

--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -1,29 +1,26 @@
 {-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module HIndent.Ast.WithComments
   ( WithComments
   , fromGenLocated
   , fromEpAnn
-  , prettyWith
   , getNode
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import qualified GHC.Hs as GHC
-import qualified GHC.Types.SrcLoc as GHC
-import HIndent.Ast.NodeComments (NodeComments(..))
-import qualified HIndent.Ast.NodeComments as NodeComments
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Printer
+import           Control.Monad
+import           Control.Monad.RWS
+import qualified GHC.Hs                      as GHC
+import qualified GHC.Types.SrcLoc            as GHC
+import           HIndent.Ast.NodeComments    (NodeComments (..))
+import qualified HIndent.Ast.NodeComments    as NodeComments
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Printer
 
 data WithComments a = WithComments
   { comments :: NodeComments
-  , node :: a
+  , node     :: a
   } deriving (Foldable, Traversable)
 
 instance Functor WithComments where
@@ -31,18 +28,6 @@ instance Functor WithComments where
 
 instance CommentExtraction (WithComments a) where
   nodeComments WithComments {..} = comments
-
-instance (Pretty a) => Pretty (WithComments a) where
-  pretty' WithComments {..} = pretty' node
-
--- | Prints comments included in the location information and then the
--- AST node body.
-prettyWith :: WithComments a -> (a -> Printer ()) -> Printer ()
-prettyWith WithComments {..} f = do
-  printCommentsBefore comments
-  f node
-  printCommentOnSameLine comments
-  printCommentsAfter comments
 
 fromGenLocated :: (CommentExtraction l) => GHC.GenLocated l a -> WithComments a
 fromGenLocated (GHC.L l a) = WithComments (nodeComments l) a
@@ -52,38 +37,3 @@ fromEpAnn ann = WithComments (NodeComments.fromEpAnn ann)
 
 getNode :: WithComments a -> a
 getNode = node
-
--- | Prints comments that are before the given AST node.
-printCommentsBefore :: NodeComments -> Printer ()
-printCommentsBefore p =
-  forM_ (commentsBefore p) $ \(GHC.L loc c) -> do
-    let col = fromIntegral $ GHC.srcSpanStartCol (GHC.anchor loc) - 1
-    indentedWithFixedLevel col $ pretty c
-    newline
-
--- | Prints comments that are on the same line as the given AST node.
-printCommentOnSameLine :: NodeComments -> Printer ()
-printCommentOnSameLine (commentsOnSameLine -> (c:cs)) = do
-  col <- gets psColumn
-  if col == 0
-    then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
-    else spacePrefixed $ fmap pretty $ c : cs
-  eolCommentsArePrinted
-printCommentOnSameLine _ = return ()
-
--- | Prints comments that are after the given AST node.
-printCommentsAfter :: NodeComments -> Printer ()
-printCommentsAfter p =
-  case commentsAfter p of
-    [] -> return ()
-    xs -> do
-      isThereCommentsOnSameLine <- gets psEolComment
-      unless isThereCommentsOnSameLine newline
-      forM_ xs $ \(GHC.L loc c) -> do
-        let col = fromIntegral $ GHC.srcSpanStartCol (GHC.anchor loc) - 1
-        indentedWithFixedLevel col $ pretty c
-        eolCommentsArePrinted

--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.WithComments
   ( WithComments(..)
@@ -8,15 +8,15 @@ module HIndent.Ast.WithComments
   , getNode
   ) where
 
-import qualified GHC.Hs                      as GHC
-import qualified GHC.Types.SrcLoc            as GHC
-import           HIndent.Ast.NodeComments    (NodeComments (..))
-import qualified HIndent.Ast.NodeComments    as NodeComments
-import           HIndent.Pretty.NodeComments
+import qualified GHC.Hs as GHC
+import qualified GHC.Types.SrcLoc as GHC
+import HIndent.Ast.NodeComments (NodeComments(..))
+import qualified HIndent.Ast.NodeComments as NodeComments
+import HIndent.Pretty.NodeComments
 
 data WithComments a = WithComments
   { comments :: NodeComments
-  , node     :: a
+  , node :: a
   } deriving (Foldable, Traversable)
 
 instance Functor WithComments where

--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -2,21 +2,17 @@
 {-# LANGUAGE RecordWildCards   #-}
 
 module HIndent.Ast.WithComments
-  ( WithComments
+  ( WithComments(..)
   , fromGenLocated
   , fromEpAnn
   , getNode
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
 import qualified GHC.Hs                      as GHC
 import qualified GHC.Types.SrcLoc            as GHC
 import           HIndent.Ast.NodeComments    (NodeComments (..))
 import qualified HIndent.Ast.NodeComments    as NodeComments
-import           HIndent.Pretty.Combinators
 import           HIndent.Pretty.NodeComments
-import           HIndent.Printer
 
 data WithComments a = WithComments
   { comments :: NodeComments

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Pretty printing.
 --
@@ -20,58 +20,58 @@ module HIndent.Pretty
   , pretty
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
-import           Data.Maybe
-import           Data.Void
-import qualified GHC.Core.Coercion                                       as GHC
-import qualified GHC.Data.Bag                                            as GHC
-import qualified GHC.Data.BooleanFormula                                 as GHC
-import qualified GHC.Data.FastString                                     as GHC
-import qualified GHC.Hs                                                  as GHC
-import           GHC.Stack
-import qualified GHC.Types.Basic                                         as GHC
-import qualified GHC.Types.Fixity                                        as GHC
-import qualified GHC.Types.ForeignCall                                   as GHC
-import qualified GHC.Types.Name                                          as GHC
-import qualified GHC.Types.Name.Reader                                   as GHC
-import qualified GHC.Types.SourceText                                    as GHC
-import qualified GHC.Types.SrcLoc                                        as GHC
-import qualified GHC.Unit.Module.Warnings                                as GHC
-import           HIndent.Applicative
+import Control.Monad
+import Control.Monad.RWS
+import Data.Maybe
+import Data.Void
+import qualified GHC.Core.Coercion as GHC
+import qualified GHC.Data.Bag as GHC
+import qualified GHC.Data.BooleanFormula as GHC
+import qualified GHC.Data.FastString as GHC
+import qualified GHC.Hs as GHC
+import GHC.Stack
+import qualified GHC.Types.Basic as GHC
+import qualified GHC.Types.Fixity as GHC
+import qualified GHC.Types.ForeignCall as GHC
+import qualified GHC.Types.Name as GHC
+import qualified GHC.Types.Name.Reader as GHC
+import qualified GHC.Types.SourceText as GHC
+import qualified GHC.Types.SrcLoc as GHC
+import qualified GHC.Unit.Module.Warnings as GHC
+import HIndent.Applicative
 import qualified HIndent.Ast.Context
-import           HIndent.Ast.Declaration
-import           HIndent.Ast.Declaration.Data
-import           HIndent.Ast.Declaration.Data.GADT.Constructor
-import           HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
-import           HIndent.Ast.Declaration.Data.Header
-import           HIndent.Ast.Declaration.Data.NewOrData
-import           HIndent.Ast.Declaration.Family.Data
-import           HIndent.Ast.Declaration.Family.Type
-import           HIndent.Ast.Declaration.Family.Type.Injectivity
-import           HIndent.Ast.Declaration.Family.Type.ResultSignature
-import           HIndent.Ast.Declaration.Instance.Class
-import           HIndent.Ast.Declaration.TypeSynonym
-import           HIndent.Ast.Declaration.TypeSynonym.Lhs
-import           HIndent.Ast.NodeComments
-import           HIndent.Ast.Type
-import           HIndent.Ast.Type.Variable
-import           HIndent.Ast.WithComments
-import           HIndent.Config
-import           HIndent.Fixity
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
-import qualified HIndent.Pretty.SigBindFamily                            as SBF
-import           HIndent.Pretty.Types
-import           HIndent.Printer
-import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr             as GHC
-import           Text.Show.Unicode
+import HIndent.Ast.Declaration
+import HIndent.Ast.Declaration.Data
+import HIndent.Ast.Declaration.Data.GADT.Constructor
+import HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
+import HIndent.Ast.Declaration.Data.Header
+import HIndent.Ast.Declaration.Data.NewOrData
+import HIndent.Ast.Declaration.Family.Data
+import HIndent.Ast.Declaration.Family.Type
+import HIndent.Ast.Declaration.Family.Type.Injectivity
+import HIndent.Ast.Declaration.Family.Type.ResultSignature
+import HIndent.Ast.Declaration.Instance.Class
+import HIndent.Ast.Declaration.TypeSynonym
+import HIndent.Ast.Declaration.TypeSynonym.Lhs
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.Type.Variable
+import HIndent.Ast.WithComments
+import HIndent.Config
+import HIndent.Fixity
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+import qualified HIndent.Pretty.SigBindFamily as SBF
+import HIndent.Pretty.Types
+import HIndent.Printer
+import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr as GHC
+import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable                                           as NonEmpty
-import qualified GHC.Core.DataCon                                        as GHC
+import qualified Data.Foldable as NonEmpty
+import qualified GHC.Core.DataCon as GHC
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified GHC.Unit                                                as GHC
+import qualified GHC.Unit as GHC
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -108,8 +108,10 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -138,24 +140,24 @@ class CommentExtraction a =>
   pretty' :: a -> Printer ()
 
 instance Pretty Declaration where
-  pretty' (HIndent.Ast.Declaration.DataFamily x)    = pretty x
-  pretty' (HIndent.Ast.Declaration.TypeFamily x)    = pretty x
-  pretty' (DataDeclaration x)                       = pretty x
-  pretty' (HIndent.Ast.Declaration.TypeSynonym x)   = pretty x
-  pretty' (TyClDecl x)                              = pretty x
+  pretty' (HIndent.Ast.Declaration.DataFamily x) = pretty x
+  pretty' (HIndent.Ast.Declaration.TypeFamily x) = pretty x
+  pretty' (DataDeclaration x) = pretty x
+  pretty' (HIndent.Ast.Declaration.TypeSynonym x) = pretty x
+  pretty' (TyClDecl x) = pretty x
   pretty' (HIndent.Ast.Declaration.ClassInstance x) = pretty x
-  pretty' (InstDecl x)                              = pretty x
-  pretty' (DerivDecl x)                             = pretty x
-  pretty' (ValDecl x)                               = pretty x
-  pretty' (SigDecl x)                               = pretty x
-  pretty' (KindSigDecl x)                           = pretty x
-  pretty' (DefDecl x)                               = pretty x
-  pretty' (ForDecl x)                               = pretty x
-  pretty' (WarningDecl x)                           = pretty x
-  pretty' (AnnDecl x)                               = pretty x
-  pretty' (RuleDecl x)                              = pretty x
-  pretty' (SpliceDecl x)                            = pretty x
-  pretty' (RoleAnnotDecl x)                         = pretty x
+  pretty' (InstDecl x) = pretty x
+  pretty' (DerivDecl x) = pretty x
+  pretty' (ValDecl x) = pretty x
+  pretty' (SigDecl x) = pretty x
+  pretty' (KindSigDecl x) = pretty x
+  pretty' (DefDecl x) = pretty x
+  pretty' (ForDecl x) = pretty x
+  pretty' (WarningDecl x) = pretty x
+  pretty' (AnnDecl x) = pretty x
+  pretty' (RuleDecl x) = pretty x
+  pretty' (SpliceDecl x) = pretty x
+  pretty' (RoleAnnotDecl x) = pretty x
 
 instance Pretty DataDeclaration where
   pretty' GADT {..} = do
@@ -202,9 +204,9 @@ instance Pretty TypeFamily where
     string name
     spacePrefixed $ fmap pretty typeVariables
     case getNode signature of
-      ResultSignature GHC.NoSig {}    -> pure ()
+      ResultSignature GHC.NoSig {} -> pure ()
       ResultSignature GHC.TyVarSig {} -> string " = " >> pretty signature
-      _                               -> space >> pretty signature
+      _ -> space >> pretty signature
     whenJust injectivity $ \x -> string " | " >> pretty x
     whenJust equations $ \xs ->
       string " where" >> newline >> indentedBlock (lined $ fmap pretty xs)
@@ -215,8 +217,8 @@ instance Pretty ClassInstance where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -263,27 +265,28 @@ instance Pretty GADTConstructor where
       ver = newline >> indentedBlock (string ":: " |=> body)
       body =
         case (forallNeeded, con_mb_cxt) of
-          (True, Just ctx)  -> withForallCtx ctx
-          (True, Nothing)   -> withForallOnly
+          (True, Just ctx) -> withForallCtx ctx
+          (True, Nothing) -> withForallOnly
           (False, Just ctx) -> withCtxOnly ctx
-          (False, Nothing)  -> noForallCtx
+          (False, Nothing) -> noForallCtx
       withForallCtx ctx = do
         pretty bindings
-        (space >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)) <-|>
-          (newline >>
-           pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
+        (space >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
+          <-|> (newline
+                  >> pretty
+                       (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
         newline
         prefixed "=> " $ prettyVertically signature
       withForallOnly = do
         pretty bindings
-        (space >> prettyHorizontally signature) <-|>
-          (newline >> prettyVertically signature)
+        (space >> prettyHorizontally signature)
+          <-|> (newline >> prettyVertically signature)
       withCtxOnly ctx =
-        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx) >>
-         string " => " >>
-         prettyHorizontally signature) <-|>
-        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx) >>
-         prefixed "=> " (prettyVertically signature))
+        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)
+           >> string " => "
+           >> prettyHorizontally signature)
+          <-|> (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)
+                  >> prefixed "=> " (prettyVertically signature))
       noForallCtx = prettyHorizontally signature <-|> prettyVertically signature
 
 instance Pretty Header where
@@ -322,8 +325,10 @@ printCommentOnSameLine' (commentsOnSameLine -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine' _ = return ()
@@ -365,16 +370,16 @@ instance Pretty HIndent.Ast.Context.Context where
           parensConditional =
             case xs of
               [_] -> id
-              _   -> parens
+              _ -> parens
       ver =
         case xs of
-          []  -> string "()"
+          [] -> string "()"
           [x] -> pretty x
-          _   -> vTuple $ fmap pretty xs
+          _ -> vTuple $ fmap pretty xs
 
 instance Pretty NewOrData where
   pretty' Newtype = string "newtype"
-  pretty' Data    = string "data"
+  pretty' Data = string "data"
 
 -- Do nothing if there are no pragmas, module headers, imports, or
 -- declarations. Otherwise, extra blank lines will be inserted if only
@@ -419,7 +424,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_cons tcdDataDefn of
         GHC.DataTypeCons {} -> string "data "
-        GHC.NewTypeCon {}   -> string "newtype "
+        GHC.NewTypeCon {} -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -434,7 +439,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType  -> string "newtype "
+        GHC.NewType -> string "newtype "
 #else
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -449,7 +454,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType  -> string "newtype "
+        GHC.NewType -> string "newtype "
 #endif
 prettyTyClDecl GHC.ClassDecl {..} = do
   if isJust tcdCtxt
@@ -470,20 +475,21 @@ prettyTyClDecl GHC.ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            []  -> string "()"
+            [] -> string "()"
             [x] -> pretty x
-            xs  -> hvTuple $ fmap pretty xs
+            xs -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock $
-          string "| " |=>
-          vCommaSep
-            (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
-               printCommentsAnd x $ \(GHC.FunDep _ from to) ->
-                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock
+          $ string "| "
+              |=> vCommaSep
+                    (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
+                       printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                         spaced
+                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -494,8 +500,8 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         GHC.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens $
-                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens
+                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
@@ -507,19 +513,19 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
-  pretty' GHC.ClsInstD {..}     = pretty cid_inst
+  pretty' GHC.ClsInstD {..} = pretty cid_inst
   pretty' GHC.DataFamInstD {..} = pretty dfid_inst
-  pretty' GHC.TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' GHC.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (GHC.HsBind GHC.GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: GHC.HsBind GHC.GhcPs -> Printer ()
-prettyHsBind GHC.FunBind {..}     = pretty fun_matches
-prettyHsBind GHC.PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind GHC.VarBind {}       = notGeneratedByParser
+prettyHsBind GHC.FunBind {..} = pretty fun_matches
+prettyHsBind GHC.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind GHC.AbsBinds {}      = notGeneratedByParser
+prettyHsBind GHC.AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (GHC.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -536,13 +542,14 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=>
-               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space
+                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -562,9 +569,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -604,13 +611,14 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=>
-               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space
+                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -630,9 +638,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' GHC.IdSig {} = notGeneratedByParser
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
@@ -691,12 +699,12 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
     where
       cons =
         case dd_cons of
-          GHC.NewTypeCon x      -> [x]
+          GHC.NewTypeCon x -> [x]
           GHC.DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (GHC.DataTypeCons _ (GHC.L _ GHC.ConDeclGADT {}:_)) -> True
-          _                                                   -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -732,7 +740,7 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
       isGADT =
         case dd_cons of
           (GHC.L _ GHC.ConDeclGADT {}:_) -> True
-          _                              -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -743,8 +751,8 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -798,17 +806,18 @@ prettyHsExpr (GHC.HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              []         -> error "Invalid function application."
+              [] -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col' - col -
-            if col == 0
-              then spaces
-              else 0
+            col'
+              - col
+              - if col == 0
+                  then spaces
+                  else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -847,11 +856,11 @@ prettyHsExpr (GHC.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens $
-      prefixedLined "," $
-      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens
+        $ prefixedLined ","
+        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing GHC.Missing {} = True
-    isMissing _              = False
+    isMissing _ = False
 prettyHsExpr (GHC.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -887,8 +896,8 @@ prettyHsExpr (GHC.HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (GHC.HsMultiIf _ guards) =
-  string "if " |=>
-  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if "
+    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (GHC.HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -952,9 +961,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsFieldBind a b)]
@@ -982,9 +991,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsRecField' a b)]
@@ -1011,10 +1020,11 @@ prettyHsExpr (GHC.HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr GHC.HsProjection {..} =
-  parens $
-  forM_ proj_flds $ \x -> do
-    string "."
-    pretty x
+  parens
+    $ forM_ proj_flds
+    $ \x -> do
+        string "."
+        pretty x
 prettyHsExpr (GHC.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -1026,8 +1036,8 @@ prettyHsExpr (GHC.HsSpliceE _ x) = pretty x
 prettyHsExpr (GHC.HsProc _ pat x@(GHC.L _ (GHC.HsCmdTop _ (GHC.L _ (GHC.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock $
-    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock
+    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (GHC.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -1061,7 +1071,7 @@ prettyHsExpr (GHC.HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case  -> string "\\case"
+      Case -> string "\\case"
       Cases -> string "\\cases"
     if null $ GHC.unLoc $ GHC.mg_alts matches
       then string " {}"
@@ -1088,10 +1098,12 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do hor <-|> ver
-                     newline
-                     prefixed "=> " $
-                       prefixedLined "-> " $ pretty <$> flatten hst_body
+               in do
+                    hor <-|> ver
+                    newline
+                    prefixed "=> "
+                      $ prefixedLined "-> "
+                      $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -1101,7 +1113,7 @@ instance Pretty HsSigType' where
     where
       flatten :: GHC.LHsType GHC.GhcPs -> [GHC.LHsType GHC.GhcPs]
       flatten (GHC.L _ (GHC.HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x                               = [x]
+      flatten x = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig GHC.HsSig {..}) =
     case sig_bndrs of
       GHC.HsOuterExplicit _ xs -> do
@@ -1110,8 +1122,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           GHC.HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
-              (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt))
+              <-|> (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -1141,10 +1153,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -1155,20 +1167,20 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
@@ -1187,10 +1199,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -1201,52 +1213,52 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
-
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt)) <-|>
-        (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt))
+        <-|> (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
-      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
+        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-
+    
     forallNeeded =
       case GHC.unLoc con_bndrs of
         GHC.HsOuterImplicit {} -> False
@@ -1254,26 +1266,30 @@ prettyConDecl GHC.ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \c -> do
-        pretty $ Context c
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \c -> do
+             pretty $ Context c
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #else
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \_ -> do
-        pretty $ Context con_mb_cxt
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \_ -> do
+             pretty $ Context con_mb_cxt
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #endif
 prettyConDecl GHC.ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1292,11 +1308,11 @@ instance Pretty
 prettyMatchExpr :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Printer ()
 prettyMatchExpr GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case GHC.unLoc $ head m_pats of
-      GHC.LazyPat {} -> space
-      GHC.BangPat {} -> space
-      _              -> return ()
+  unless (null m_pats)
+    $ case GHC.unLoc $ head m_pats of
+        GHC.LazyPat {} -> space
+        GHC.BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr GHC.Match {m_ctxt = GHC.CaseAlt, ..} = do
@@ -1316,8 +1332,9 @@ prettyMatchExpr GHC.Match {..} =
     GHC.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
-          spaced $
-            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
+          spaced
+            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
+                ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1330,11 +1347,11 @@ instance Pretty
 prettyMatchProc :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Printer ()
 prettyMatchProc GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case GHC.unLoc $ head m_pats of
-      GHC.LazyPat {} -> space
-      GHC.BangPat {} -> space
-      _              -> return ()
+  unless (null m_pats)
+    $ case GHC.unLoc $ head m_pats of
+        GHC.LazyPat {} -> space
+        GHC.BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc GHC.Match {m_ctxt = GHC.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1405,7 +1422,7 @@ instance Pretty
     where
       horizontal =
         case rec_dotdot of
-          Just _  -> braces $ string ".."
+          Just _ -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1417,8 +1434,8 @@ instance Pretty
   pretty' GHC.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (GHC.HsType GHC.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1525,7 +1542,7 @@ prettyHsType (GHC.HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (GHC.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _  -> hvPromotedList $ fmap pretty xs
+    _ -> hvPromotedList $ fmap pretty xs
 prettyHsType (GHC.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (GHC.HsTyLit _ x) = pretty x
 prettyHsType GHC.HsWildCardTy {} = string "_"
@@ -1546,11 +1563,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (GHC.HsValBinds epa lr, _) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty
@@ -1561,11 +1578,11 @@ instance Pretty
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (GHC.HsValBinds epa lr) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (GHC.HsMatchContext GHC.GhcPs) where
@@ -1700,8 +1717,11 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
   pretty' (GHC.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars $
-        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ GHC.unpackFS r
+      wrapWithBars
+        $ indentedWithFixedLevel 0
+        $ sequence_
+        $ printers [] ""
+        $ GHC.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1765,23 +1785,23 @@ prettyPat (GHC.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat GHC.HsRecFields {..}) =
     case fieldPrinters of
-      []  -> string "{}"
+      [] -> string "{}"
       [x] -> braces x
-      xs  -> hvFields xs
+      xs -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
   pretty' (GHC.PatBr _ expr) =
     brackets $ string "p" >> wrapWithBars (pretty expr)
   pretty' (GHC.DecBrL _ decls) =
-    brackets $
-    string "d| " |=>
-    lined (fmap (pretty . fmap mkDeclaration . fromGenLocated) decls) >>
-    string " |"
+    brackets
+      $ string "d| "
+          |=> lined (fmap (pretty . fmap mkDeclaration . fromGenLocated) decls)
+          >> string " |"
   pretty' GHC.DecBrG {} = notGeneratedByParser
   pretty' (GHC.TypBr _ expr) =
     brackets $ string "t" >> wrapWithBars (pretty expr)
@@ -1790,10 +1810,10 @@ instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SBF.SigBindFamily where
-  pretty' (SBF.Sig x)         = pretty x
-  pretty' (SBF.Bind x)        = pretty x
-  pretty' (SBF.TypeFamily x)  = pretty x
-  pretty' (SBF.TyFamInst x)   = pretty x
+  pretty' (SBF.Sig x) = pretty x
+  pretty' (SBF.Bind x) = pretty x
+  pretty' (SBF.TypeFamily x) = pretty x
+  pretty' (SBF.TyFamInst x) = pretty x
   pretty' (SBF.DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty GHC.EpaComment where
@@ -1815,7 +1835,7 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where
   pretty' (GHC.Present _ e) = pretty e
-  pretty' GHC.Missing {}    = pure () -- This appears in a tuple section.
+  pretty' GHC.Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField GHC.HsFieldBind {..}) = do
@@ -1920,7 +1940,7 @@ instance Pretty (GHC.ConDeclField GHC.GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (GHC.L _ (GHC.HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x)                            = pretty' x
+  pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1981,9 +2001,9 @@ instance Pretty InfixApp where
       GHC.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (GHC.BooleanFormula a) where
-  pretty' (GHC.Var x)    = pretty x
-  pretty' (GHC.And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (GHC.Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Var x) = pretty x
+  pretty' (GHC.And xs) = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Or xs) = hvBarSep $ fmap pretty xs
   pretty' (GHC.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
@@ -1991,7 +2011,7 @@ instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
 
 instance Pretty (GHC.AmbiguousFieldOcc GHC.GhcPs) where
   pretty' (GHC.Unambiguous _ name) = pretty name
-  pretty' (GHC.Ambiguous _ name)   = pretty name
+  pretty' (GHC.Ambiguous _ name) = pretty name
 
 instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
   pretty' GHC.HsDerivingClause { deriv_clause_strategy = Just strategy@(GHC.L _ GHC.ViaStrategy {})
@@ -2007,14 +2027,14 @@ instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
 
 instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
   pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
-  pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
+  pretty' (GHC.DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty GHC.OverlapMode where
-  pretty' GHC.NoOverlap {}    = notUsedInParsedStage
+  pretty' GHC.NoOverlap {} = notUsedInParsedStage
   pretty' GHC.Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' GHC.Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
+  pretty' GHC.Overlapping {} = string "{-# OVERLAPPING #-}"
+  pretty' GHC.Overlaps {} = string "{-# OVERLAPS #-}"
+  pretty' GHC.Incoherent {} = string "{-# INCOHERENT #-}"
 
 instance Pretty GHC.StringLiteral where
   pretty' = output
@@ -2022,13 +2042,13 @@ instance Pretty GHC.StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
   pretty' GHC.FamilyDecl {..} = do
-    string $
-      case fdInfo of
-        GHC.DataFamily          -> "data"
-        GHC.OpenTypeFamily      -> "type"
-        GHC.ClosedTypeFamily {} -> "type"
+    string
+      $ case fdInfo of
+          GHC.DataFamily -> "data"
+          GHC.OpenTypeFamily -> "type"
+          GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      GHC.TopLevel    -> string " family "
+      GHC.TopLevel -> string " family "
       GHC.NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
@@ -2051,8 +2071,8 @@ instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
       _ -> pure ()
 
 instance Pretty (GHC.FamilyResultSig GHC.GhcPs) where
-  pretty' GHC.NoSig {}       = pure ()
-  pretty' (GHC.KindSig _ x)  = string ":: " >> pretty x
+  pretty' GHC.NoSig {} = pure ()
+  pretty' (GHC.KindSig _ x) = string ":: " >> pretty x
   pretty' (GHC.TyVarSig _ x) = pretty x
 
 instance Pretty (GHC.HsTyVarBndr a GHC.GhcPs) where
@@ -2071,8 +2091,8 @@ instance Pretty (GHC.ArithSeqInfo GHC.GhcPs) where
   pretty' (GHC.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (GHC.FromThenTo from next to) =
-    brackets $
-    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets
+      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
   pretty' GHC.HsForAllVis {..} = do
@@ -2118,9 +2138,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (GHC.L _ [])  -> parens
+          (GHC.L _ []) -> parens
           (GHC.L _ [_]) -> id
-          _             -> parens
+          _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(GHC.L _ [])) =
@@ -2135,10 +2155,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing            -> id
-          Just (GHC.L _ [])  -> parens
+          Nothing -> id
+          Just (GHC.L _ []) -> parens
           Just (GHC.L _ [_]) -> id
-          Just _             -> parens
+          Just _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -2224,24 +2244,27 @@ instance Pretty
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x)    = pretty x
+  pretty' (GHC.HsValArg x) = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
+  pretty' GHC.HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
            (GHC.HsArg
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x)    = pretty x
+  pretty' (GHC.HsValArg x) = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
+  pretty' GHC.HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsQuote GHC.GhcPs) where
   pretty' (GHC.ExpBr _ x) = brackets $ wrapWithBars $ pretty x
   pretty' (GHC.PatBr _ x) = brackets $ string "p" >> wrapWithBars (pretty x)
   pretty' (GHC.DecBrL _ decls) =
-    brackets $ string "d| " |=> lined (fmap pretty decls) >> string " |"
+    brackets
+      $ string "d| "
+          |=> lined (fmap (pretty . fmap mkDeclaration . fromGenLocated) decls)
+          >> string " |"
   pretty' GHC.DecBrG {} = notUsedInParsedStage
   pretty' (GHC.TypBr _ x) = brackets $ string "t" >> wrapWithBars (pretty x)
   pretty' (GHC.VarBr _ True x) = string "'" >> pretty x
@@ -2259,7 +2282,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2273,7 +2296,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2291,15 +2314,15 @@ instance Pretty (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.GhcPs) where
-  pretty' (GHC.IEName _ name)    = pretty name
+  pretty' (GHC.IEName _ name) = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
+  pretty' (GHC.IEType _ name) = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.RdrName) where
-  pretty' (GHC.IEName name)      = pretty name
+  pretty' (GHC.IEName name) = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
+  pretty' (GHC.IEType _ name) = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.DotFieldOcc GHC.GhcPs) where
@@ -2452,9 +2475,9 @@ instance Pretty GHC.CExportSpec where
   pretty' (GHC.CExportStatic _ _ x) = pretty x
 
 instance Pretty GHC.Safety where
-  pretty' GHC.PlaySafe          = string "safe"
+  pretty' GHC.PlaySafe = string "safe"
   pretty' GHC.PlayInterruptible = string "interruptible"
-  pretty' GHC.PlayRisky         = string "unsafe"
+  pretty' GHC.PlayRisky = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.AnnDecl GHC.GhcPs) where
   pretty' (GHC.HsAnnotation _ (GHC.ValueAnnProvenance name) expr) =
@@ -2474,14 +2497,14 @@ instance Pretty (GHC.AnnDecl GHC.GhcPs) where
 #endif
 instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
   pretty' (GHC.RoleAnnotDecl _ name roles) =
-    spaced $
-    [string "type role", pretty name] ++
-    fmap (maybe (string "_") pretty . GHC.unLoc) roles
+    spaced
+      $ [string "type role", pretty name]
+          ++ fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
 instance Pretty GHC.Role where
-  pretty' GHC.Nominal          = string "nominal"
+  pretty' GHC.Nominal = string "nominal"
   pretty' GHC.Representational = string "representational"
-  pretty' GHC.Phantom          = string "phantom"
+  pretty' GHC.Phantom = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2541,8 +2564,8 @@ instance Pretty GHC.InlinePragma where
     pretty inl_inline
     case inl_act of
       GHC.ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      GHC.ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                    -> pure ()
+      GHC.ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
 instance Pretty GHC.InlineSpec where
   pretty' = prettyInlineSpec
@@ -2558,25 +2581,25 @@ prettyInlineSpec GHC.NoUserInlinePrag =
 prettyInlineSpec GHC.Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
-  pretty' GHC.Unidirectional           = string "<-"
-  pretty' GHC.ImplicitBidirectional    = string "="
+  pretty' GHC.Unidirectional = string "<-"
+  pretty' GHC.ImplicitBidirectional = string "="
   pretty' GHC.ExplicitBidirectional {} = string "<-"
 
 instance Pretty (GHC.HsOverLit GHC.GhcPs) where
   pretty' GHC.OverLit {..} = pretty ol_val
 
 instance Pretty GHC.OverLitVal where
-  pretty' (GHC.HsIntegral x)   = pretty x
+  pretty' (GHC.HsIntegral x) = pretty x
   pretty' (GHC.HsFractional x) = pretty x
   pretty' (GHC.HsIsString _ x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = output s
-  pretty' GHC.IL {..}                         = string $ show il_value
+  pretty' GHC.IL {..} = string $ show il_value
 #else
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = string s
-  pretty' GHC.IL {..}                         = string $ show il_value
+  pretty' GHC.IL {..} = string $ show il_value
 #endif
 instance Pretty GHC.FractionalLit where
   pretty' = output
@@ -2595,7 +2618,7 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
   pretty' GHC.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      GHC.HsString {}     -> prettyString
+      GHC.HsString {} -> prettyString
       GHC.HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2606,8 +2629,9 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1) $
-                lined $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1)
+                $ lined
+                $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsPragE GHC.GhcPs) where
   pretty' (GHC.HsPragSCC _ x) =
@@ -2621,13 +2645,13 @@ instance Pretty GHC.HsIPName where
   pretty' (GHC.HsIPName x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsTyLit GHC.GhcPs) where
-  pretty' (GHC.HsNumTy _ x)  = string $ show x
-  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
+  pretty' (GHC.HsNumTy _ x) = string $ show x
+  pretty' (GHC.HsStrTy _ x) = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #else
 instance Pretty GHC.HsTyLit where
-  pretty' (GHC.HsNumTy _ x)  = string $ show x
-  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
+  pretty' (GHC.HsNumTy _ x) = string $ show x
+  pretty' (GHC.HsStrTy _ x) = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (GHC.HsPatSigType GHC.GhcPs) where
@@ -2649,10 +2673,10 @@ prettyIPBind (GHC.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (GHC.DerivStrategy GHC.GhcPs) where
-  pretty' GHC.StockStrategy {}    = string "stock"
+  pretty' GHC.StockStrategy {} = string "stock"
   pretty' GHC.AnyclassStrategy {} = string "anyclass"
-  pretty' GHC.NewtypeStrategy {}  = string "newtype"
-  pretty' (GHC.ViaStrategy x)     = string "via " >> pretty x
+  pretty' GHC.NewtypeStrategy {} = string "newtype"
+  pretty' (GHC.ViaStrategy x) = string "via " >> pretty x
 
 instance Pretty GHC.XViaStrategyPs where
   pretty' (GHC.XViaStrategyPs _ ty) = pretty ty
@@ -2720,9 +2744,12 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets $
-        spaced
-          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
+        brackets
+          $ spaced
+              [ pretty listCompLhs
+              , string "|"
+              , hCommaSep $ fmap pretty listCompRhs
+              ]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2740,7 +2767,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do  = string "do"
+  pretty' Do = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2760,10 +2787,10 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty GHC.CCallConv where
-  pretty' GHC.CCallConv          = string "ccall"
-  pretty' GHC.CApiConv           = string "capi"
-  pretty' GHC.StdCallConv        = string "stdcall"
-  pretty' GHC.PrimCallConv       = string "prim"
+  pretty' GHC.CCallConv = string "ccall"
+  pretty' GHC.CApiConv = string "capi"
+  pretty' GHC.StdCallConv = string "stdcall"
+  pretty' GHC.PrimCallConv = string "prim"
   pretty' GHC.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
@@ -2773,13 +2800,13 @@ instance Pretty GHC.HsSrcBang where
     pretty strictness
 
 instance Pretty GHC.SrcUnpackedness where
-  pretty' GHC.SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' GHC.SrcUnpack = string "{-# UNPACK #-}"
   pretty' GHC.SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' GHC.NoSrcUnpack = pure ()
 
 instance Pretty GHC.SrcStrictness where
-  pretty' GHC.SrcLazy     = string "~"
-  pretty' GHC.SrcStrict   = string "!"
+  pretty' GHC.SrcLazy = string "~"
+  pretty' GHC.SrcStrict = string "!"
   pretty' GHC.NoSrcStrict = pure ()
 
 instance Pretty (GHC.HsOuterSigTyVarBndrs GHC.GhcPs) where
@@ -2803,8 +2830,11 @@ instance Pretty (GHC.HsUntypedSplice GHC.GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars .
-         indentedWithFixedLevel 0 . sequence_ . printers [] "" . GHC.unpackFS)
+        (wrapWithBars
+           . indentedWithFixedLevel 0
+           . sequence_
+           . printers [] ""
+           . GHC.unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1969,23 +1969,23 @@ instance Pretty FamEqn' where
     pretty feqn_rhs
     where
       prefix =
-        case (famEqnFor, dd_cons feqn_rhs) of
-          (DataFamInstDeclForTopLevel, NewTypeCon {}) -> "newtype instance"
-          (DataFamInstDeclForTopLevel, DataTypeCons {}) -> "data instance"
-          (DataFamInstDeclForInsideClassInst, NewTypeCon {}) -> "newtype"
-          (DataFamInstDeclForInsideClassInst, DataTypeCons {}) -> "data"
+        case (famEqnFor, GHC.dd_cons feqn_rhs) of
+          (DataFamInstDeclForTopLevel, GHC.NewTypeCon {}) -> "newtype instance"
+          (DataFamInstDeclForTopLevel, GHC.DataTypeCons {}) -> "data instance"
+          (DataFamInstDeclForInsideClassInst, GHC.NewTypeCon {}) -> "newtype"
+          (DataFamInstDeclForInsideClassInst, GHC.DataTypeCons {}) -> "data"
 #else
 instance Pretty FamEqn' where
-  pretty' FamEqn' {famEqn = FamEqn {..}, ..} = do
+  pretty' FamEqn' {famEqn = GHC.FamEqn {..}, ..} = do
     spaced $ string prefix : pretty feqn_tycon : fmap pretty feqn_pats
     pretty feqn_rhs
     where
       prefix =
-        case (famEqnFor, dd_ND feqn_rhs) of
-          (DataFamInstDeclForTopLevel, NewType) -> "newtype instance"
-          (DataFamInstDeclForTopLevel, DataType) -> "data instance"
-          (DataFamInstDeclForInsideClassInst, NewType) -> "newtype"
-          (DataFamInstDeclForInsideClassInst, DataType) -> "data"
+        case (famEqnFor, GHC.dd_ND feqn_rhs) of
+          (DataFamInstDeclForTopLevel, GHC.NewType) -> "newtype instance"
+          (DataFamInstDeclForTopLevel, GHC.DataType) -> "data instance"
+          (DataFamInstDeclForInsideClassInst, GHC.NewType) -> "newtype"
+          (DataFamInstDeclForInsideClassInst, GHC.DataType) -> "data"
 #endif
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Pretty printing.
 --
@@ -21,58 +21,58 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
-import           Data.Maybe
-import           Data.Void
-import qualified GHC.Core.Coercion                                   as GHC
-import qualified GHC.Data.Bag                                        as GHC
-import HIndent.Ast.Declaration.TypeSynonym.Lhs
+import Control.Monad
+import Control.Monad.RWS
+import Data.Maybe
+import Data.Void
+import qualified GHC.Core.Coercion as GHC
+import qualified GHC.Data.Bag as GHC
+import qualified GHC.Data.BooleanFormula as GHC
+import qualified GHC.Data.FastString as GHC
+import qualified GHC.Hs as GHC
+import GHC.Stack
+import qualified GHC.Types.Basic as GHC
+import qualified GHC.Types.Fixity as GHC
+import qualified GHC.Types.ForeignCall as GHC
+import qualified GHC.Types.Name as GHC
+import qualified GHC.Types.Name.Reader as GHC
+import qualified GHC.Types.SourceText as GHC
+import qualified GHC.Types.SrcLoc as GHC
+import qualified GHC.Unit.Module.Warnings as GHC
+import HIndent.Applicative
 import qualified HIndent.Ast.Context
-import HIndent.Ast.Declaration.Family.Type.Injectivity
-import HIndent.Ast.Type.Variable
-import HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
-import HIndent.Ast.Type
-import HIndent.Ast.WithComments
-import HIndent.Ast.Declaration.Data.Header
+import HIndent.Ast.Declaration
+import HIndent.Ast.Declaration.Data
 import HIndent.Ast.Declaration.Data.GADT.Constructor
-import qualified GHC.Data.BooleanFormula                             as GHC
-import qualified GHC.Data.FastString                                 as GHC
-import qualified GHC.Hs                                              as GHC
-import           GHC.Stack
-import qualified GHC.Types.Basic                                     as GHC
-import qualified GHC.Types.Fixity                                    as GHC
-import qualified GHC.Types.ForeignCall                               as GHC
-import qualified GHC.Types.Name                                      as GHC
-import qualified GHC.Types.Name.Reader                               as GHC
-import qualified GHC.Types.SourceText                                as GHC
-import qualified GHC.Types.SrcLoc                                    as GHC
-import qualified GHC.Unit.Module.Warnings                            as GHC
-import           HIndent.Applicative
-import           HIndent.Ast.Declaration
-import           HIndent.Ast.Declaration.Data
-import           HIndent.Ast.Declaration.Family.Data
-import           HIndent.Ast.Declaration.Family.Type
-import           HIndent.Ast.Declaration.Family.Type.ResultSignature
-import           HIndent.Ast.Declaration.Instance.Class
-import           HIndent.Ast.Declaration.TypeSynonym
-import           HIndent.Ast.NodeComments
+import HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
+import HIndent.Ast.Declaration.Data.Header
 import HIndent.Ast.Declaration.Data.NewOrData
-import           HIndent.Config
-import           HIndent.Fixity
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
-import qualified HIndent.Pretty.SigBindFamily                        as SBF
-import           HIndent.Pretty.Types
-import           HIndent.Printer
-import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr         as GHC
-import           Text.Show.Unicode
+import HIndent.Ast.Declaration.Family.Data
+import HIndent.Ast.Declaration.Family.Type
+import HIndent.Ast.Declaration.Family.Type.Injectivity
+import HIndent.Ast.Declaration.Family.Type.ResultSignature
+import HIndent.Ast.Declaration.Instance.Class
+import HIndent.Ast.Declaration.TypeSynonym
+import HIndent.Ast.Declaration.TypeSynonym.Lhs
+import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.Type.Variable
+import HIndent.Ast.WithComments
+import HIndent.Config
+import HIndent.Fixity
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+import qualified HIndent.Pretty.SigBindFamily as SBF
+import HIndent.Pretty.Types
+import HIndent.Printer
+import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr as GHC
+import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable                                       as NonEmpty
-import qualified GHC.Core.DataCon                                    as GHC
+import qualified Data.Foldable as NonEmpty
+import qualified GHC.Core.DataCon as GHC
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified GHC.Unit                                            as GHC
+import qualified GHC.Unit as GHC
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -109,8 +109,10 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -139,24 +141,24 @@ class CommentExtraction a =>
   pretty' :: a -> Printer ()
 
 instance Pretty Declaration where
-  pretty' (HIndent.Ast.Declaration.DataFamily x)  = pretty x
-  pretty' (HIndent.Ast.Declaration.TypeFamily x)  = pretty x
-  pretty' (DataDeclaration x)                     = pretty x
+  pretty' (HIndent.Ast.Declaration.DataFamily x) = pretty x
+  pretty' (HIndent.Ast.Declaration.TypeFamily x) = pretty x
+  pretty' (DataDeclaration x) = pretty x
   pretty' (HIndent.Ast.Declaration.TypeSynonym x) = pretty x
-  pretty' (TyClDecl x)                            = pretty x
-  pretty' (HIndent.Ast.Declaration.ClassInstance x)                       = pretty x
-  pretty' (InstDecl x)                            = pretty x
-  pretty' (DerivDecl x)                           = pretty x
-  pretty' (ValDecl x)                             = pretty x
-  pretty' (SigDecl x)                             = pretty x
-  pretty' (KindSigDecl x)                         = pretty x
-  pretty' (DefDecl x)                             = pretty x
-  pretty' (ForDecl x)                             = pretty x
-  pretty' (WarningDecl x)                         = pretty x
-  pretty' (AnnDecl x)                             = pretty x
-  pretty' (RuleDecl x)                            = pretty x
-  pretty' (SpliceDecl x)                          = pretty x
-  pretty' (RoleAnnotDecl x)                       = pretty x
+  pretty' (TyClDecl x) = pretty x
+  pretty' (HIndent.Ast.Declaration.ClassInstance x) = pretty x
+  pretty' (InstDecl x) = pretty x
+  pretty' (DerivDecl x) = pretty x
+  pretty' (ValDecl x) = pretty x
+  pretty' (SigDecl x) = pretty x
+  pretty' (KindSigDecl x) = pretty x
+  pretty' (DefDecl x) = pretty x
+  pretty' (ForDecl x) = pretty x
+  pretty' (WarningDecl x) = pretty x
+  pretty' (AnnDecl x) = pretty x
+  pretty' (RuleDecl x) = pretty x
+  pretty' (SpliceDecl x) = pretty x
+  pretty' (RoleAnnotDecl x) = pretty x
 
 instance Pretty DataDeclaration where
   pretty' GADT {..} = do
@@ -203,9 +205,9 @@ instance Pretty TypeFamily where
     string name
     spacePrefixed $ fmap pretty typeVariables
     case getNode signature of
-      ResultSignature GHC.NoSig {}    -> pure ()
+      ResultSignature GHC.NoSig {} -> pure ()
       ResultSignature GHC.TyVarSig {} -> string " = " >> pretty signature
-      _                               -> space >> pretty signature
+      _ -> space >> pretty signature
     whenJust injectivity $ \x -> string " | " >> pretty x
     whenJust equations $ \xs ->
       string " where" >> newline >> indentedBlock (lined $ fmap pretty xs)
@@ -216,8 +218,8 @@ instance Pretty ClassInstance where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -264,25 +266,28 @@ instance Pretty GADTConstructor where
       ver = newline >> indentedBlock (string ":: " |=> body)
       body =
         case (forallNeeded, con_mb_cxt) of
-          (True, Just ctx)  -> withForallCtx ctx
-          (True, Nothing)   -> withForallOnly
+          (True, Just ctx) -> withForallCtx ctx
+          (True, Nothing) -> withForallOnly
           (False, Just ctx) -> withCtxOnly ctx
-          (False, Nothing)  -> noForallCtx
+          (False, Nothing) -> noForallCtx
       withForallCtx ctx = do
         pretty bindings
-        (space >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)) <-|>
-          (newline >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
+        (space >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
+          <-|> (newline
+                  >> pretty
+                       (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
         newline
         prefixed "=> " $ prettyVertically signature
       withForallOnly = do
         pretty bindings
-        (space >> prettyHorizontally signature) <-|>
-          (newline >> prettyVertically signature)
+        (space >> prettyHorizontally signature)
+          <-|> (newline >> prettyVertically signature)
       withCtxOnly ctx =
-        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx) >> string " => " >>
-         prettyHorizontally signature) <-|>
-        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx) >>
-         prefixed "=> " (prettyVertically signature))
+        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)
+           >> string " => "
+           >> prettyHorizontally signature)
+          <-|> (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)
+                  >> prefixed "=> " (prettyVertically signature))
       noForallCtx = prettyHorizontally signature <-|> prettyVertically signature
 
 instance Pretty Header where
@@ -321,8 +326,10 @@ printCommentOnSameLine' (commentsOnSameLine -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine' _ = return ()
@@ -364,16 +371,16 @@ instance Pretty HIndent.Ast.Context.Context where
           parensConditional =
             case xs of
               [_] -> id
-              _   -> parens
+              _ -> parens
       ver =
         case xs of
-          []  -> string "()"
+          [] -> string "()"
           [x] -> pretty x
-          _   -> vTuple $ fmap pretty xs
+          _ -> vTuple $ fmap pretty xs
 
 instance Pretty NewOrData where
   pretty' Newtype = string "newtype"
-  pretty' Data    = string "data"
+  pretty' Data = string "data"
 
 -- Do nothing if there are no pragmas, module headers, imports, or
 -- declarations. Otherwise, extra blank lines will be inserted if only
@@ -383,19 +390,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GHC.GenLocated l e) where
   pretty' (GHC.L _ e) = pretty e
 
 instance Pretty (GHC.HsDecl GHC.GhcPs) where
-  pretty' (GHC.TyClD _ d)      = pretty d
-  pretty' (GHC.InstD _ inst)   = pretty inst
-  pretty' (GHC.DerivD _ x)     = pretty x
-  pretty' (GHC.ValD _ bind)    = pretty bind
-  pretty' (GHC.SigD _ s)       = pretty s
-  pretty' (GHC.KindSigD _ x)   = pretty x
-  pretty' (GHC.DefD _ x)       = pretty x
-  pretty' (GHC.ForD _ x)       = pretty x
-  pretty' (GHC.WarningD _ x)   = pretty x
-  pretty' (GHC.AnnD _ x)       = pretty x
-  pretty' (GHC.RuleD _ x)      = pretty x
-  pretty' (GHC.SpliceD _ sp)   = pretty sp
-  pretty' GHC.DocD {}          = docNode
+  pretty' (GHC.TyClD _ d) = pretty d
+  pretty' (GHC.InstD _ inst) = pretty inst
+  pretty' (GHC.DerivD _ x) = pretty x
+  pretty' (GHC.ValD _ bind) = pretty bind
+  pretty' (GHC.SigD _ s) = pretty s
+  pretty' (GHC.KindSigD _ x) = pretty x
+  pretty' (GHC.DefD _ x) = pretty x
+  pretty' (GHC.ForD _ x) = pretty x
+  pretty' (GHC.WarningD _ x) = pretty x
+  pretty' (GHC.AnnD _ x) = pretty x
+  pretty' (GHC.RuleD _ x) = pretty x
+  pretty' (GHC.SpliceD _ sp) = pretty sp
+  pretty' GHC.DocD {} = docNode
   pretty' (GHC.RoleAnnotD _ x) = pretty x
 
 instance Pretty (GHC.TyClDecl GHC.GhcPs) where
@@ -434,7 +441,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_cons tcdDataDefn of
         GHC.DataTypeCons {} -> string "data "
-        GHC.NewTypeCon {}   -> string "newtype "
+        GHC.NewTypeCon {} -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -449,7 +456,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType  -> string "newtype "
+        GHC.NewType -> string "newtype "
 #else
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -464,7 +471,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType  -> string "newtype "
+        GHC.NewType -> string "newtype "
 #endif
 prettyTyClDecl GHC.ClassDecl {..} = do
   if isJust tcdCtxt
@@ -485,20 +492,21 @@ prettyTyClDecl GHC.ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            []  -> string "()"
+            [] -> string "()"
             [x] -> pretty x
-            xs  -> hvTuple $ fmap pretty xs
+            xs -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock $
-          string "| " |=>
-          vCommaSep
-            (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
-               printCommentsAnd x $ \(GHC.FunDep _ from to) ->
-                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock
+          $ string "| "
+              |=> vCommaSep
+                    (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
+                       printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                         spaced
+                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -509,27 +517,32 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         GHC.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens $
-                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens
+                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
-      SBF.mkSortedLSigBindFamilyList tcdSigs (GHC.bagToList tcdMeths) tcdATs [] []
+      SBF.mkSortedLSigBindFamilyList
+        tcdSigs
+        (GHC.bagToList tcdMeths)
+        tcdATs
+        []
+        []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
-  pretty' GHC.ClsInstD {..}     = pretty cid_inst
+  pretty' GHC.ClsInstD {..} = pretty cid_inst
   pretty' GHC.DataFamInstD {..} = pretty dfid_inst
-  pretty' GHC.TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' GHC.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (GHC.HsBind GHC.GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: GHC.HsBind GHC.GhcPs -> Printer ()
-prettyHsBind GHC.FunBind {..}     = pretty fun_matches
-prettyHsBind GHC.PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind GHC.VarBind {}       = notGeneratedByParser
+prettyHsBind GHC.FunBind {..} = pretty fun_matches
+prettyHsBind GHC.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind GHC.AbsBinds {}      = notGeneratedByParser
+prettyHsBind GHC.AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (GHC.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -546,13 +559,14 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=>
-               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space
+                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -572,9 +586,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -614,13 +628,14 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space |=>
-               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space
+                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -640,9 +655,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' GHC.IdSig {} = notGeneratedByParser
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
@@ -701,12 +716,12 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
     where
       cons =
         case dd_cons of
-          GHC.NewTypeCon x      -> [x]
+          GHC.NewTypeCon x -> [x]
           GHC.DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (GHC.DataTypeCons _ (GHC.L _ GHC.ConDeclGADT {}:_)) -> True
-          _                                                   -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -742,7 +757,7 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
       isGADT =
         case dd_cons of
           (GHC.L _ GHC.ConDeclGADT {}:_) -> True
-          _                              -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -753,8 +768,8 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -808,17 +823,18 @@ prettyHsExpr (GHC.HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              []         -> error "Invalid function application."
+              [] -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col' - col -
-            if col == 0
-              then spaces
-              else 0
+            col'
+              - col
+              - if col == 0
+                  then spaces
+                  else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -857,11 +873,11 @@ prettyHsExpr (GHC.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens $
-      prefixedLined "," $
-      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens
+        $ prefixedLined ","
+        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing GHC.Missing {} = True
-    isMissing _              = False
+    isMissing _ = False
 prettyHsExpr (GHC.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -897,8 +913,8 @@ prettyHsExpr (GHC.HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (GHC.HsMultiIf _ guards) =
-  string "if " |=>
-  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if "
+    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (GHC.HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -962,9 +978,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsFieldBind a b)]
@@ -992,9 +1008,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsRecField' a b)]
@@ -1021,10 +1037,11 @@ prettyHsExpr (GHC.HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr GHC.HsProjection {..} =
-  parens $
-  forM_ proj_flds $ \x -> do
-    string "."
-    pretty x
+  parens
+    $ forM_ proj_flds
+    $ \x -> do
+        string "."
+        pretty x
 prettyHsExpr (GHC.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -1036,8 +1053,8 @@ prettyHsExpr (GHC.HsSpliceE _ x) = pretty x
 prettyHsExpr (GHC.HsProc _ pat x@(GHC.L _ (GHC.HsCmdTop _ (GHC.L _ (GHC.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock $
-    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock
+    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (GHC.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -1071,7 +1088,7 @@ prettyHsExpr (GHC.HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case  -> string "\\case"
+      Case -> string "\\case"
       Cases -> string "\\cases"
     if null $ GHC.unLoc $ GHC.mg_alts matches
       then string " {}"
@@ -1098,10 +1115,12 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do hor <-|> ver
-                     newline
-                     prefixed "=> " $
-                       prefixedLined "-> " $ pretty <$> flatten hst_body
+               in do
+                    hor <-|> ver
+                    newline
+                    prefixed "=> "
+                      $ prefixedLined "-> "
+                      $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -1111,7 +1130,7 @@ instance Pretty HsSigType' where
     where
       flatten :: GHC.LHsType GHC.GhcPs -> [GHC.LHsType GHC.GhcPs]
       flatten (GHC.L _ (GHC.HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x                               = [x]
+      flatten x = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig GHC.HsSig {..}) =
     case sig_bndrs of
       GHC.HsOuterExplicit _ xs -> do
@@ -1120,8 +1139,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           GHC.HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
-              (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt))
+              <-|> (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -1151,10 +1170,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -1165,20 +1184,20 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
@@ -1197,10 +1216,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -1211,52 +1230,52 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
-
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt)) <-|>
-        (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt))
+        <-|> (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
-      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
+        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-
+    
     forallNeeded =
       case GHC.unLoc con_bndrs of
         GHC.HsOuterImplicit {} -> False
@@ -1264,26 +1283,30 @@ prettyConDecl GHC.ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \c -> do
-        pretty $ Context c
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \c -> do
+             pretty $ Context c
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #else
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \_ -> do
-        pretty $ Context con_mb_cxt
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \_ -> do
+             pretty $ Context con_mb_cxt
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #endif
 prettyConDecl GHC.ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1302,11 +1325,11 @@ instance Pretty
 prettyMatchExpr :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Printer ()
 prettyMatchExpr GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case GHC.unLoc $ head m_pats of
-      GHC.LazyPat {} -> space
-      GHC.BangPat {} -> space
-      _              -> return ()
+  unless (null m_pats)
+    $ case GHC.unLoc $ head m_pats of
+        GHC.LazyPat {} -> space
+        GHC.BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr GHC.Match {m_ctxt = GHC.CaseAlt, ..} = do
@@ -1326,8 +1349,9 @@ prettyMatchExpr GHC.Match {..} =
     GHC.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
-          spaced $
-            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
+          spaced
+            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
+                ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1340,11 +1364,11 @@ instance Pretty
 prettyMatchProc :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Printer ()
 prettyMatchProc GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case GHC.unLoc $ head m_pats of
-      GHC.LazyPat {} -> space
-      GHC.BangPat {} -> space
-      _              -> return ()
+  unless (null m_pats)
+    $ case GHC.unLoc $ head m_pats of
+        GHC.LazyPat {} -> space
+        GHC.BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc GHC.Match {m_ctxt = GHC.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1415,7 +1439,7 @@ instance Pretty
     where
       horizontal =
         case rec_dotdot of
-          Just _  -> braces $ string ".."
+          Just _ -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1427,8 +1451,8 @@ instance Pretty
   pretty' GHC.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (GHC.HsType GHC.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1535,7 +1559,7 @@ prettyHsType (GHC.HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (GHC.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _  -> hvPromotedList $ fmap pretty xs
+    _ -> hvPromotedList $ fmap pretty xs
 prettyHsType (GHC.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (GHC.HsTyLit _ x) = pretty x
 prettyHsType GHC.HsWildCardTy {} = string "_"
@@ -1556,11 +1580,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (GHC.HsValBinds epa lr, _) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty
@@ -1571,11 +1595,11 @@ instance Pretty
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (GHC.HsValBinds epa lr) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (GHC.HsMatchContext GHC.GhcPs) where
@@ -1710,8 +1734,11 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
   pretty' (GHC.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars $
-        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ GHC.unpackFS r
+      wrapWithBars
+        $ indentedWithFixedLevel 0
+        $ sequence_
+        $ printers [] ""
+        $ GHC.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1775,13 +1802,13 @@ prettyPat (GHC.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat GHC.HsRecFields {..}) =
     case fieldPrinters of
-      []  -> string "{}"
+      [] -> string "{}"
       [x] -> braces x
-      xs  -> hvFields xs
+      xs -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1797,10 +1824,10 @@ instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SBF.SigBindFamily where
-  pretty' (SBF.Sig x)         = pretty x
-  pretty' (SBF.Bind x)        = pretty x
-  pretty' (SBF.TypeFamily x)  = pretty x
-  pretty' (SBF.TyFamInst x)   = pretty x
+  pretty' (SBF.Sig x) = pretty x
+  pretty' (SBF.Bind x) = pretty x
+  pretty' (SBF.TypeFamily x) = pretty x
+  pretty' (SBF.TyFamInst x) = pretty x
   pretty' (SBF.DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty GHC.EpaComment where
@@ -1822,7 +1849,7 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where
   pretty' (GHC.Present _ e) = pretty e
-  pretty' GHC.Missing {}    = pure () -- This appears in a tuple section.
+  pretty' GHC.Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField GHC.HsFieldBind {..}) = do
@@ -1927,7 +1954,7 @@ instance Pretty (GHC.ConDeclField GHC.GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (GHC.L _ (GHC.HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x)                            = pretty' x
+  pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1988,9 +2015,9 @@ instance Pretty InfixApp where
       GHC.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (GHC.BooleanFormula a) where
-  pretty' (GHC.Var x)    = pretty x
-  pretty' (GHC.And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (GHC.Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Var x) = pretty x
+  pretty' (GHC.And xs) = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Or xs) = hvBarSep $ fmap pretty xs
   pretty' (GHC.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
@@ -1998,7 +2025,7 @@ instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
 
 instance Pretty (GHC.AmbiguousFieldOcc GHC.GhcPs) where
   pretty' (GHC.Unambiguous _ name) = pretty name
-  pretty' (GHC.Ambiguous _ name)   = pretty name
+  pretty' (GHC.Ambiguous _ name) = pretty name
 
 instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
   pretty' GHC.HsDerivingClause { deriv_clause_strategy = Just strategy@(GHC.L _ GHC.ViaStrategy {})
@@ -2014,14 +2041,14 @@ instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
 
 instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
   pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
-  pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
+  pretty' (GHC.DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty GHC.OverlapMode where
-  pretty' GHC.NoOverlap {}    = notUsedInParsedStage
+  pretty' GHC.NoOverlap {} = notUsedInParsedStage
   pretty' GHC.Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' GHC.Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
+  pretty' GHC.Overlapping {} = string "{-# OVERLAPPING #-}"
+  pretty' GHC.Overlaps {} = string "{-# OVERLAPS #-}"
+  pretty' GHC.Incoherent {} = string "{-# INCOHERENT #-}"
 
 instance Pretty GHC.StringLiteral where
   pretty' = output
@@ -2029,13 +2056,13 @@ instance Pretty GHC.StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
   pretty' GHC.FamilyDecl {..} = do
-    string $
-      case fdInfo of
-        GHC.DataFamily          -> "data"
-        GHC.OpenTypeFamily      -> "type"
-        GHC.ClosedTypeFamily {} -> "type"
+    string
+      $ case fdInfo of
+          GHC.DataFamily -> "data"
+          GHC.OpenTypeFamily -> "type"
+          GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      GHC.TopLevel    -> string " family "
+      GHC.TopLevel -> string " family "
       GHC.NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
@@ -2058,8 +2085,8 @@ instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
       _ -> pure ()
 
 instance Pretty (GHC.FamilyResultSig GHC.GhcPs) where
-  pretty' GHC.NoSig {}       = pure ()
-  pretty' (GHC.KindSig _ x)  = string ":: " >> pretty x
+  pretty' GHC.NoSig {} = pure ()
+  pretty' (GHC.KindSig _ x) = string ":: " >> pretty x
   pretty' (GHC.TyVarSig _ x) = pretty x
 
 instance Pretty (GHC.HsTyVarBndr a GHC.GhcPs) where
@@ -2078,8 +2105,8 @@ instance Pretty (GHC.ArithSeqInfo GHC.GhcPs) where
   pretty' (GHC.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (GHC.FromThenTo from next to) =
-    brackets $
-    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets
+      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
   pretty' GHC.HsForAllVis {..} = do
@@ -2125,9 +2152,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (GHC.L _ [])  -> parens
+          (GHC.L _ []) -> parens
           (GHC.L _ [_]) -> id
-          _             -> parens
+          _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(GHC.L _ [])) =
@@ -2142,10 +2169,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing            -> id
-          Just (GHC.L _ [])  -> parens
+          Nothing -> id
+          Just (GHC.L _ []) -> parens
           Just (GHC.L _ [_]) -> id
-          Just _             -> parens
+          Just _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -2231,17 +2258,17 @@ instance Pretty
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x)    = pretty x
+  pretty' (GHC.HsValArg x) = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
+  pretty' GHC.HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
            (GHC.HsArg
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x)    = pretty x
+  pretty' (GHC.HsValArg x) = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
+  pretty' GHC.HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsQuote GHC.GhcPs) where
@@ -2266,7 +2293,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2280,7 +2307,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2298,15 +2325,15 @@ instance Pretty (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.GhcPs) where
-  pretty' (GHC.IEName _ name)    = pretty name
+  pretty' (GHC.IEName _ name) = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
+  pretty' (GHC.IEType _ name) = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.RdrName) where
-  pretty' (GHC.IEName name)      = pretty name
+  pretty' (GHC.IEName name) = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
+  pretty' (GHC.IEType _ name) = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.DotFieldOcc GHC.GhcPs) where
@@ -2459,9 +2486,9 @@ instance Pretty GHC.CExportSpec where
   pretty' (GHC.CExportStatic _ _ x) = pretty x
 
 instance Pretty GHC.Safety where
-  pretty' GHC.PlaySafe          = string "safe"
+  pretty' GHC.PlaySafe = string "safe"
   pretty' GHC.PlayInterruptible = string "interruptible"
-  pretty' GHC.PlayRisky         = string "unsafe"
+  pretty' GHC.PlayRisky = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.AnnDecl GHC.GhcPs) where
   pretty' (GHC.HsAnnotation _ (GHC.ValueAnnProvenance name) expr) =
@@ -2481,14 +2508,14 @@ instance Pretty (GHC.AnnDecl GHC.GhcPs) where
 #endif
 instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
   pretty' (GHC.RoleAnnotDecl _ name roles) =
-    spaced $
-    [string "type role", pretty name] ++
-    fmap (maybe (string "_") pretty . GHC.unLoc) roles
+    spaced
+      $ [string "type role", pretty name]
+          ++ fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
 instance Pretty GHC.Role where
-  pretty' GHC.Nominal          = string "nominal"
+  pretty' GHC.Nominal = string "nominal"
   pretty' GHC.Representational = string "representational"
-  pretty' GHC.Phantom          = string "phantom"
+  pretty' GHC.Phantom = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2548,8 +2575,8 @@ instance Pretty GHC.InlinePragma where
     pretty inl_inline
     case inl_act of
       GHC.ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      GHC.ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                    -> pure ()
+      GHC.ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
 instance Pretty GHC.InlineSpec where
   pretty' = prettyInlineSpec
@@ -2565,25 +2592,25 @@ prettyInlineSpec GHC.NoUserInlinePrag =
 prettyInlineSpec GHC.Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
-  pretty' GHC.Unidirectional           = string "<-"
-  pretty' GHC.ImplicitBidirectional    = string "="
+  pretty' GHC.Unidirectional = string "<-"
+  pretty' GHC.ImplicitBidirectional = string "="
   pretty' GHC.ExplicitBidirectional {} = string "<-"
 
 instance Pretty (GHC.HsOverLit GHC.GhcPs) where
   pretty' GHC.OverLit {..} = pretty ol_val
 
 instance Pretty GHC.OverLitVal where
-  pretty' (GHC.HsIntegral x)   = pretty x
+  pretty' (GHC.HsIntegral x) = pretty x
   pretty' (GHC.HsFractional x) = pretty x
   pretty' (GHC.HsIsString _ x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = output s
-  pretty' GHC.IL {..}                         = string $ show il_value
+  pretty' GHC.IL {..} = string $ show il_value
 #else
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = string s
-  pretty' GHC.IL {..}                         = string $ show il_value
+  pretty' GHC.IL {..} = string $ show il_value
 #endif
 instance Pretty GHC.FractionalLit where
   pretty' = output
@@ -2602,7 +2629,7 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
   pretty' GHC.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      GHC.HsString {}     -> prettyString
+      GHC.HsString {} -> prettyString
       GHC.HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2613,8 +2640,9 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1) $
-                lined $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1)
+                $ lined
+                $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsPragE GHC.GhcPs) where
   pretty' (GHC.HsPragSCC _ x) =
@@ -2628,13 +2656,13 @@ instance Pretty GHC.HsIPName where
   pretty' (GHC.HsIPName x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsTyLit GHC.GhcPs) where
-  pretty' (GHC.HsNumTy _ x)  = string $ show x
-  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
+  pretty' (GHC.HsNumTy _ x) = string $ show x
+  pretty' (GHC.HsStrTy _ x) = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #else
 instance Pretty GHC.HsTyLit where
-  pretty' (GHC.HsNumTy _ x)  = string $ show x
-  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
+  pretty' (GHC.HsNumTy _ x) = string $ show x
+  pretty' (GHC.HsStrTy _ x) = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (GHC.HsPatSigType GHC.GhcPs) where
@@ -2656,10 +2684,10 @@ prettyIPBind (GHC.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (GHC.DerivStrategy GHC.GhcPs) where
-  pretty' GHC.StockStrategy {}    = string "stock"
+  pretty' GHC.StockStrategy {} = string "stock"
   pretty' GHC.AnyclassStrategy {} = string "anyclass"
-  pretty' GHC.NewtypeStrategy {}  = string "newtype"
-  pretty' (GHC.ViaStrategy x)     = string "via " >> pretty x
+  pretty' GHC.NewtypeStrategy {} = string "newtype"
+  pretty' (GHC.ViaStrategy x) = string "via " >> pretty x
 
 instance Pretty GHC.XViaStrategyPs where
   pretty' (GHC.XViaStrategyPs _ ty) = pretty ty
@@ -2727,9 +2755,12 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets $
-        spaced
-          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
+        brackets
+          $ spaced
+              [ pretty listCompLhs
+              , string "|"
+              , hCommaSep $ fmap pretty listCompRhs
+              ]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2747,7 +2778,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do  = string "do"
+  pretty' Do = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2767,10 +2798,10 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty GHC.CCallConv where
-  pretty' GHC.CCallConv          = string "ccall"
-  pretty' GHC.CApiConv           = string "capi"
-  pretty' GHC.StdCallConv        = string "stdcall"
-  pretty' GHC.PrimCallConv       = string "prim"
+  pretty' GHC.CCallConv = string "ccall"
+  pretty' GHC.CApiConv = string "capi"
+  pretty' GHC.StdCallConv = string "stdcall"
+  pretty' GHC.PrimCallConv = string "prim"
   pretty' GHC.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
@@ -2780,13 +2811,13 @@ instance Pretty GHC.HsSrcBang where
     pretty strictness
 
 instance Pretty GHC.SrcUnpackedness where
-  pretty' GHC.SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' GHC.SrcUnpack = string "{-# UNPACK #-}"
   pretty' GHC.SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' GHC.NoSrcUnpack = pure ()
 
 instance Pretty GHC.SrcStrictness where
-  pretty' GHC.SrcLazy     = string "~"
-  pretty' GHC.SrcStrict   = string "!"
+  pretty' GHC.SrcLazy = string "~"
+  pretty' GHC.SrcStrict = string "!"
   pretty' GHC.NoSrcStrict = pure ()
 
 instance Pretty (GHC.HsOuterSigTyVarBndrs GHC.GhcPs) where
@@ -2810,8 +2841,11 @@ instance Pretty (GHC.HsUntypedSplice GHC.GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars .
-         indentedWithFixedLevel 0 . sequence_ . printers [] "" . GHC.unpackFS)
+        (wrapWithBars
+           . indentedWithFixedLevel 0
+           . sequence_
+           . printers [] ""
+           . GHC.unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -18,7 +18,6 @@
 module HIndent.Pretty
   ( Pretty(..)
   , pretty
-  , printCommentsAnd
   ) where
 
 import Control.Monad

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 -- | Pretty printing.
 --
@@ -21,58 +21,58 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import Data.Maybe
-import Data.Void
-import qualified GHC.Core.Coercion as GHC
-import qualified GHC.Data.Bag as GHC
-import qualified GHC.Data.BooleanFormula as GHC
-import qualified GHC.Data.FastString as GHC
-import qualified GHC.Hs as GHC
-import GHC.Stack
-import qualified GHC.Types.Basic as GHC
-import qualified GHC.Types.Fixity as GHC
-import qualified GHC.Types.ForeignCall as GHC
-import qualified GHC.Types.Name as GHC
-import qualified GHC.Types.Name.Reader as GHC
-import qualified GHC.Types.SourceText as GHC
-import qualified GHC.Types.SrcLoc as GHC
-import qualified GHC.Unit.Module.Warnings as GHC
-import HIndent.Applicative
+import           Control.Monad
+import           Control.Monad.RWS
+import           Data.Maybe
+import           Data.Void
+import qualified GHC.Core.Coercion                                       as GHC
+import qualified GHC.Data.Bag                                            as GHC
+import qualified GHC.Data.BooleanFormula                                 as GHC
+import qualified GHC.Data.FastString                                     as GHC
+import qualified GHC.Hs                                                  as GHC
+import           GHC.Stack
+import qualified GHC.Types.Basic                                         as GHC
+import qualified GHC.Types.Fixity                                        as GHC
+import qualified GHC.Types.ForeignCall                                   as GHC
+import qualified GHC.Types.Name                                          as GHC
+import qualified GHC.Types.Name.Reader                                   as GHC
+import qualified GHC.Types.SourceText                                    as GHC
+import qualified GHC.Types.SrcLoc                                        as GHC
+import qualified GHC.Unit.Module.Warnings                                as GHC
+import           HIndent.Applicative
 import qualified HIndent.Ast.Context
-import HIndent.Ast.Declaration
-import HIndent.Ast.Declaration.Data
-import HIndent.Ast.Declaration.Data.GADT.Constructor
-import HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
-import HIndent.Ast.Declaration.Data.Header
-import HIndent.Ast.Declaration.Data.NewOrData
-import HIndent.Ast.Declaration.Family.Data
-import HIndent.Ast.Declaration.Family.Type
-import HIndent.Ast.Declaration.Family.Type.Injectivity
-import HIndent.Ast.Declaration.Family.Type.ResultSignature
-import HIndent.Ast.Declaration.Instance.Class
-import HIndent.Ast.Declaration.TypeSynonym
-import HIndent.Ast.Declaration.TypeSynonym.Lhs
-import HIndent.Ast.NodeComments
-import HIndent.Ast.Type
-import HIndent.Ast.Type.Variable
-import HIndent.Ast.WithComments
-import HIndent.Config
-import HIndent.Fixity
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import qualified HIndent.Pretty.SigBindFamily as SBF
-import HIndent.Pretty.Types
-import HIndent.Printer
-import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr as GHC
-import Text.Show.Unicode
+import           HIndent.Ast.Declaration
+import           HIndent.Ast.Declaration.Data
+import           HIndent.Ast.Declaration.Data.GADT.Constructor
+import           HIndent.Ast.Declaration.Data.GADT.Constructor.Signature
+import           HIndent.Ast.Declaration.Data.Header
+import           HIndent.Ast.Declaration.Data.NewOrData
+import           HIndent.Ast.Declaration.Family.Data
+import           HIndent.Ast.Declaration.Family.Type
+import           HIndent.Ast.Declaration.Family.Type.Injectivity
+import           HIndent.Ast.Declaration.Family.Type.ResultSignature
+import           HIndent.Ast.Declaration.Instance.Class
+import           HIndent.Ast.Declaration.TypeSynonym
+import           HIndent.Ast.Declaration.TypeSynonym.Lhs
+import           HIndent.Ast.NodeComments
+import           HIndent.Ast.Type
+import           HIndent.Ast.Type.Variable
+import           HIndent.Ast.WithComments
+import           HIndent.Config
+import           HIndent.Fixity
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import qualified HIndent.Pretty.SigBindFamily                            as SBF
+import           HIndent.Pretty.Types
+import           HIndent.Printer
+import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr             as GHC
+import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable as NonEmpty
-import qualified GHC.Core.DataCon as GHC
+import qualified Data.Foldable                                           as NonEmpty
+import qualified GHC.Core.DataCon                                        as GHC
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified GHC.Unit as GHC
+import qualified GHC.Unit                                                as GHC
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -109,10 +109,8 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
+         spaced $ fmap pretty $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -141,24 +139,24 @@ class CommentExtraction a =>
   pretty' :: a -> Printer ()
 
 instance Pretty Declaration where
-  pretty' (HIndent.Ast.Declaration.DataFamily x) = pretty x
-  pretty' (HIndent.Ast.Declaration.TypeFamily x) = pretty x
-  pretty' (DataDeclaration x) = pretty x
-  pretty' (HIndent.Ast.Declaration.TypeSynonym x) = pretty x
-  pretty' (TyClDecl x) = pretty x
+  pretty' (HIndent.Ast.Declaration.DataFamily x)    = pretty x
+  pretty' (HIndent.Ast.Declaration.TypeFamily x)    = pretty x
+  pretty' (DataDeclaration x)                       = pretty x
+  pretty' (HIndent.Ast.Declaration.TypeSynonym x)   = pretty x
+  pretty' (TyClDecl x)                              = pretty x
   pretty' (HIndent.Ast.Declaration.ClassInstance x) = pretty x
-  pretty' (InstDecl x) = pretty x
-  pretty' (DerivDecl x) = pretty x
-  pretty' (ValDecl x) = pretty x
-  pretty' (SigDecl x) = pretty x
-  pretty' (KindSigDecl x) = pretty x
-  pretty' (DefDecl x) = pretty x
-  pretty' (ForDecl x) = pretty x
-  pretty' (WarningDecl x) = pretty x
-  pretty' (AnnDecl x) = pretty x
-  pretty' (RuleDecl x) = pretty x
-  pretty' (SpliceDecl x) = pretty x
-  pretty' (RoleAnnotDecl x) = pretty x
+  pretty' (InstDecl x)                              = pretty x
+  pretty' (DerivDecl x)                             = pretty x
+  pretty' (ValDecl x)                               = pretty x
+  pretty' (SigDecl x)                               = pretty x
+  pretty' (KindSigDecl x)                           = pretty x
+  pretty' (DefDecl x)                               = pretty x
+  pretty' (ForDecl x)                               = pretty x
+  pretty' (WarningDecl x)                           = pretty x
+  pretty' (AnnDecl x)                               = pretty x
+  pretty' (RuleDecl x)                              = pretty x
+  pretty' (SpliceDecl x)                            = pretty x
+  pretty' (RoleAnnotDecl x)                         = pretty x
 
 instance Pretty DataDeclaration where
   pretty' GADT {..} = do
@@ -205,9 +203,9 @@ instance Pretty TypeFamily where
     string name
     spacePrefixed $ fmap pretty typeVariables
     case getNode signature of
-      ResultSignature GHC.NoSig {} -> pure ()
+      ResultSignature GHC.NoSig {}    -> pure ()
       ResultSignature GHC.TyVarSig {} -> string " = " >> pretty signature
-      _ -> space >> pretty signature
+      _                               -> space >> pretty signature
     whenJust injectivity $ \x -> string " | " >> pretty x
     whenJust equations $ \xs ->
       string " where" >> newline >> indentedBlock (lined $ fmap pretty xs)
@@ -218,8 +216,8 @@ instance Pretty ClassInstance where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
+        unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -266,28 +264,27 @@ instance Pretty GADTConstructor where
       ver = newline >> indentedBlock (string ":: " |=> body)
       body =
         case (forallNeeded, con_mb_cxt) of
-          (True, Just ctx) -> withForallCtx ctx
-          (True, Nothing) -> withForallOnly
+          (True, Just ctx)  -> withForallCtx ctx
+          (True, Nothing)   -> withForallOnly
           (False, Just ctx) -> withCtxOnly ctx
-          (False, Nothing) -> noForallCtx
+          (False, Nothing)  -> noForallCtx
       withForallCtx ctx = do
         pretty bindings
-        (space >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
-          <-|> (newline
-                  >> pretty
-                       (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
+        (space >> pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)) <-|>
+          (newline >>
+           pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx))
         newline
         prefixed "=> " $ prettyVertically signature
       withForallOnly = do
         pretty bindings
-        (space >> prettyHorizontally signature)
-          <-|> (newline >> prettyVertically signature)
+        (space >> prettyHorizontally signature) <-|>
+          (newline >> prettyVertically signature)
       withCtxOnly ctx =
-        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)
-           >> string " => "
-           >> prettyHorizontally signature)
-          <-|> (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx)
-                  >> prefixed "=> " (prettyVertically signature))
+        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx) >>
+         string " => " >>
+         prettyHorizontally signature) <-|>
+        (pretty (HIndent.Ast.Context.mkContext <$> fromGenLocated ctx) >>
+         prefixed "=> " (prettyVertically signature))
       noForallCtx = prettyHorizontally signature <-|> prettyVertically signature
 
 instance Pretty Header where
@@ -326,10 +323,8 @@ printCommentOnSameLine' (commentsOnSameLine -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
+         spaced $ fmap pretty $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine' _ = return ()
@@ -371,16 +366,16 @@ instance Pretty HIndent.Ast.Context.Context where
           parensConditional =
             case xs of
               [_] -> id
-              _ -> parens
+              _   -> parens
       ver =
         case xs of
-          [] -> string "()"
+          []  -> string "()"
           [x] -> pretty x
-          _ -> vTuple $ fmap pretty xs
+          _   -> vTuple $ fmap pretty xs
 
 instance Pretty NewOrData where
   pretty' Newtype = string "newtype"
-  pretty' Data = string "data"
+  pretty' Data    = string "data"
 
 -- Do nothing if there are no pragmas, module headers, imports, or
 -- declarations. Otherwise, extra blank lines will be inserted if only
@@ -388,22 +383,6 @@ instance Pretty NewOrData where
 -- https://github.com/mihaimaruseac/hindent/issues/586#issuecomment-1374992624.
 instance (CommentExtraction l, Pretty e) => Pretty (GHC.GenLocated l e) where
   pretty' (GHC.L _ e) = pretty e
-
-instance Pretty (GHC.HsDecl GHC.GhcPs) where
-  pretty' (GHC.TyClD _ d) = pretty d
-  pretty' (GHC.InstD _ inst) = pretty inst
-  pretty' (GHC.DerivD _ x) = pretty x
-  pretty' (GHC.ValD _ bind) = pretty bind
-  pretty' (GHC.SigD _ s) = pretty s
-  pretty' (GHC.KindSigD _ x) = pretty x
-  pretty' (GHC.DefD _ x) = pretty x
-  pretty' (GHC.ForD _ x) = pretty x
-  pretty' (GHC.WarningD _ x) = pretty x
-  pretty' (GHC.AnnD _ x) = pretty x
-  pretty' (GHC.RuleD _ x) = pretty x
-  pretty' (GHC.SpliceD _ sp) = pretty sp
-  pretty' GHC.DocD {} = docNode
-  pretty' (GHC.RoleAnnotD _ x) = pretty x
 
 instance Pretty (GHC.TyClDecl GHC.GhcPs) where
   pretty' = prettyTyClDecl
@@ -441,7 +420,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_cons tcdDataDefn of
         GHC.DataTypeCons {} -> string "data "
-        GHC.NewTypeCon {} -> string "newtype "
+        GHC.NewTypeCon {}   -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -456,7 +435,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType -> string "newtype "
+        GHC.NewType  -> string "newtype "
 #else
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -471,7 +450,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType -> string "newtype "
+        GHC.NewType  -> string "newtype "
 #endif
 prettyTyClDecl GHC.ClassDecl {..} = do
   if isJust tcdCtxt
@@ -492,21 +471,20 @@ prettyTyClDecl GHC.ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            [] -> string "()"
+            []  -> string "()"
             [x] -> pretty x
-            xs -> hvTuple $ fmap pretty xs
+            xs  -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock
-          $ string "| "
-              |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
-                       printCommentsAnd x $ \(GHC.FunDep _ from to) ->
-                         spaced
-                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock $
+          string "| " |=>
+          vCommaSep
+            (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
+               printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -517,8 +495,8 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         GHC.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens
-                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens $
+                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
@@ -530,19 +508,19 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
-  pretty' GHC.ClsInstD {..} = pretty cid_inst
+  pretty' GHC.ClsInstD {..}     = pretty cid_inst
   pretty' GHC.DataFamInstD {..} = pretty dfid_inst
-  pretty' GHC.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' GHC.TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (GHC.HsBind GHC.GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: GHC.HsBind GHC.GhcPs -> Printer ()
-prettyHsBind GHC.FunBind {..} = pretty fun_matches
-prettyHsBind GHC.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind GHC.VarBind {} = notGeneratedByParser
+prettyHsBind GHC.FunBind {..}     = pretty fun_matches
+prettyHsBind GHC.PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.VarBind {}       = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind GHC.AbsBinds {} = notGeneratedByParser
+prettyHsBind GHC.AbsBinds {}      = notGeneratedByParser
 #endif
 prettyHsBind (GHC.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -559,14 +537,13 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space
-                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space |=>
+               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -586,9 +563,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -628,14 +605,13 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space
-                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space |=>
+               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -655,9 +631,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' GHC.IdSig {} = notGeneratedByParser
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
@@ -716,12 +692,12 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
     where
       cons =
         case dd_cons of
-          GHC.NewTypeCon x -> [x]
+          GHC.NewTypeCon x      -> [x]
           GHC.DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (GHC.DataTypeCons _ (GHC.L _ GHC.ConDeclGADT {}:_)) -> True
-          _ -> False
+          _                                                   -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -757,7 +733,7 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
       isGADT =
         case dd_cons of
           (GHC.L _ GHC.ConDeclGADT {}:_) -> True
-          _ -> False
+          _                              -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -768,8 +744,8 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
+        unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -823,18 +799,17 @@ prettyHsExpr (GHC.HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              [] -> error "Invalid function application."
+              []         -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col'
-              - col
-              - if col == 0
-                  then spaces
-                  else 0
+            col' - col -
+            if col == 0
+              then spaces
+              else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -873,11 +848,11 @@ prettyHsExpr (GHC.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens
-        $ prefixedLined ","
-        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens $
+      prefixedLined "," $
+      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing GHC.Missing {} = True
-    isMissing _ = False
+    isMissing _              = False
 prettyHsExpr (GHC.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -913,8 +888,8 @@ prettyHsExpr (GHC.HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (GHC.HsMultiIf _ guards) =
-  string "if "
-    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if " |=>
+  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (GHC.HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -978,9 +953,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsFieldBind a b)]
@@ -1008,9 +983,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsRecField' a b)]
@@ -1037,11 +1012,10 @@ prettyHsExpr (GHC.HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr GHC.HsProjection {..} =
-  parens
-    $ forM_ proj_flds
-    $ \x -> do
-        string "."
-        pretty x
+  parens $
+  forM_ proj_flds $ \x -> do
+    string "."
+    pretty x
 prettyHsExpr (GHC.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -1053,8 +1027,8 @@ prettyHsExpr (GHC.HsSpliceE _ x) = pretty x
 prettyHsExpr (GHC.HsProc _ pat x@(GHC.L _ (GHC.HsCmdTop _ (GHC.L _ (GHC.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock
-    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock $
+    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (GHC.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -1088,7 +1062,7 @@ prettyHsExpr (GHC.HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case -> string "\\case"
+      Case  -> string "\\case"
       Cases -> string "\\cases"
     if null $ GHC.unLoc $ GHC.mg_alts matches
       then string " {}"
@@ -1115,12 +1089,10 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do
-                    hor <-|> ver
-                    newline
-                    prefixed "=> "
-                      $ prefixedLined "-> "
-                      $ pretty <$> flatten hst_body
+               in do hor <-|> ver
+                     newline
+                     prefixed "=> " $
+                       prefixedLined "-> " $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -1130,7 +1102,7 @@ instance Pretty HsSigType' where
     where
       flatten :: GHC.LHsType GHC.GhcPs -> [GHC.LHsType GHC.GhcPs]
       flatten (GHC.L _ (GHC.HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x = [x]
+      flatten x                               = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig GHC.HsSig {..}) =
     case sig_bndrs of
       GHC.HsOuterExplicit _ xs -> do
@@ -1139,8 +1111,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           GHC.HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt))
-              <-|> (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
+              (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -1170,10 +1142,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -1184,20 +1156,20 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
@@ -1216,10 +1188,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -1230,52 +1202,52 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt))
-        <-|> (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt)) <-|>
+        (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
-        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-    
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
+      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
+
     forallNeeded =
       case GHC.unLoc con_bndrs of
         GHC.HsOuterImplicit {} -> False
@@ -1283,30 +1255,26 @@ prettyConDecl GHC.ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \c -> do
-             pretty $ Context c
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \c -> do
+        pretty $ Context c
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #else
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \_ -> do
-             pretty $ Context con_mb_cxt
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \_ -> do
+        pretty $ Context con_mb_cxt
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #endif
 prettyConDecl GHC.ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1325,11 +1293,11 @@ instance Pretty
 prettyMatchExpr :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Printer ()
 prettyMatchExpr GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case GHC.unLoc $ head m_pats of
-        GHC.LazyPat {} -> space
-        GHC.BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case GHC.unLoc $ head m_pats of
+      GHC.LazyPat {} -> space
+      GHC.BangPat {} -> space
+      _              -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr GHC.Match {m_ctxt = GHC.CaseAlt, ..} = do
@@ -1349,9 +1317,8 @@ prettyMatchExpr GHC.Match {..} =
     GHC.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
-          spaced
-            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
-                ++ fmap pretty xs
+          spaced $
+            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1364,11 +1331,11 @@ instance Pretty
 prettyMatchProc :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Printer ()
 prettyMatchProc GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case GHC.unLoc $ head m_pats of
-        GHC.LazyPat {} -> space
-        GHC.BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case GHC.unLoc $ head m_pats of
+      GHC.LazyPat {} -> space
+      GHC.BangPat {} -> space
+      _              -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc GHC.Match {m_ctxt = GHC.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1439,7 +1406,7 @@ instance Pretty
     where
       horizontal =
         case rec_dotdot of
-          Just _ -> braces $ string ".."
+          Just _  -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1451,8 +1418,8 @@ instance Pretty
   pretty' GHC.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (GHC.HsType GHC.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1559,7 +1526,7 @@ prettyHsType (GHC.HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (GHC.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hvPromotedList $ fmap pretty xs
+    _  -> hvPromotedList $ fmap pretty xs
 prettyHsType (GHC.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (GHC.HsTyLit _ x) = pretty x
 prettyHsType GHC.HsWildCardTy {} = string "_"
@@ -1580,11 +1547,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (GHC.HsValBinds epa lr, _) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty
@@ -1595,11 +1562,11 @@ instance Pretty
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (GHC.HsValBinds epa lr) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty (GHC.HsMatchContext GHC.GhcPs) where
@@ -1734,11 +1701,8 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
   pretty' (GHC.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars
-        $ indentedWithFixedLevel 0
-        $ sequence_
-        $ printers [] ""
-        $ GHC.unpackFS r
+      wrapWithBars $
+        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ GHC.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1802,20 +1766,23 @@ prettyPat (GHC.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat GHC.HsRecFields {..}) =
     case fieldPrinters of
-      [] -> string "{}"
+      []  -> string "{}"
       [x] -> braces x
-      xs -> hvFields xs
+      xs  -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
   pretty' (GHC.PatBr _ expr) =
     brackets $ string "p" >> wrapWithBars (pretty expr)
   pretty' (GHC.DecBrL _ decls) =
-    brackets $ string "d| " |=> lined (fmap pretty decls) >> string " |"
+    brackets $
+    string "d| " |=>
+    lined (fmap (pretty . fmap mkDeclaration . fromGenLocated) decls) >>
+    string " |"
   pretty' GHC.DecBrG {} = notGeneratedByParser
   pretty' (GHC.TypBr _ expr) =
     brackets $ string "t" >> wrapWithBars (pretty expr)
@@ -1824,10 +1791,10 @@ instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SBF.SigBindFamily where
-  pretty' (SBF.Sig x) = pretty x
-  pretty' (SBF.Bind x) = pretty x
-  pretty' (SBF.TypeFamily x) = pretty x
-  pretty' (SBF.TyFamInst x) = pretty x
+  pretty' (SBF.Sig x)         = pretty x
+  pretty' (SBF.Bind x)        = pretty x
+  pretty' (SBF.TypeFamily x)  = pretty x
+  pretty' (SBF.TyFamInst x)   = pretty x
   pretty' (SBF.DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty GHC.EpaComment where
@@ -1849,7 +1816,7 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where
   pretty' (GHC.Present _ e) = pretty e
-  pretty' GHC.Missing {} = pure () -- This appears in a tuple section.
+  pretty' GHC.Missing {}    = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField GHC.HsFieldBind {..}) = do
@@ -1954,7 +1921,7 @@ instance Pretty (GHC.ConDeclField GHC.GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (GHC.L _ (GHC.HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x) = pretty' x
+  pretty' (InfixExpr x)                            = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -2015,9 +1982,9 @@ instance Pretty InfixApp where
       GHC.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (GHC.BooleanFormula a) where
-  pretty' (GHC.Var x) = pretty x
-  pretty' (GHC.And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (GHC.Or xs) = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Var x)    = pretty x
+  pretty' (GHC.And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Or xs)    = hvBarSep $ fmap pretty xs
   pretty' (GHC.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
@@ -2025,7 +1992,7 @@ instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
 
 instance Pretty (GHC.AmbiguousFieldOcc GHC.GhcPs) where
   pretty' (GHC.Unambiguous _ name) = pretty name
-  pretty' (GHC.Ambiguous _ name) = pretty name
+  pretty' (GHC.Ambiguous _ name)   = pretty name
 
 instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
   pretty' GHC.HsDerivingClause { deriv_clause_strategy = Just strategy@(GHC.L _ GHC.ViaStrategy {})
@@ -2041,14 +2008,14 @@ instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
 
 instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
   pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
-  pretty' (GHC.DctMulti _ ts) = hvTuple $ fmap pretty ts
+  pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
 instance Pretty GHC.OverlapMode where
-  pretty' GHC.NoOverlap {} = notUsedInParsedStage
+  pretty' GHC.NoOverlap {}    = notUsedInParsedStage
   pretty' GHC.Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' GHC.Overlapping {} = string "{-# OVERLAPPING #-}"
-  pretty' GHC.Overlaps {} = string "{-# OVERLAPS #-}"
-  pretty' GHC.Incoherent {} = string "{-# INCOHERENT #-}"
+  pretty' GHC.Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty GHC.StringLiteral where
   pretty' = output
@@ -2056,13 +2023,13 @@ instance Pretty GHC.StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
   pretty' GHC.FamilyDecl {..} = do
-    string
-      $ case fdInfo of
-          GHC.DataFamily -> "data"
-          GHC.OpenTypeFamily -> "type"
-          GHC.ClosedTypeFamily {} -> "type"
+    string $
+      case fdInfo of
+        GHC.DataFamily          -> "data"
+        GHC.OpenTypeFamily      -> "type"
+        GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      GHC.TopLevel -> string " family "
+      GHC.TopLevel    -> string " family "
       GHC.NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
@@ -2085,8 +2052,8 @@ instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
       _ -> pure ()
 
 instance Pretty (GHC.FamilyResultSig GHC.GhcPs) where
-  pretty' GHC.NoSig {} = pure ()
-  pretty' (GHC.KindSig _ x) = string ":: " >> pretty x
+  pretty' GHC.NoSig {}       = pure ()
+  pretty' (GHC.KindSig _ x)  = string ":: " >> pretty x
   pretty' (GHC.TyVarSig _ x) = pretty x
 
 instance Pretty (GHC.HsTyVarBndr a GHC.GhcPs) where
@@ -2105,8 +2072,8 @@ instance Pretty (GHC.ArithSeqInfo GHC.GhcPs) where
   pretty' (GHC.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (GHC.FromThenTo from next to) =
-    brackets
-      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets $
+    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
   pretty' GHC.HsForAllVis {..} = do
@@ -2152,9 +2119,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (GHC.L _ []) -> parens
+          (GHC.L _ [])  -> parens
           (GHC.L _ [_]) -> id
-          _ -> parens
+          _             -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(GHC.L _ [])) =
@@ -2169,10 +2136,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing -> id
-          Just (GHC.L _ []) -> parens
+          Nothing            -> id
+          Just (GHC.L _ [])  -> parens
           Just (GHC.L _ [_]) -> id
-          Just _ -> parens
+          Just _             -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -2258,17 +2225,17 @@ instance Pretty
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x) = pretty x
+  pretty' (GHC.HsValArg x)    = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
 #else
 instance Pretty
            (GHC.HsArg
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x) = pretty x
+  pretty' (GHC.HsValArg x)    = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsQuote GHC.GhcPs) where
@@ -2293,7 +2260,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2307,7 +2274,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2325,15 +2292,15 @@ instance Pretty (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.GhcPs) where
-  pretty' (GHC.IEName _ name) = pretty name
+  pretty' (GHC.IEName _ name)    = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name) = string "type " >> pretty name
+  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.RdrName) where
-  pretty' (GHC.IEName name) = pretty name
+  pretty' (GHC.IEName name)      = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name) = string "type " >> pretty name
+  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.DotFieldOcc GHC.GhcPs) where
@@ -2486,9 +2453,9 @@ instance Pretty GHC.CExportSpec where
   pretty' (GHC.CExportStatic _ _ x) = pretty x
 
 instance Pretty GHC.Safety where
-  pretty' GHC.PlaySafe = string "safe"
+  pretty' GHC.PlaySafe          = string "safe"
   pretty' GHC.PlayInterruptible = string "interruptible"
-  pretty' GHC.PlayRisky = string "unsafe"
+  pretty' GHC.PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.AnnDecl GHC.GhcPs) where
   pretty' (GHC.HsAnnotation _ (GHC.ValueAnnProvenance name) expr) =
@@ -2508,14 +2475,14 @@ instance Pretty (GHC.AnnDecl GHC.GhcPs) where
 #endif
 instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
   pretty' (GHC.RoleAnnotDecl _ name roles) =
-    spaced
-      $ [string "type role", pretty name]
-          ++ fmap (maybe (string "_") pretty . GHC.unLoc) roles
+    spaced $
+    [string "type role", pretty name] ++
+    fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
 instance Pretty GHC.Role where
-  pretty' GHC.Nominal = string "nominal"
+  pretty' GHC.Nominal          = string "nominal"
   pretty' GHC.Representational = string "representational"
-  pretty' GHC.Phantom = string "phantom"
+  pretty' GHC.Phantom          = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2575,8 +2542,8 @@ instance Pretty GHC.InlinePragma where
     pretty inl_inline
     case inl_act of
       GHC.ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      GHC.ActiveAfter _ x -> space >> brackets (string $ show x)
-      _ -> pure ()
+      GHC.ActiveAfter _ x  -> space >> brackets (string $ show x)
+      _                    -> pure ()
 
 instance Pretty GHC.InlineSpec where
   pretty' = prettyInlineSpec
@@ -2592,25 +2559,25 @@ prettyInlineSpec GHC.NoUserInlinePrag =
 prettyInlineSpec GHC.Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
-  pretty' GHC.Unidirectional = string "<-"
-  pretty' GHC.ImplicitBidirectional = string "="
+  pretty' GHC.Unidirectional           = string "<-"
+  pretty' GHC.ImplicitBidirectional    = string "="
   pretty' GHC.ExplicitBidirectional {} = string "<-"
 
 instance Pretty (GHC.HsOverLit GHC.GhcPs) where
   pretty' GHC.OverLit {..} = pretty ol_val
 
 instance Pretty GHC.OverLitVal where
-  pretty' (GHC.HsIntegral x) = pretty x
+  pretty' (GHC.HsIntegral x)   = pretty x
   pretty' (GHC.HsFractional x) = pretty x
   pretty' (GHC.HsIsString _ x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = output s
-  pretty' GHC.IL {..} = string $ show il_value
+  pretty' GHC.IL {..}                         = string $ show il_value
 #else
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = string s
-  pretty' GHC.IL {..} = string $ show il_value
+  pretty' GHC.IL {..}                         = string $ show il_value
 #endif
 instance Pretty GHC.FractionalLit where
   pretty' = output
@@ -2629,7 +2596,7 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
   pretty' GHC.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      GHC.HsString {} -> prettyString
+      GHC.HsString {}     -> prettyString
       GHC.HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2640,9 +2607,8 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1)
-                $ lined
-                $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1) $
+                lined $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsPragE GHC.GhcPs) where
   pretty' (GHC.HsPragSCC _ x) =
@@ -2656,13 +2622,13 @@ instance Pretty GHC.HsIPName where
   pretty' (GHC.HsIPName x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsTyLit GHC.GhcPs) where
-  pretty' (GHC.HsNumTy _ x) = string $ show x
-  pretty' (GHC.HsStrTy _ x) = string $ ushow x
+  pretty' (GHC.HsNumTy _ x)  = string $ show x
+  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #else
 instance Pretty GHC.HsTyLit where
-  pretty' (GHC.HsNumTy _ x) = string $ show x
-  pretty' (GHC.HsStrTy _ x) = string $ ushow x
+  pretty' (GHC.HsNumTy _ x)  = string $ show x
+  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (GHC.HsPatSigType GHC.GhcPs) where
@@ -2684,10 +2650,10 @@ prettyIPBind (GHC.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (GHC.DerivStrategy GHC.GhcPs) where
-  pretty' GHC.StockStrategy {} = string "stock"
+  pretty' GHC.StockStrategy {}    = string "stock"
   pretty' GHC.AnyclassStrategy {} = string "anyclass"
-  pretty' GHC.NewtypeStrategy {} = string "newtype"
-  pretty' (GHC.ViaStrategy x) = string "via " >> pretty x
+  pretty' GHC.NewtypeStrategy {}  = string "newtype"
+  pretty' (GHC.ViaStrategy x)     = string "via " >> pretty x
 
 instance Pretty GHC.XViaStrategyPs where
   pretty' (GHC.XViaStrategyPs _ ty) = pretty ty
@@ -2755,12 +2721,9 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets
-          $ spaced
-              [ pretty listCompLhs
-              , string "|"
-              , hCommaSep $ fmap pretty listCompRhs
-              ]
+        brackets $
+        spaced
+          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2778,7 +2741,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do = string "do"
+  pretty' Do  = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2798,10 +2761,10 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty GHC.CCallConv where
-  pretty' GHC.CCallConv = string "ccall"
-  pretty' GHC.CApiConv = string "capi"
-  pretty' GHC.StdCallConv = string "stdcall"
-  pretty' GHC.PrimCallConv = string "prim"
+  pretty' GHC.CCallConv          = string "ccall"
+  pretty' GHC.CApiConv           = string "capi"
+  pretty' GHC.StdCallConv        = string "stdcall"
+  pretty' GHC.PrimCallConv       = string "prim"
   pretty' GHC.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
@@ -2811,13 +2774,13 @@ instance Pretty GHC.HsSrcBang where
     pretty strictness
 
 instance Pretty GHC.SrcUnpackedness where
-  pretty' GHC.SrcUnpack = string "{-# UNPACK #-}"
+  pretty' GHC.SrcUnpack   = string "{-# UNPACK #-}"
   pretty' GHC.SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' GHC.NoSrcUnpack = pure ()
 
 instance Pretty GHC.SrcStrictness where
-  pretty' GHC.SrcLazy = string "~"
-  pretty' GHC.SrcStrict = string "!"
+  pretty' GHC.SrcLazy     = string "~"
+  pretty' GHC.SrcStrict   = string "!"
   pretty' GHC.NoSrcStrict = pure ()
 
 instance Pretty (GHC.HsOuterSigTyVarBndrs GHC.GhcPs) where
@@ -2841,11 +2804,8 @@ instance Pretty (GHC.HsUntypedSplice GHC.GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars
-           . indentedWithFixedLevel 0
-           . sequence_
-           . printers [] ""
-           . GHC.unpackFS)
+        (wrapWithBars .
+         indentedWithFixedLevel 0 . sequence_ . printers [] "" . GHC.unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 -- | Pretty printing.
 --
@@ -21,41 +21,42 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import Data.Maybe
-import Data.Void
-import qualified GHC.Core.Coercion as GHC
-import qualified GHC.Data.Bag as GHC
-import qualified GHC.Data.BooleanFormula as GHC
-import qualified GHC.Data.FastString as GHC
-import qualified GHC.Hs as GHC
-import GHC.Stack
-import qualified GHC.Types.Basic as GHC
-import qualified GHC.Types.Fixity as GHC
-import qualified GHC.Types.ForeignCall as GHC
-import qualified GHC.Types.Name as GHC
-import qualified GHC.Types.Name.Reader as GHC
-import qualified GHC.Types.SourceText as GHC
-import qualified GHC.Types.SrcLoc as GHC
-import qualified GHC.Unit.Module.Warnings as GHC
-import HIndent.Applicative
-import HIndent.Ast.NodeComments
-import HIndent.Config
-import HIndent.Fixity
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
-import HIndent.Printer
+import           Control.Monad
+import           Control.Monad.RWS
+import           Data.Maybe
+import           Data.Void
+import qualified GHC.Core.Coercion                           as GHC
+import qualified GHC.Data.Bag                                as GHC
+import qualified GHC.Data.BooleanFormula                     as GHC
+import qualified GHC.Data.FastString                         as GHC
+import qualified GHC.Hs                                      as GHC
+import           GHC.Stack
+import qualified GHC.Types.Basic                             as GHC
+import qualified GHC.Types.Fixity                            as GHC
+import qualified GHC.Types.ForeignCall                       as GHC
+import qualified GHC.Types.Name                              as GHC
+import qualified GHC.Types.Name.Reader                       as GHC
+import qualified GHC.Types.SourceText                        as GHC
+import qualified GHC.Types.SrcLoc                            as GHC
+import qualified GHC.Unit.Module.Warnings                    as GHC
+import           HIndent.Applicative
+import           HIndent.Ast.Declaration
+import           HIndent.Ast.NodeComments
+import           HIndent.Config
+import           HIndent.Fixity
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
+import           HIndent.Printer
 import qualified Language.Haskell.GhclibParserEx.GHC.Hs.Expr as GHC
-import Text.Show.Unicode
+import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable as NonEmpty
-import qualified GHC.Core.DataCon as GHC
+import qualified Data.Foldable                               as NonEmpty
+import qualified GHC.Core.DataCon                            as GHC
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified GHC.Unit as GHC
+import qualified GHC.Unit                                    as GHC
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -92,10 +93,8 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
+         spaced $ fmap pretty $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -123,6 +122,244 @@ class CommentExtraction a =>
   where
   pretty' :: a -> Printer ()
 
+instance Pretty Declaration where
+  pretty' (DataFamily x)      = pretty x
+  pretty' (TypeFamily x)      = pretty x
+  pretty' (DataDeclaration x) = pretty x
+  pretty' (TypeSynonym x)     = pretty x
+  pretty' (TyClDecl x)        = pretty x
+  pretty' (ClassInstance x)   = pretty x
+  pretty' (InstDecl x)        = pretty x
+  pretty' (DerivDecl x)       = pretty x
+  pretty' (ValDecl x)         = pretty x
+  pretty' (SigDecl x)         = pretty x
+  pretty' (KindSigDecl x)     = pretty x
+  pretty' (DefDecl x)         = pretty x
+  pretty' (ForDecl x)         = pretty x
+  pretty' (WarningDecl x)     = pretty x
+  pretty' (AnnDecl x)         = pretty x
+  pretty' (RuleDecl x)        = pretty x
+  pretty' (SpliceDecl x)      = pretty x
+  pretty' (RoleAnnotDecl x)   = pretty x
+
+instance Pretty DataDeclaration where
+  pretty' GADT {..} = do
+    pretty header
+    whenJust kind $ \x -> string " :: " >> pretty x
+    string " where"
+    indentedBlock $ newlinePrefixed $ fmap pretty constructors
+  pretty' Record {..} = do
+    pretty header
+    case dd_cons of
+      [] -> indentedBlock derivingsAfterNewline
+      [x@(GHC.L _ GHC.ConDeclH98 {con_args = GHC.RecCon {}})] -> do
+        string " = "
+        pretty x
+        unless (null dd_derivs) $ space |=> printDerivings
+      [x] -> do
+        string " ="
+        newline
+        indentedBlock $ do
+          pretty x
+          derivingsAfterNewline
+      _ ->
+        indentedBlock $ do
+          newline
+          string "= " |=> vBarSep (fmap pretty dd_cons)
+          derivingsAfterNewline
+    where
+      derivingsAfterNewline =
+        unless (null dd_derivs) $ newline >> printDerivings
+      printDerivings = lined $ fmap pretty dd_derivs
+
+instance Pretty DataFamily where
+  pretty' DataFamily {..} = do
+    string "data "
+    when isTopLevel $ string "family "
+    string name
+    spacePrefixed $ fmap pretty typeVariables
+    whenJust signature $ \sig -> space >> pretty sig
+
+instance Pretty TypeFamily where
+  pretty' TypeFamily {..} = do
+    string "type "
+    when isTopLevel $ string "family "
+    string name
+    spacePrefixed $ fmap pretty typeVariables
+    case getNode signature of
+      ResultSignature GHC.NoSig {} -> pure ()
+      ResultSignature GHC.TyVarSig {} -> string " = " >> pretty signature
+      _ -> space >> pretty signature
+    whenJust injectivity $ \x -> string " | " >> pretty x
+    whenJust equations $ \xs ->
+      string " where" >> newline >> indentedBlock (lined $ fmap pretty xs)
+
+instance Pretty ClassInstance where
+  pretty' (ClassInstance GHC.ClsInstDecl {..}) = do
+    string "instance " |=> do
+      whenJust cid_overlap_mode $ \x -> do
+        pretty x
+        space
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
+    unless (null sigsAndMethods) $ do
+      newline
+      indentedBlock $ lined $ fmap pretty sigsAndMethods
+    where
+      sigsAndMethods =
+        mkSortedLSigBindFamilyList
+          cid_sigs
+          (bagToList cid_binds)
+          []
+          cid_tyfam_insts
+          cid_datafam_insts
+
+instance Pretty TypeSynonym where
+  pretty' TypeSynonym {..} = do
+    string "type "
+    pretty lhs
+    hor <-|> ver
+    where
+      hor = string " = " >> pretty rhs
+      ver = newline >> indentedBlock (string "= " |=> pretty rhs)
+
+instance Pretty TypeSynonymLhs where
+  pretty' Prefix {..} = spaced $ pretty name : fmap pretty typeVariables
+  pretty' Infix {..} =
+    spaced [pretty left, pretty $ fmap InfixOp name, pretty right]
+
+instance Pretty Injectivity where
+  pretty' (Injectivity x) = pretty x
+
+instance Pretty ResultSignature where
+  pretty' (ResultSignature x) = pretty x
+
+instance Pretty TypeVariable where
+  pretty' TypeVariable {kind = Just kind, ..} =
+    parens $ prettyWith name string >> string " :: " >> pretty kind
+  pretty' TypeVariable {kind = Nothing, ..} = prettyWith name string
+
+instance Pretty GADTConstructor where
+  pretty' (GADTConstructor {..}) = do
+    hCommaSep $ fmap (`prettyWith` string) names
+    hor <-|> ver
+    where
+      hor = string " :: " |=> body
+      ver = newline >> indentedBlock (string ":: " |=> body)
+      body =
+        case (forallNeeded, con_mb_cxt) of
+          (True, Just ctx) -> withForallCtx ctx
+          (True, Nothing) -> withForallOnly
+          (False, Just ctx) -> withCtxOnly ctx
+          (False, Nothing) -> noForallCtx
+      withForallCtx ctx = do
+        pretty bindings
+        (space >> pretty (mkContext <$> fromGenLocated ctx))
+          <-|> (newline >> pretty (mkContext <$> fromGenLocated ctx))
+        newline
+        prefixed "=> " $ prettyVertically signature
+      withForallOnly = do
+        pretty bindings
+        (space >> prettyHorizontally signature)
+          <-|> (newline >> prettyVertically signature)
+      withCtxOnly ctx =
+        (pretty (mkContext <$> fromGenLocated ctx)
+           >> string " => "
+           >> prettyHorizontally signature)
+          <-|> (pretty (mkContext <$> fromGenLocated ctx)
+                  >> prefixed "=> " (prettyVertically signature))
+      noForallCtx = prettyHorizontally signature <-|> prettyVertically signature
+
+instance Pretty Header where
+  pretty' Header {..} = do
+    (pretty newOrData >> space) |=> do
+      whenJust context $ \c -> pretty c >> string " =>" >> newline
+      pretty name
+    spacePrefixed $ fmap pretty typeVariables
+
+instance Pretty Type where
+  pretty' (Type x) = pretty x
+
+instance (Pretty a) => Pretty (WithComments a) where
+  pretty' WithComments {..} = pretty' node
+
+-- | Prints comments included in the location information and then the
+-- AST node body.
+prettyWith :: WithComments a -> (a -> Printer ()) -> Printer ()
+prettyWith WithComments {..} f = do
+  printCommentsBefore comments
+  f node
+  printCommentOnSameLine comments
+  printCommentsAfter comments
+
+-- | Prints comments that are before the given AST node.
+printCommentsBefore :: NodeComments -> Printer ()
+printCommentsBefore p =
+  forM_ (commentsBefore p) $ \(GHC.L loc c) -> do
+    let col = fromIntegral $ GHC.srcSpanStartCol (GHC.anchor loc) - 1
+    indentedWithFixedLevel col $ pretty c
+    newline
+
+-- | Prints comments that are on the same line as the given AST node.
+printCommentOnSameLine :: NodeComments -> Printer ()
+printCommentOnSameLine (commentsOnSameLine -> (c:cs)) = do
+  col <- gets psColumn
+  if col == 0
+    then indentedWithFixedLevel
+           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c) $
+         spaced $ fmap pretty $ c : cs
+    else spacePrefixed $ fmap pretty $ c : cs
+  eolCommentsArePrinted
+printCommentOnSameLine _ = return ()
+
+-- | Prints comments that are after the given AST node.
+printCommentsAfter :: NodeComments -> Printer ()
+printCommentsAfter p =
+  case commentsAfter p of
+    [] -> return ()
+    xs -> do
+      isThereCommentsOnSameLine <- gets psEolComment
+      unless isThereCommentsOnSameLine newline
+      forM_ xs $ \(GHC.L loc c) -> do
+        let col = fromIntegral $ GHC.srcSpanStartCol (GHC.anchor loc) - 1
+        indentedWithFixedLevel col $ pretty c
+        eolCommentsArePrinted
+
+prettyHorizontally :: ConstructorSignature -> Printer ()
+prettyHorizontally (ByArrows {..}) =
+  inter (string " -> ") $ fmap pretty parameters ++ [pretty result]
+prettyHorizontally (Record {..}) =
+  inter
+    (string " -> ")
+    [prettyWith fields (vFields' . fmap pretty), pretty result]
+
+prettyVertically :: ConstructorSignature -> Printer ()
+prettyVertically (ByArrows {..}) =
+  prefixedLined "-> " $ fmap pretty parameters ++ [pretty result]
+prettyVertically (Record {..}) =
+  prefixedLined
+    "-> "
+    [prettyWith fields (vFields' . fmap pretty), pretty result]
+
+instance Pretty Context where
+  pretty' (Context xs) = hor <-|> ver
+    where
+      hor = parensConditional $ hCommaSep $ fmap pretty xs
+        where
+          parensConditional =
+            case xs of
+              [_] -> id
+              _ -> parens
+      ver =
+        case xs of
+          [] -> string "()"
+          [x] -> pretty x
+          _ -> vTuple $ fmap pretty xs
+
+instance Pretty NewOrData where
+  pretty' Newtype = string "newtype"
+  pretty' Data = string "data"
+
 -- Do nothing if there are no pragmas, module headers, imports, or
 -- declarations. Otherwise, extra blank lines will be inserted if only
 -- comments are present in the source code. See
@@ -131,19 +368,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GHC.GenLocated l e) where
   pretty' (GHC.L _ e) = pretty e
 
 instance Pretty (GHC.HsDecl GHC.GhcPs) where
-  pretty' (GHC.TyClD _ d) = pretty d
-  pretty' (GHC.InstD _ inst) = pretty inst
-  pretty' (GHC.DerivD _ x) = pretty x
-  pretty' (GHC.ValD _ bind) = pretty bind
-  pretty' (GHC.SigD _ s) = pretty s
-  pretty' (GHC.KindSigD _ x) = pretty x
-  pretty' (GHC.DefD _ x) = pretty x
-  pretty' (GHC.ForD _ x) = pretty x
-  pretty' (GHC.WarningD _ x) = pretty x
-  pretty' (GHC.AnnD _ x) = pretty x
-  pretty' (GHC.RuleD _ x) = pretty x
-  pretty' (GHC.SpliceD _ sp) = pretty sp
-  pretty' GHC.DocD {} = docNode
+  pretty' (GHC.TyClD _ d)      = pretty d
+  pretty' (GHC.InstD _ inst)   = pretty inst
+  pretty' (GHC.DerivD _ x)     = pretty x
+  pretty' (GHC.ValD _ bind)    = pretty bind
+  pretty' (GHC.SigD _ s)       = pretty s
+  pretty' (GHC.KindSigD _ x)   = pretty x
+  pretty' (GHC.DefD _ x)       = pretty x
+  pretty' (GHC.ForD _ x)       = pretty x
+  pretty' (GHC.WarningD _ x)   = pretty x
+  pretty' (GHC.AnnD _ x)       = pretty x
+  pretty' (GHC.RuleD _ x)      = pretty x
+  pretty' (GHC.SpliceD _ sp)   = pretty sp
+  pretty' GHC.DocD {}          = docNode
   pretty' (GHC.RoleAnnotD _ x) = pretty x
 
 instance Pretty (GHC.TyClDecl GHC.GhcPs) where
@@ -182,7 +419,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_cons tcdDataDefn of
         GHC.DataTypeCons {} -> string "data "
-        GHC.NewTypeCon {} -> string "newtype "
+        GHC.NewTypeCon {}   -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -197,7 +434,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType -> string "newtype "
+        GHC.NewType  -> string "newtype "
 #else
 prettyTyClDecl GHC.DataDecl {..} = do
   printDataNewtype |=> do
@@ -212,7 +449,7 @@ prettyTyClDecl GHC.DataDecl {..} = do
     printDataNewtype =
       case GHC.dd_ND tcdDataDefn of
         GHC.DataType -> string "data "
-        GHC.NewType -> string "newtype "
+        GHC.NewType  -> string "newtype "
 #endif
 prettyTyClDecl GHC.ClassDecl {..} = do
   if isJust tcdCtxt
@@ -233,21 +470,20 @@ prettyTyClDecl GHC.ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            [] -> string "()"
+            []  -> string "()"
             [x] -> pretty x
-            xs -> hvTuple $ fmap pretty xs
+            xs  -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock
-          $ string "| "
-              |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
-                       printCommentsAnd x $ \(GHC.FunDep _ from to) ->
-                         spaced
-                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock $
+          string "| " |=>
+          vCommaSep
+            (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
+               printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -258,27 +494,27 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         GHC.Infix ->
           case GHC.hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens
-                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens $
+                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (GHC.bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (GHC.InstDecl GHC.GhcPs) where
-  pretty' GHC.ClsInstD {..} = pretty cid_inst
+  pretty' GHC.ClsInstD {..}     = pretty cid_inst
   pretty' GHC.DataFamInstD {..} = pretty dfid_inst
-  pretty' GHC.TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' GHC.TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (GHC.HsBind GHC.GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: GHC.HsBind GHC.GhcPs -> Printer ()
-prettyHsBind GHC.FunBind {..} = pretty fun_matches
-prettyHsBind GHC.PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind GHC.VarBind {} = notGeneratedByParser
+prettyHsBind GHC.FunBind {..}     = pretty fun_matches
+prettyHsBind GHC.PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind GHC.VarBind {}       = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind GHC.AbsBinds {} = notGeneratedByParser
+prettyHsBind GHC.AbsBinds {}      = notGeneratedByParser
 #endif
 prettyHsBind (GHC.PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -295,14 +531,13 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space
-                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space |=>
+               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -322,9 +557,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -364,14 +599,13 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
         headLen <- printerLength printFunName
         indentSpaces <- getIndentSpaces
         if headLen < indentSpaces
-          then space
-                 |=> pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
+          then space |=>
+               pretty (HsSigTypeInsideDeclSig <$> GHC.hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> GHC.hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (GHC.PatSynSig _ names sig) =
     spaced
@@ -391,9 +625,9 @@ instance Pretty (GHC.Sig GHC.GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' GHC.IdSig {} = notGeneratedByParser
   pretty' (GHC.FixSig _ x) = pretty x
   pretty' (GHC.InlineSig _ name detail) =
@@ -452,12 +686,12 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
     where
       cons =
         case dd_cons of
-          GHC.NewTypeCon x -> [x]
+          GHC.NewTypeCon x      -> [x]
           GHC.DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (GHC.DataTypeCons _ (GHC.L _ GHC.ConDeclGADT {}:_)) -> True
-          _ -> False
+          _                                                   -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -493,7 +727,7 @@ instance Pretty (GHC.HsDataDefn GHC.GhcPs) where
       isGADT =
         case dd_cons of
           (GHC.L _ GHC.ConDeclGADT {}:_) -> True
-          _ -> False
+          _                              -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -504,8 +738,8 @@ instance Pretty (GHC.ClsInstDecl GHC.GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
+        unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -559,18 +793,17 @@ prettyHsExpr (GHC.HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              [] -> error "Invalid function application."
+              []         -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col'
-              - col
-              - if col == 0
-                  then spaces
-                  else 0
+            col' - col -
+            if col == 0
+              then spaces
+              else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -609,11 +842,11 @@ prettyHsExpr (GHC.ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens
-        $ prefixedLined ","
-        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens $
+      prefixedLined "," $
+      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing GHC.Missing {} = True
-    isMissing _ = False
+    isMissing _              = False
 prettyHsExpr (GHC.ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -649,8 +882,8 @@ prettyHsExpr (GHC.HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (GHC.HsMultiIf _ guards) =
-  string "if "
-    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if " |=>
+  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (GHC.HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -714,9 +947,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsFieldBind a b)]
@@ -744,9 +977,9 @@ prettyHsExpr (GHC.RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GHC.GenLocated l (GHC.HsRecField' a b)]
@@ -773,11 +1006,10 @@ prettyHsExpr (GHC.HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr GHC.HsProjection {..} =
-  parens
-    $ forM_ proj_flds
-    $ \x -> do
-        string "."
-        pretty x
+  parens $
+  forM_ proj_flds $ \x -> do
+    string "."
+    pretty x
 prettyHsExpr (GHC.ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -789,8 +1021,8 @@ prettyHsExpr (GHC.HsSpliceE _ x) = pretty x
 prettyHsExpr (GHC.HsProc _ pat x@(GHC.L _ (GHC.HsCmdTop _ (GHC.L _ (GHC.HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock
-    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock $
+    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (GHC.HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -824,7 +1056,7 @@ prettyHsExpr (GHC.HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case -> string "\\case"
+      Case  -> string "\\case"
       Cases -> string "\\cases"
     if null $ GHC.unLoc $ GHC.mg_alts matches
       then string " {}"
@@ -851,12 +1083,10 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do
-                    hor <-|> ver
-                    newline
-                    prefixed "=> "
-                      $ prefixedLined "-> "
-                      $ pretty <$> flatten hst_body
+               in do hor <-|> ver
+                     newline
+                     prefixed "=> " $
+                       prefixedLined "-> " $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -866,7 +1096,7 @@ instance Pretty HsSigType' where
     where
       flatten :: GHC.LHsType GHC.GhcPs -> [GHC.LHsType GHC.GhcPs]
       flatten (GHC.L _ (GHC.HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x = [x]
+      flatten x                               = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig GHC.HsSig {..}) =
     case sig_bndrs of
       GHC.HsOuterExplicit _ xs -> do
@@ -875,8 +1105,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           GHC.HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt))
-              <-|> (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
+              (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -906,10 +1136,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -920,20 +1150,20 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ ->
           prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
@@ -952,10 +1182,10 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -966,52 +1196,52 @@ prettyConDecl GHC.ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt))
-        <-|> (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt)) <-|>
+        (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
-        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-    
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
+      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         GHC.PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(GHC.HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         GHC.RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
+
     forallNeeded =
       case GHC.unLoc con_bndrs of
         GHC.HsOuterImplicit {} -> False
@@ -1019,30 +1249,26 @@ prettyConDecl GHC.ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \c -> do
-             pretty $ Context c
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \c -> do
+        pretty $ Context c
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #else
 prettyConDecl GHC.ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \_ -> do
-             pretty $ Context con_mb_cxt
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \_ -> do
+        pretty $ Context con_mb_cxt
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #endif
 prettyConDecl GHC.ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1061,11 +1287,11 @@ instance Pretty
 prettyMatchExpr :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Printer ()
 prettyMatchExpr GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case GHC.unLoc $ head m_pats of
-        GHC.LazyPat {} -> space
-        GHC.BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case GHC.unLoc $ head m_pats of
+      GHC.LazyPat {} -> space
+      GHC.BangPat {} -> space
+      _              -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr GHC.Match {m_ctxt = GHC.CaseAlt, ..} = do
@@ -1085,9 +1311,8 @@ prettyMatchExpr GHC.Match {..} =
     GHC.Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, GHC.FunRhs {..}) -> do
-          spaced
-            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
-                ++ fmap pretty xs
+          spaced $
+            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1100,11 +1325,11 @@ instance Pretty
 prettyMatchProc :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Printer ()
 prettyMatchProc GHC.Match {m_ctxt = GHC.LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case GHC.unLoc $ head m_pats of
-        GHC.LazyPat {} -> space
-        GHC.BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case GHC.unLoc $ head m_pats of
+      GHC.LazyPat {} -> space
+      GHC.BangPat {} -> space
+      _              -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc GHC.Match {m_ctxt = GHC.CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1175,7 +1400,7 @@ instance Pretty
     where
       horizontal =
         case rec_dotdot of
-          Just _ -> braces $ string ".."
+          Just _  -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1187,8 +1412,8 @@ instance Pretty
   pretty' GHC.HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (GHC.HsType GHC.GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1295,7 +1520,7 @@ prettyHsType (GHC.HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (GHC.HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hvPromotedList $ fmap pretty xs
+    _  -> hvPromotedList $ fmap pretty xs
 prettyHsType (GHC.HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (GHC.HsTyLit _ x) = pretty x
 prettyHsType GHC.HsWildCardTy {} = string "_"
@@ -1316,11 +1541,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (GHC.HsValBinds epa lr, _) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty
@@ -1331,11 +1556,11 @@ instance Pretty
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (GHC.HsValBinds epa lr) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (GHC.L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty (GHC.HsMatchContext GHC.GhcPs) where
@@ -1470,11 +1695,8 @@ instance Pretty (GHC.HsSplice GHC.GhcPs) where
   pretty' (GHC.HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars
-        $ indentedWithFixedLevel 0
-        $ sequence_
-        $ printers [] ""
-        $ GHC.unpackFS r
+      wrapWithBars $
+        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ GHC.unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1538,13 +1760,13 @@ prettyPat (GHC.SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat GHC.HsRecFields {..}) =
     case fieldPrinters of
-      [] -> string "{}"
+      []  -> string "{}"
       [x] -> braces x
-      xs -> hvFields xs
+      xs  -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1560,10 +1782,10 @@ instance Pretty (GHC.HsBracket GHC.GhcPs) where
   pretty' (GHC.TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x) = pretty x
-  pretty' (Bind x) = pretty x
-  pretty' (TypeFamily x) = pretty x
-  pretty' (TyFamInst x) = pretty x
+  pretty' (Sig x)         = pretty x
+  pretty' (Bind x)        = pretty x
+  pretty' (TypeFamily x)  = pretty x
+  pretty' (TyFamInst x)   = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty GHC.EpaComment where
@@ -1585,7 +1807,7 @@ instance Pretty (GHC.HsValBindsLR GHC.GhcPs GHC.GhcPs) where
 
 instance Pretty (GHC.HsTupArg GHC.GhcPs) where
   pretty' (GHC.Present _ e) = pretty e
-  pretty' GHC.Missing {} = pure () -- This appears in a tuple section.
+  pretty' GHC.Missing {}    = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField GHC.HsFieldBind {..}) = do
@@ -1690,7 +1912,7 @@ instance Pretty (GHC.ConDeclField GHC.GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (GHC.L _ (GHC.HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x) = pretty' x
+  pretty' (InfixExpr x)                            = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1751,9 +1973,9 @@ instance Pretty InfixApp where
       GHC.Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (GHC.BooleanFormula a) where
-  pretty' (GHC.Var x) = pretty x
-  pretty' (GHC.And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (GHC.Or xs) = hvBarSep $ fmap pretty xs
+  pretty' (GHC.Var x)    = pretty x
+  pretty' (GHC.And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (GHC.Or xs)    = hvBarSep $ fmap pretty xs
   pretty' (GHC.Parens x) = parens $ pretty x
 
 instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
@@ -1761,7 +1983,7 @@ instance Pretty (GHC.FieldLabelStrings GHC.GhcPs) where
 
 instance Pretty (GHC.AmbiguousFieldOcc GHC.GhcPs) where
   pretty' (GHC.Unambiguous _ name) = pretty name
-  pretty' (GHC.Ambiguous _ name) = pretty name
+  pretty' (GHC.Ambiguous _ name)   = pretty name
 
 instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
   pretty' GHC.HsDerivingClause { deriv_clause_strategy = Just strategy@(GHC.L _ GHC.ViaStrategy {})
@@ -1777,14 +1999,14 @@ instance Pretty (GHC.HsDerivingClause GHC.GhcPs) where
 
 instance Pretty (GHC.DerivClauseTys GHC.GhcPs) where
   pretty' (GHC.DctSingle _ ty) = parens $ pretty ty
-  pretty' (GHC.DctMulti _ ts) = hvTuple $ fmap pretty ts
+  pretty' (GHC.DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
 instance Pretty GHC.OverlapMode where
-  pretty' GHC.NoOverlap {} = notUsedInParsedStage
+  pretty' GHC.NoOverlap {}    = notUsedInParsedStage
   pretty' GHC.Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' GHC.Overlapping {} = string "{-# OVERLAPPING #-}"
-  pretty' GHC.Overlaps {} = string "{-# OVERLAPS #-}"
-  pretty' GHC.Incoherent {} = string "{-# INCOHERENT #-}"
+  pretty' GHC.Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' GHC.Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' GHC.Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty GHC.StringLiteral where
   pretty' = output
@@ -1792,13 +2014,13 @@ instance Pretty GHC.StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
   pretty' GHC.FamilyDecl {..} = do
-    string
-      $ case fdInfo of
-          GHC.DataFamily -> "data"
-          GHC.OpenTypeFamily -> "type"
-          GHC.ClosedTypeFamily {} -> "type"
+    string $
+      case fdInfo of
+        GHC.DataFamily          -> "data"
+        GHC.OpenTypeFamily      -> "type"
+        GHC.ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      GHC.TopLevel -> string " family "
+      GHC.TopLevel    -> string " family "
       GHC.NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> GHC.hsq_explicit fdTyVars
@@ -1821,8 +2043,8 @@ instance Pretty (GHC.FamilyDecl GHC.GhcPs) where
       _ -> pure ()
 
 instance Pretty (GHC.FamilyResultSig GHC.GhcPs) where
-  pretty' GHC.NoSig {} = pure ()
-  pretty' (GHC.KindSig _ x) = string ":: " >> pretty x
+  pretty' GHC.NoSig {}       = pure ()
+  pretty' (GHC.KindSig _ x)  = string ":: " >> pretty x
   pretty' (GHC.TyVarSig _ x) = pretty x
 
 instance Pretty (GHC.HsTyVarBndr a GHC.GhcPs) where
@@ -1841,8 +2063,8 @@ instance Pretty (GHC.ArithSeqInfo GHC.GhcPs) where
   pretty' (GHC.FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (GHC.FromThenTo from next to) =
-    brackets
-      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets $
+    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (GHC.HsForAllTelescope GHC.GhcPs) where
   pretty' GHC.HsForAllVis {..} = do
@@ -1888,9 +2110,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (GHC.L _ []) -> parens
+          (GHC.L _ [])  -> parens
           (GHC.L _ [_]) -> id
-          _ -> parens
+          _             -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(GHC.L _ [])) =
@@ -1905,10 +2127,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing -> id
-          Just (GHC.L _ []) -> parens
+          Nothing            -> id
+          Just (GHC.L _ [])  -> parens
           Just (GHC.L _ [_]) -> id
-          Just _ -> parens
+          Just _             -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1994,17 +2216,17 @@ instance Pretty
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x) = pretty x
+  pretty' (GHC.HsValArg x)    = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
 #else
 instance Pretty
            (GHC.HsArg
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x) = pretty x
+  pretty' (GHC.HsValArg x)    = pretty x
   pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty x
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty' GHC.HsArgPar {}     = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.HsQuote GHC.GhcPs) where
@@ -2029,7 +2251,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2043,7 +2265,7 @@ instance Pretty (GHC.WarnDecl GHC.GhcPs) where
   pretty' (GHC.Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       GHC.DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      GHC.WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      GHC.WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2061,15 +2283,15 @@ instance Pretty (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.GhcPs) where
-  pretty' (GHC.IEName _ name) = pretty name
+  pretty' (GHC.IEName _ name)    = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name) = string "type " >> pretty name
+  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (GHC.IEWrappedName GHC.RdrName) where
-  pretty' (GHC.IEName name) = pretty name
+  pretty' (GHC.IEName name)      = pretty name
   pretty' (GHC.IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (GHC.IEType _ name) = string "type " >> pretty name
+  pretty' (GHC.IEType _ name)    = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.DotFieldOcc GHC.GhcPs) where
@@ -2222,9 +2444,9 @@ instance Pretty GHC.CExportSpec where
   pretty' (GHC.CExportStatic _ _ x) = pretty x
 
 instance Pretty GHC.Safety where
-  pretty' GHC.PlaySafe = string "safe"
+  pretty' GHC.PlaySafe          = string "safe"
   pretty' GHC.PlayInterruptible = string "interruptible"
-  pretty' GHC.PlayRisky = string "unsafe"
+  pretty' GHC.PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.AnnDecl GHC.GhcPs) where
   pretty' (GHC.HsAnnotation _ (GHC.ValueAnnProvenance name) expr) =
@@ -2244,14 +2466,14 @@ instance Pretty (GHC.AnnDecl GHC.GhcPs) where
 #endif
 instance Pretty (GHC.RoleAnnotDecl GHC.GhcPs) where
   pretty' (GHC.RoleAnnotDecl _ name roles) =
-    spaced
-      $ [string "type role", pretty name]
-          ++ fmap (maybe (string "_") pretty . GHC.unLoc) roles
+    spaced $
+    [string "type role", pretty name] ++
+    fmap (maybe (string "_") pretty . GHC.unLoc) roles
 
 instance Pretty GHC.Role where
-  pretty' GHC.Nominal = string "nominal"
+  pretty' GHC.Nominal          = string "nominal"
   pretty' GHC.Representational = string "representational"
-  pretty' GHC.Phantom = string "phantom"
+  pretty' GHC.Phantom          = string "phantom"
 
 instance Pretty (GHC.TyFamInstDecl GHC.GhcPs) where
   pretty' GHC.TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2311,8 +2533,8 @@ instance Pretty GHC.InlinePragma where
     pretty inl_inline
     case inl_act of
       GHC.ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      GHC.ActiveAfter _ x -> space >> brackets (string $ show x)
-      _ -> pure ()
+      GHC.ActiveAfter _ x  -> space >> brackets (string $ show x)
+      _                    -> pure ()
 
 instance Pretty GHC.InlineSpec where
   pretty' = prettyInlineSpec
@@ -2328,25 +2550,25 @@ prettyInlineSpec GHC.NoUserInlinePrag =
 prettyInlineSpec GHC.Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
-  pretty' GHC.Unidirectional = string "<-"
-  pretty' GHC.ImplicitBidirectional = string "="
+  pretty' GHC.Unidirectional           = string "<-"
+  pretty' GHC.ImplicitBidirectional    = string "="
   pretty' GHC.ExplicitBidirectional {} = string "<-"
 
 instance Pretty (GHC.HsOverLit GHC.GhcPs) where
   pretty' GHC.OverLit {..} = pretty ol_val
 
 instance Pretty GHC.OverLitVal where
-  pretty' (GHC.HsIntegral x) = pretty x
+  pretty' (GHC.HsIntegral x)   = pretty x
   pretty' (GHC.HsFractional x) = pretty x
   pretty' (GHC.HsIsString _ x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = output s
-  pretty' GHC.IL {..} = string $ show il_value
+  pretty' GHC.IL {..}                         = string $ show il_value
 #else
 instance Pretty GHC.IntegralLit where
   pretty' GHC.IL {il_text = GHC.SourceText s} = string s
-  pretty' GHC.IL {..} = string $ show il_value
+  pretty' GHC.IL {..}                         = string $ show il_value
 #endif
 instance Pretty GHC.FractionalLit where
   pretty' = output
@@ -2365,7 +2587,7 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
   pretty' GHC.HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      GHC.HsString {} -> prettyString
+      GHC.HsString {}     -> prettyString
       GHC.HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2376,9 +2598,8 @@ instance Pretty (GHC.HsLit GHC.GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1)
-                $ lined
-                $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1) $
+                lined $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsPragE GHC.GhcPs) where
   pretty' (GHC.HsPragSCC _ x) =
@@ -2392,13 +2613,13 @@ instance Pretty GHC.HsIPName where
   pretty' (GHC.HsIPName x) = string $ GHC.unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (GHC.HsTyLit GHC.GhcPs) where
-  pretty' (GHC.HsNumTy _ x) = string $ show x
-  pretty' (GHC.HsStrTy _ x) = string $ ushow x
+  pretty' (GHC.HsNumTy _ x)  = string $ show x
+  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #else
 instance Pretty GHC.HsTyLit where
-  pretty' (GHC.HsNumTy _ x) = string $ show x
-  pretty' (GHC.HsStrTy _ x) = string $ ushow x
+  pretty' (GHC.HsNumTy _ x)  = string $ show x
+  pretty' (GHC.HsStrTy _ x)  = string $ ushow x
   pretty' (GHC.HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (GHC.HsPatSigType GHC.GhcPs) where
@@ -2420,10 +2641,10 @@ prettyIPBind (GHC.IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (GHC.DerivStrategy GHC.GhcPs) where
-  pretty' GHC.StockStrategy {} = string "stock"
+  pretty' GHC.StockStrategy {}    = string "stock"
   pretty' GHC.AnyclassStrategy {} = string "anyclass"
-  pretty' GHC.NewtypeStrategy {} = string "newtype"
-  pretty' (GHC.ViaStrategy x) = string "via " >> pretty x
+  pretty' GHC.NewtypeStrategy {}  = string "newtype"
+  pretty' (GHC.ViaStrategy x)     = string "via " >> pretty x
 
 instance Pretty GHC.XViaStrategyPs where
   pretty' (GHC.XViaStrategyPs _ ty) = pretty ty
@@ -2491,12 +2712,9 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets
-          $ spaced
-              [ pretty listCompLhs
-              , string "|"
-              , hCommaSep $ fmap pretty listCompRhs
-              ]
+        brackets $
+        spaced
+          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2514,7 +2732,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do = string "do"
+  pretty' Do  = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2534,10 +2752,10 @@ instance Pretty (GHC.RuleBndr GHC.GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty GHC.CCallConv where
-  pretty' GHC.CCallConv = string "ccall"
-  pretty' GHC.CApiConv = string "capi"
-  pretty' GHC.StdCallConv = string "stdcall"
-  pretty' GHC.PrimCallConv = string "prim"
+  pretty' GHC.CCallConv          = string "ccall"
+  pretty' GHC.CApiConv           = string "capi"
+  pretty' GHC.StdCallConv        = string "stdcall"
+  pretty' GHC.PrimCallConv       = string "prim"
   pretty' GHC.JavaScriptCallConv = string "javascript"
 
 instance Pretty GHC.HsSrcBang where
@@ -2547,13 +2765,13 @@ instance Pretty GHC.HsSrcBang where
     pretty strictness
 
 instance Pretty GHC.SrcUnpackedness where
-  pretty' GHC.SrcUnpack = string "{-# UNPACK #-}"
+  pretty' GHC.SrcUnpack   = string "{-# UNPACK #-}"
   pretty' GHC.SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' GHC.NoSrcUnpack = pure ()
 
 instance Pretty GHC.SrcStrictness where
-  pretty' GHC.SrcLazy = string "~"
-  pretty' GHC.SrcStrict = string "!"
+  pretty' GHC.SrcLazy     = string "~"
+  pretty' GHC.SrcStrict   = string "!"
   pretty' GHC.NoSrcStrict = pure ()
 
 instance Pretty (GHC.HsOuterSigTyVarBndrs GHC.GhcPs) where
@@ -2577,11 +2795,8 @@ instance Pretty (GHC.HsUntypedSplice GHC.GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars
-           . indentedWithFixedLevel 0
-           . sequence_
-           . printers [] ""
-           . GHC.unpackFS)
+        (wrapWithBars .
+         indentedWithFixedLevel 0 . sequence_ . printers [] "" . GHC.unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =


### PR DESCRIPTION
### Description of the PR

Moves all `Pretty` instances for HIndent-specific AST types.

This is pretty ugly as it requires exposing all the internal structures of all AST types, but is necessary to remove existing instances for GHC's AST types one by one.

Please review and merge this PR after #841.

#819 

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
