### PR TITLE
refactor: simplify the pattern synonym representation

### DIFF
--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1771,11 +1771,6 @@ instance Pretty
     error
       "Cannot handle here because `InfixCon` does not have the information of the constructor."
 
-instance Pretty (GHC.HsPatSynDir GHC.GhcPs) where
-  pretty' GHC.Unidirectional = string "<-"
-  pretty' GHC.ImplicitBidirectional = string "="
-  pretty' GHC.ExplicitBidirectional {} = string "<-"
-
 instance Pretty (GHC.HsOverLit GHC.GhcPs) where
   pretty' GHC.OverLit {..} = pretty ol_val
 

--- a/src/HIndent/Pretty.hs-boot
+++ b/src/HIndent/Pretty.hs-boot
@@ -64,7 +64,6 @@ instance Pretty
               (GHC.GenLocated GHC.SrcSpanAnnN GHC.RdrName)
               [GHC.RecordPatSynField GHC.GhcPs])
 
-instance Pretty (GHC.HsPatSynDir GHC.GhcPs)
 
 instance Pretty PatInsidePatDecl
 

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -293,11 +293,6 @@ instance CommentExtraction FixityDirection where
 instance CommentExtraction InlinePragma where
   nodeComments InlinePragma {} = emptyNodeComments
 
-instance CommentExtraction (HsPatSynDir GhcPs) where
-  nodeComments Unidirectional = emptyNodeComments
-  nodeComments ImplicitBidirectional = emptyNodeComments
-  nodeComments ExplicitBidirectional {} = emptyNodeComments
-
 instance CommentExtraction (HsOverLit GhcPs) where
   nodeComments OverLit {} = emptyNodeComments
 


### PR DESCRIPTION
### Description of the PR

This PR extracts the `where` clause information from the direction node, making each node have a single meaning.

#1029

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
