### PR TITLE
Let HIndent format multiple files in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support for GHC 9.8 ([#775]).
 - Support for `ImportPostQualified` ([#875]).
+- HIndent now formats multiple files in parallel ([#914]).
 
 ### Changed
 
@@ -377,6 +378,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#914]: https://github.com/mihaimaruseac/hindent/pull/914
 [#875]: https://github.com/mihaimaruseac/hindent/pull/875
 [#873]: https://github.com/mihaimaruseac/hindent/pull/873
 [#868]: https://github.com/mihaimaruseac/hindent/pull/868

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -149,9 +149,10 @@ library
       Paths_hindent
   hs-source-dirs:
       src
-  ghc-options: -Wall -O2
+  ghc-options: -Wall -O2 -threaded
   build-depends:
       Cabal
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -183,9 +184,10 @@ library hindent-internal
       Paths_hindent
   hs-source-dirs:
       internal
-  ghc-options: -Wall -O2
+  ghc-options: -Wall -O2 -threaded
   build-depends:
       Cabal
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -217,9 +219,10 @@ executable hindent
       Paths_hindent
   hs-source-dirs:
       app
-  ghc-options: -Wall -O2
+  ghc-options: -Wall -O2 -threaded
   build-depends:
       Cabal
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -252,10 +255,11 @@ test-suite hindent-test
       Paths_hindent
   hs-source-dirs:
       tests
-  ghc-options: -Wall -O2
+  ghc-options: -Wall -O2 -threaded
   build-depends:
       Cabal
     , Diff
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -290,9 +294,10 @@ benchmark hindent-bench
       Paths_hindent
   hs-source-dirs:
       benchmarks
-  ghc-options: -Wall -O2
+  ghc-options: -Wall -O2 -threaded
   build-depends:
       Cabal
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers

--- a/package.yaml
+++ b/package.yaml
@@ -24,10 +24,11 @@ extra-source-files:
 data-files:   elisp/hindent.el
 github:       mihaimaruseac/hindent
 
-ghc-options: -Wall -O2
+ghc-options: -Wall -O2 -threaded
 
 dependencies:
   - Cabal
+  - async
   - base >= 4.7 && < 5
   - bytestring
   - containers

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -23,6 +23,7 @@ module HIndent
   , HsModule'
   ) where
 
+import Control.Concurrent.Async
 import Control.Exception
 import Control.Monad
 import Data.ByteString (ByteString)
@@ -79,7 +80,7 @@ hindent args = do
         then S8.interact
                (either (error . prettyParseError) id
                   . reformat style exts Nothing)
-        else forM_ paths $ \filepath -> do
+        else forConcurrently_ paths $ \filepath -> do
                cabalexts <- getCabalExtensionsForSourcePath filepath
                text <- S.readFile filepath
                case reformat style (cabalexts ++ exts) (Just filepath) text of


### PR DESCRIPTION
### Description of the PR

`hindent +RTS -N -RTS *.hs` now formats the given Haskell files in parallel.

### Checklist

*   \[x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
*   \[x] Add tests in [TESTS.md](/TESTS.md) if possible.
