### PR TITLE
Avoid using `showOutputable`

### DIFF
--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -20,7 +20,7 @@ import HIndent.Pretty.NodeComments
 import qualified Data.List.NonEmpty as NE
 #endif
 data GADTConstructor = GADTConstructor
-  { names :: [WithComments String]
+  { names :: [WithComments (GHC.IdP GHC.GhcPs)]
   , forallNeeded :: Bool
   , bindings :: WithComments (GHC.HsOuterSigTyVarBndrs GHC.GhcPs)
   , context :: Maybe (WithComments Context)
@@ -32,7 +32,7 @@ instance CommentExtraction GADTConstructor where
 
 instance Pretty GADTConstructor where
   pretty' (GADTConstructor {..}) = do
-    hCommaSep $ fmap (`prettyWith` string) names
+    hCommaSep $ fmap (`prettyWith` pretty) names
     hor <-|> ver
     where
       hor = string " :: " |=> body
@@ -71,12 +71,10 @@ mkGADTConstructor decl@GHC.ConDeclGADT {..} = Just $ GADTConstructor {..}
     context = fmap (fmap mkContext . fromGenLocated) con_mb_cxt
 mkGADTConstructor _ = Nothing
 
-getNames :: GHC.ConDecl GHC.GhcPs -> Maybe [WithComments String]
+getNames :: GHC.ConDecl GHC.GhcPs -> Maybe [WithComments (GHC.IdP GHC.GhcPs)]
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
-getNames GHC.ConDeclGADT {..} =
-  Just $ NE.toList $ fmap (fmap showOutputable . fromGenLocated) con_names
+getNames GHC.ConDeclGADT {..} = Just $ NE.toList $ fmap fromGenLocated con_names
 #else
-getNames GHC.ConDeclGADT {..} =
-  Just $ fmap (fmap showOutputable . fromGenLocated) con_names
+getNames GHC.ConDeclGADT {..} = Just $ fmap fromGenLocated con_names
 #endif
 getNames _ = Nothing

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -20,7 +20,7 @@ import HIndent.Pretty.NodeComments
 
 data DataFamily = DataFamily
   { isTopLevel :: Bool
-  , name :: String
+  , name :: GHC.LIdP GHC.GhcPs
   , typeVariables :: [WithComments TypeVariable]
   , signature :: Maybe (WithComments Type)
   }
@@ -32,7 +32,7 @@ instance Pretty DataFamily where
   pretty' DataFamily {..} = do
     string "data "
     when isTopLevel $ string "family "
-    string name
+    pretty name
     spacePrefixed $ fmap pretty typeVariables
     whenJust signature $ \sig -> space >> pretty sig
 
@@ -46,7 +46,7 @@ mkDataFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
       case fdTopLevel of
         GHC.TopLevel -> True
         GHC.NotTopLevel -> False
-    name = showOutputable fdLName
+    name = fdLName
     typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit
     signature =
       case GHC.unLoc fdResultSig of

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -20,7 +20,7 @@ import HIndent.Pretty.NodeComments
 
 data TypeFamily = TypeFamily
   { isTopLevel :: Bool
-  , name :: String
+  , name :: GHC.LIdP GHC.GhcPs
   , typeVariables :: [WithComments TypeVariable]
   , signature :: WithComments ResultSignature
   , injectivity :: Maybe (WithComments Injectivity)
@@ -34,7 +34,7 @@ instance Pretty TypeFamily where
   pretty' TypeFamily {..} = do
     string "type "
     when isTopLevel $ string "family "
-    string name
+    pretty name
     spacePrefixed $ fmap pretty typeVariables
     pretty signature
     whenJust injectivity $ \x -> string " | " >> pretty x
@@ -50,7 +50,7 @@ mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
       case fdTopLevel of
         GHC.TopLevel -> True
         GHC.NotTopLevel -> False
-    name = showOutputable fdLName
+    name = fdLName
     typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit
     signature = mkResultSignature <$> fromGenLocated fdResultSig
     injectivity = fmap (fmap mkInjectivity . fromGenLocated) fdInjectivityAnn

--- a/src/HIndent/Ast/Module/Export/Entry.hs
+++ b/src/HIndent/Ast/Module/Export/Entry.hs
@@ -1,21 +1,35 @@
+{-# LANGUAGE CPP #-}
+
 module HIndent.Ast.Module.Export.Entry
   ( ExportEntry
   , mkExportEntry
   ) where
 
 import GHC.Stack
+import qualified GHC.Types.SrcLoc as GHC
+import qualified GHC.Unit as GHC
 import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
-
+#if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 data ExportEntry
-  = SingleIdentifier String
-  | WithSpecificConstructors String [String]
-  | WithAllConstructors String
-  | ByModule String
-
+  = SingleIdentifier (GHC.LIEWrappedName GHC.GhcPs)
+  | WithSpecificConstructors
+      (GHC.LIEWrappedName GHC.GhcPs)
+      [GHC.LIEWrappedName GHC.GhcPs]
+  | WithAllConstructors (GHC.LIEWrappedName GHC.GhcPs)
+  | ByModule (GHC.GenLocated GHC.SrcSpanAnnA GHC.ModuleName)
+#else
+data ExportEntry
+  = SingleIdentifier (GHC.LIEWrappedName (GHC.IdP GHC.GhcPs))
+  | WithSpecificConstructors
+      (GHC.LIEWrappedName (GHC.IdP GHC.GhcPs))
+      [GHC.LIEWrappedName (GHC.IdP GHC.GhcPs)]
+  | WithAllConstructors (GHC.LIEWrappedName (GHC.IdP GHC.GhcPs))
+  | ByModule (GHC.GenLocated GHC.SrcSpanAnnA GHC.ModuleName)
+#endif
 instance CommentExtraction ExportEntry where
   nodeComments SingleIdentifier {} = NodeComments [] [] []
   nodeComments WithSpecificConstructors {} = NodeComments [] [] []
@@ -23,21 +37,18 @@ instance CommentExtraction ExportEntry where
   nodeComments ByModule {} = NodeComments [] [] []
 
 instance Pretty ExportEntry where
-  pretty' (SingleIdentifier s) = string s
-  pretty' (WithSpecificConstructors s xs) = string s >> hTuple (fmap string xs)
-  pretty' (WithAllConstructors s) = string s >> string "(..)"
-  pretty' (ByModule s) = string "module " >> string s
+  pretty' (SingleIdentifier s) = pretty s
+  pretty' (WithSpecificConstructors s xs) = pretty s >> hTuple (fmap pretty xs)
+  pretty' (WithAllConstructors s) = pretty s >> string "(..)"
+  pretty' (ByModule s) = string "module " >> pretty s
 
 mkExportEntry :: GHC.IE GHC.GhcPs -> ExportEntry
-mkExportEntry (GHC.IEVar _ name) = SingleIdentifier $ showOutputable name
-mkExportEntry (GHC.IEThingAbs _ name) = SingleIdentifier $ showOutputable name
-mkExportEntry (GHC.IEThingAll _ name) =
-  WithAllConstructors $ showOutputable name
+mkExportEntry (GHC.IEVar _ name) = SingleIdentifier name
+mkExportEntry (GHC.IEThingAbs _ name) = SingleIdentifier name
+mkExportEntry (GHC.IEThingAll _ name) = WithAllConstructors name
 mkExportEntry (GHC.IEThingWith _ name _ constructors) =
-  WithSpecificConstructors
-    (showOutputable name)
-    (fmap showOutputable constructors)
-mkExportEntry (GHC.IEModuleContents _ name) = ByModule $ showOutputable name
+  WithSpecificConstructors name constructors
+mkExportEntry (GHC.IEModuleContents _ name) = ByModule name
 mkExportEntry GHC.IEGroup {} = neverAppears
 mkExportEntry GHC.IEDoc {} = neverAppears
 mkExportEntry GHC.IEDocNamed {} = neverAppears

--- a/src/HIndent/Ast/Module/Name.hs
+++ b/src/HIndent/Ast/Module/Name.hs
@@ -19,4 +19,4 @@ instance Pretty ModuleName where
   pretty' (ModuleName x) = string "module " >> string x
 
 mkModuleName :: GHC.ModuleName -> ModuleName
-mkModuleName = ModuleName . showOutputable
+mkModuleName = ModuleName . GHC.moduleNameString

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -14,7 +14,7 @@ import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
 
 data TypeVariable = TypeVariable
-  { name :: WithComments String
+  { name :: WithComments (GHC.IdP GHC.GhcPs)
   , kind :: Maybe (WithComments Type)
   }
 
@@ -23,14 +23,12 @@ instance CommentExtraction TypeVariable where
 
 instance Pretty TypeVariable where
   pretty' TypeVariable {kind = Just kind, ..} =
-    parens $ prettyWith name string >> string " :: " >> pretty kind
-  pretty' TypeVariable {kind = Nothing, ..} = prettyWith name string
+    parens $ pretty name >> string " :: " >> pretty kind
+  pretty' TypeVariable {kind = Nothing, ..} = pretty name
 
 mkTypeVariable :: GHC.HsTyVarBndr a GHC.GhcPs -> TypeVariable
 mkTypeVariable (GHC.UserTyVar _ _ n) =
-  TypeVariable {name = showOutputable <$> fromGenLocated n, kind = Nothing}
+  TypeVariable {name = fromGenLocated n, kind = Nothing}
 mkTypeVariable (GHC.KindedTyVar _ _ n k) =
   TypeVariable
-    { name = showOutputable <$> fromGenLocated n
-    , kind = Just $ mkType <$> fromGenLocated k
-    }
+    {name = fromGenLocated n, kind = Just $ mkType <$> fromGenLocated k}


### PR DESCRIPTION
### Description of the PR

Replaces `showOutputable` with other functions because the use of this function should be avoided if possible.

Fixes: #898


### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
