### PR TITLE
refactor: extract DoOrMdo and QualifiedDo modules

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -98,10 +98,12 @@ library
       HIndent.Ast.Declaration.Warning.Kind
       HIndent.Ast.Expression
       HIndent.Ast.Expression.Bracket
+      HIndent.Ast.Expression.DoOrMdo
       HIndent.Ast.Expression.FieldSelector
       HIndent.Ast.Expression.ListComprehension
       HIndent.Ast.Expression.OverloadedLabel
       HIndent.Ast.Expression.Pragmatic
+      HIndent.Ast.Expression.QualifiedDo
       HIndent.Ast.Expression.RangeExpression
       HIndent.Ast.Expression.RecordConstructionField
       HIndent.Ast.Expression.RecordUpdateField

--- a/src/HIndent/Ast/Expression.hs
+++ b/src/HIndent/Ast/Expression.hs
@@ -35,6 +35,7 @@ import HIndent.Ast.Expression.OverloadedLabel
   , mkOverloadedLabel
   )
 import HIndent.Ast.Expression.Pragmatic (ExpressionPragma, mkExpressionPragma)
+import HIndent.Ast.Expression.QualifiedDo (QualifiedDo, mkQualifiedDo)
 import HIndent.Ast.Expression.RangeExpression
   ( RangeExpression
   , mkRangeExpression
@@ -50,7 +51,6 @@ import HIndent.Ast.Expression.RecordUpdateField
 import HIndent.Ast.Guard (Guard, mkMultiWayIfExprGuard)
 import HIndent.Ast.LocalBinds (LocalBinds, mkLocalBinds)
 import HIndent.Ast.MatchGroup (MatchGroup, hasMatches, mkExprMatchGroup)
-import HIndent.Ast.Module.Name (mkModuleName)
 import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments (NodeComments(..))
 import HIndent.Ast.Pattern
@@ -65,7 +65,6 @@ import HIndent.CabalFile ()
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
-import HIndent.Pretty.Types (DoOrMdo(..), QualifiedDo(..))
 import HIndent.Printer
 import qualified Language.Haskell.Syntax.Basic as HS
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
@@ -554,16 +553,16 @@ mkExpression (GHC.HsDo _ GHC.MonadComp statements) =
   ListComprehension
     $ LC.mkListComprehension . fmap (fmap mkExprStatement . fromGenLocated)
         <$> fromGenLocated statements
-mkExpression (GHC.HsDo _ (GHC.DoExpr moduleName) statements) =
+mkExpression (GHC.HsDo _ stmtContext@(GHC.DoExpr _) statements) =
   DoBlock
-    { qualifiedDo = QualifiedDo (fmap mkModuleName moduleName) Do
+    { qualifiedDo = mkQualifiedDo stmtContext
     , statements =
         fmap (fmap mkExprStatement . fromGenLocated)
           <$> fromGenLocated statements
     }
-mkExpression (GHC.HsDo _ (GHC.MDoExpr moduleName) statements) =
+mkExpression (GHC.HsDo _ stmtContext@(GHC.MDoExpr _) statements) =
   DoBlock
-    { qualifiedDo = QualifiedDo (fmap mkModuleName moduleName) Mdo
+    { qualifiedDo = mkQualifiedDo stmtContext
     , statements =
         fmap (fmap mkExprStatement . fromGenLocated)
           <$> fromGenLocated statements

--- a/src/HIndent/Ast/Expression/DoOrMdo.hs
+++ b/src/HIndent/Ast/Expression/DoOrMdo.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module HIndent.Ast.Expression.DoOrMdo
+  ( DoOrMdo
+  , mkDoOrMdo
+  ) where
+
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import {-# SOURCE #-} HIndent.Pretty (Pretty(..))
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+
+data DoOrMdo
+  = Do
+  | Mdo
+
+instance CommentExtraction DoOrMdo where
+  nodeComments = const emptyNodeComments
+
+instance Pretty DoOrMdo where
+  pretty' Do = string "do"
+  pretty' Mdo = string "mdo"
+
+mkDoOrMdo :: GHC.HsDoFlavour -> DoOrMdo
+mkDoOrMdo (GHC.DoExpr _) = Do
+mkDoOrMdo (GHC.MDoExpr _) = Mdo
+mkDoOrMdo _ = error "`mkDoOrMdo` only supports `DoExpr` and `MDoExpr`."

--- a/src/HIndent/Ast/Expression/QualifiedDo.hs
+++ b/src/HIndent/Ast/Expression/QualifiedDo.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module HIndent.Ast.Expression.QualifiedDo
+  ( QualifiedDo
+  , mkQualifiedDo
+  ) where
+
+import HIndent.Ast.Expression.DoOrMdo (DoOrMdo, mkDoOrMdo)
+import HIndent.Ast.Module.Name (ModuleName, mkModuleName)
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+
+data QualifiedDo =
+  QualifiedDo (Maybe ModuleName) DoOrMdo
+
+instance CommentExtraction QualifiedDo where
+  nodeComments = const emptyNodeComments
+
+instance Pretty QualifiedDo where
+  pretty' (QualifiedDo (Just moduleName) doOrMdo) = do
+    pretty moduleName
+    string "."
+    pretty doOrMdo
+  pretty' (QualifiedDo Nothing doOrMdo) = pretty doOrMdo
+
+mkQualifiedDo :: GHC.HsDoFlavour -> QualifiedDo
+mkQualifiedDo stmtContext@(GHC.DoExpr moduleName) =
+  QualifiedDo (fmap mkModuleName moduleName) $ mkDoOrMdo stmtContext
+mkQualifiedDo stmtContext@(GHC.MDoExpr moduleName) =
+  QualifiedDo (fmap mkModuleName moduleName) $ mkDoOrMdo stmtContext
+mkQualifiedDo _ = error "`mkQualifiedDo` only supports `DoExpr` and `MDoExpr`."

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -403,17 +403,6 @@ prettyHsLit x =
             indentedWithSpace (-1)
               $ lined
               $ fmap (string . dropWhile (/= '\\')) ss
-
-instance Pretty DoOrMdo where
-  pretty' Do = string "do"
-  pretty' Mdo = string "mdo"
-
-instance Pretty QualifiedDo where
-  pretty' (QualifiedDo (Just m) d) = do
-    pretty m
-    string "."
-    pretty d
-  pretty' (QualifiedDo Nothing d) = pretty d
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty GHC.FieldLabelString where
   pretty' = output

--- a/src/HIndent/Pretty.hs-boot
+++ b/src/HIndent/Pretty.hs-boot
@@ -63,8 +63,6 @@ instance Pretty (GHC.HsLit GHC.GhcPs)
 
 instance Pretty (GHC.HsOverLit GHC.GhcPs)
 
-instance Pretty QualifiedDo
-
 instance Pretty
            (GHC.StmtLR
               GHC.GhcPs

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -42,12 +42,6 @@ instance CommentExtraction l => CommentExtraction (GenLocated l e) where
 instance CommentExtraction (MatchGroup GhcPs a) where
   nodeComments MG {} = emptyNodeComments
 
-instance CommentExtraction DoOrMdo where
-  nodeComments = const emptyNodeComments
-
-instance CommentExtraction QualifiedDo where
-  nodeComments = const emptyNodeComments
-
 instance CommentExtraction (HsSigType GhcPs) where
   nodeComments HsSig {} = emptyNodeComments
 

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -17,13 +17,10 @@ module HIndent.Pretty.Types
   , Context(..)
   , HorizontalContext(..)
   , VerticalContext(..)
-  , DoOrMdo(..)
-  , QualifiedDo(..)
   , DataFamInstDeclFor(..)
   ) where
 
 import GHC.Hs
-import {-# SOURCE #-} qualified HIndent.Ast.Module.Name as HIndent
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
 import GHC.Unit
 #endif
@@ -91,16 +88,6 @@ newtype HorizontalContext =
 newtype VerticalContext =
   VerticalContext (Maybe (LHsContext GhcPs))
 #endif
--- | Values indicating whether `do` or `mdo` is used.
-data DoOrMdo
-  = Do
-  | Mdo
-
--- | Values indicating whether the `do` is qualified with a module name (and
--- whether `do` or `mdo` is used)
-data QualifiedDo =
-  QualifiedDo (Maybe HIndent.ModuleName) DoOrMdo
-
 -- | Values indicating where a data family instance is declared.
 data DataFamInstDeclFor
   = DataFamInstDeclForTopLevel


### PR DESCRIPTION
### Description of the PR

Extracts `DoOrMdo` and `QualifiedDo` from `Types.hs` because we are going to remove that file.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
