### PR TITLE
Fix not pretty-printing multiple functional dependencies correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix not pretty-printing multiple signatures in a `SPECIALISE` ([#784]).
 - Fix the bug of not pretty-printing multiple module-level warning messages ([#822])
 - Fix the bug of wrongly converting a `newtype` instance to a `data` one ([#839])
+- Fix the bug of not pretty-printing multiple functional dependencies in a typeclass ([#843])
 
 ### Removed
 
@@ -372,6 +373,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#843]: https://github.com/mihaimaruseac/hindent/pull/843
 [#839]: https://github.com/mihaimaruseac/hindent/pull/839
 [#829]: https://github.com/mihaimaruseac/hindent/pull/829
 [#822]: https://github.com/mihaimaruseac/hindent/pull/822

--- a/TESTS.md
+++ b/TESTS.md
@@ -1951,12 +1951,18 @@ type m ~> n = ()
 
 #### Functional dependencies
 
-Short
+Single
 
 ```haskell
 -- https://github.com/commercialhaskell/hindent/issues/323
 class Foo a b | a -> b where
   f :: a -> b
+```
+
+Multiple dependencies in a line
+
+```haskell
+class Foo a b | a -> b, b -> a
 ```
 
 Long

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -467,9 +467,12 @@ prettyTyClDecl GHC.ClassDecl {..} = do
       printNameAndTypeVariables
       unless (null tcdFDs) $ do
         string " | "
-        forM_ tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
-          printCommentsAnd x $ \(GHC.FunDep _ from to) ->
-            spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to
+        hCommaSep
+          (fmap
+             (\x ->
+                printCommentsAnd x $ \(GHC.FunDep _ from to) ->
+                  spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+             tcdFDs)
       unless (null sigsMethodsFamilies) $ string " where"
     verHead = do
       string "class " |=> do
@@ -486,7 +489,7 @@ prettyTyClDecl GHC.ClassDecl {..} = do
         indentedBlock
           $ string "| "
               |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(GHC.L _ GHC.FunDep {}) ->
+                    (flip fmap tcdFDs $ \x ->
                        printCommentsAnd x $ \(GHC.FunDep _ from to) ->
                          spaced
                            $ fmap pretty from ++ [string "->"] ++ fmap pretty to)


### PR DESCRIPTION
### Description of the PR

Pretty-prints multiple functional dependencios with commas.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
