### PR TITLE
refactor: remove empty warning comment wrappers

### DIFF
--- a/src/HIndent/Ast/Declaration/Warning.hs
+++ b/src/HIndent/Ast/Declaration/Warning.hs
@@ -7,6 +7,7 @@ module HIndent.Ast.Declaration.Warning
   ) where
 
 import qualified GHC.Types.SourceText as GHC
+import qualified GHC.Types.SrcLoc as GHC
 import HIndent.Ast.Declaration.Warning.Kind
 import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments
@@ -20,7 +21,7 @@ import HIndent.Pretty.NodeComments
 data WarningDeclaration = WarningDeclaration
   { names :: [WithComments PrefixName]
   , kind :: Kind
-  , reasons :: [WithComments GHC.StringLiteral]
+  , reasons :: [GHC.StringLiteral]
   }
 
 instance CommentExtraction WarningDeclaration where
@@ -40,43 +41,43 @@ mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap (fromGenLocated . fmap GHC.hsDocString) rs
+    reasons = fmap (GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap (fromGenLocated . fmap GHC.hsDocString) rs
+    reasons = fmap (GHC.hsDocString . GHC.unLoc) rs
 #elif MIN_VERSION_ghc_lib_parser(9, 8, 1)
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap (fromGenLocated . fmap GHC.hsDocString) rs
+    reasons = fmap (GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap (fromGenLocated . fmap GHC.hsDocString) rs
+    reasons = fmap (GHC.hsDocString . GHC.unLoc) rs
 #elif MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap (fromGenLocated . fmap GHC.hsDocString) rs
+    reasons = fmap (GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap (fromGenLocated . fmap GHC.hsDocString) rs
+    reasons = fmap (GHC.hsDocString . GHC.unLoc) rs
 #else
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap fromGenLocated rs
+    reasons = fmap GHC.unLoc rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
     names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    reasons = fmap fromGenLocated rs
+    reasons = fmap GHC.unLoc rs
 #endif

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -7,6 +7,7 @@ module HIndent.Ast.Module.Warning
   ) where
 
 import qualified GHC.Types.SourceText as GHC
+import qualified GHC.Types.SrcLoc as GHC
 import HIndent.Ast.Declaration.Warning.Kind
 import HIndent.Ast.NodeComments
 import HIndent.Ast.WithComments
@@ -15,24 +16,19 @@ import qualified HIndent.GhcLibParserWrapper.GHC.Unit.Module.Warnings as GHC
 import HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
-#if !MIN_VERSION_ghc_lib_parser(9, 10, 0)
-import qualified GHC.Types.SrcLoc as GHC
-#endif
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 data ModuleWarning = ModuleWarning
-  { messages :: [GHC.LocatedE
-                   (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs)]
+  { messages :: [GHC.StringLiteral]
   , kind :: Kind
   }
 #elif MIN_VERSION_ghc_lib_parser(9, 4, 1)
 data ModuleWarning = ModuleWarning
-  { messages :: [GHC.Located
-                   (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs)]
+  { messages :: [GHC.StringLiteral]
   , kind :: Kind
   }
 #else
 data ModuleWarning = ModuleWarning
-  { messages :: [GHC.GenLocated GHC.SrcSpan GHC.StringLiteral]
+  { messages :: [GHC.StringLiteral]
   , kind :: Kind
   }
 #endif
@@ -54,20 +50,29 @@ mkModuleWarning =
 
 fromWarningTxt :: GHC.WarningTxt' -> ModuleWarning
 #if MIN_VERSION_ghc_lib_parser(9, 8, 1)
-fromWarningTxt (GHC.WarningTxt _ _ messages) = ModuleWarning {..}
+fromWarningTxt (GHC.WarningTxt _ _ warningMessages) = ModuleWarning {..}
   where
     kind = Warning
+    messages = fmap (GHC.hsDocString . GHC.unLoc) warningMessages
 #else
-fromWarningTxt (GHC.WarningTxt _ messages) = ModuleWarning {..}
+fromWarningTxt (GHC.WarningTxt _ warningMessages) = ModuleWarning {..}
   where
     kind = Warning
+    messages = fmap (GHC.hsDocString . GHC.unLoc) warningMessages
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
-fromWarningTxt (GHC.DeprecatedTxt _ messages) = ModuleWarning {..}
+fromWarningTxt (GHC.DeprecatedTxt _ warningMessages) = ModuleWarning {..}
   where
     kind = Deprecated
+    messages = fmap (GHC.hsDocString . GHC.unLoc) warningMessages
+#elif MIN_VERSION_ghc_lib_parser(9, 4, 1)
+fromWarningTxt (GHC.DeprecatedTxt _ warningMessages) = ModuleWarning {..}
+  where
+    kind = Deprecated
+    messages = fmap (GHC.hsDocString . GHC.unLoc) warningMessages
 #else
-fromWarningTxt (GHC.DeprecatedTxt _ messages) = ModuleWarning {..}
+fromWarningTxt (GHC.DeprecatedTxt _ warningMessages) = ModuleWarning {..}
   where
     kind = Deprecated
+    messages = fmap GHC.unLoc warningMessages
 #endif


### PR DESCRIPTION
### Description of the PR

Removes `fromGenLocated` as the generated `WithComments` always has no comments at all.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
