### PR TITLE
Update Stack LTS to 22.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - The formatting style of import declarations with constructors ([#829]).
 - HIndent no longer inserts an empty line after a standalone kind signature ([#873]).
+- Bumped Stack LTS to 22.26 ([#918]).
 
 ### Fixed
 
@@ -378,6 +379,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#918]: https://github.com/mihaimaruseac/hindent/pull/918
 [#914]: https://github.com/mihaimaruseac/hindent/pull/914
 [#875]: https://github.com/mihaimaruseac/hindent/pull/875
 [#873]: https://github.com/mihaimaruseac/hindent/pull/873

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.4
+resolver: lts-22.26
 packages:
 - '.'
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94
-    size: 648660
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
-  original: lts-20.4
+    sha256: 8e7996960d864443a66eb4105338bbdd6830377b9f6f99cd5527ef73c10c01e7
+    size: 719128
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/26.yaml
+  original: lts-22.26


### PR DESCRIPTION
### Description of the PR

Bump Stack LTS to 22.26 to use newer HLS.

### Checklist

*   \[x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
*   \[x] Add tests in [TESTS.md](/TESTS.md) if possible.
