### PR TITLE
fix: indentation for constraints in default method signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Template Haskell functions no longer get unwanted '$' symbols prepended ([#1033])
+- Default method signatures with constraints are now properly indented ([#1042])
 
 ### Removed
 
@@ -404,6 +405,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#1042]: https://github.com/mihaimaruseac/hindent/pull/1042
 [#1033]: https://github.com/mihaimaruseac/hindent/pull/1033
 [#1000]: https://github.com/mihaimaruseac/hindent/pull/1000
 [#967]: https://github.com/mihaimaruseac/hindent/pull/967

--- a/TESTS.md
+++ b/TESTS.md
@@ -459,6 +459,25 @@ class Foo a where
   bar = mappend
 ```
 
+Default signatures with constraints
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/492
+class HasEnvExpr m =>
+      MonadRecordEnvExpr m
+  where
+  addEnvExpression :: EnvExpr m -> m HostExpr
+  default addEnvExpression ::
+       ( MonadTrans t
+       , Monad n
+       , MonadRecordEnvExpr n
+       , t n ~ m
+       , EnvExpr m ~ EnvExpr n
+       )
+    => EnvExpr m
+    -> m HostExpr
+```
+
 `TypeOperators` and `MultiParamTypeClasses`
 
 ```haskell

--- a/src/HIndent/Ast/Declaration/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Signature.hs
@@ -103,13 +103,19 @@ instance Pretty Signature where
       , string "::"
       , pretty signature
       ]
-  pretty' DefaultClassMethod {..} =
-    spaced
-      [ string "default"
-      , hCommaSep $ fmap pretty names
-      , string "::"
-      , printCommentsAnd signature pretty
-      ]
+  pretty' DefaultClassMethod {..} = do
+    string "default "
+    hCommaSep $ fmap pretty names
+    string " ::"
+    hor <-|> ver
+    where
+      hor =
+        space >> printCommentsAnd signature (pretty . HsSigTypeInsideDeclSig)
+      ver = do
+        newline
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd signature (pretty . HsSigTypeInsideDeclSig)
   pretty' ClassMethod {..} = do
     hCommaSep $ fmap pretty names
     string " ::"


### PR DESCRIPTION
### Description of the PR

Fixes: #492

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
