### PR TITLE
build: require `criterion >= 1.6.5` for benchmarks

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -341,7 +341,7 @@ benchmark hindent-bench
     , base >=4.7 && <5
     , bytestring
     , containers
-    , criterion
+    , criterion >=1.6.5.0
     , deepseq
     , directory
     , exceptions

--- a/package.yaml
+++ b/package.yaml
@@ -84,7 +84,7 @@ benchmarks:
     main: Main.hs
     source-dirs: benchmarks
     dependencies:
-      - criterion
+      - criterion >= 1.6.5.0
       - deepseq
       - hindent
       - hindent-internal


### PR DESCRIPTION
### Description of the PR

Older versions no longer compile.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
