### PR TITLE
refactor: introduce comment group infrastructure

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -122,6 +122,7 @@ library
       HIndent.Ast.Import.Entry
       HIndent.Ast.Import.Entry.Collection
       HIndent.Ast.Import.ImportingOrHiding
+      HIndent.Ast.IsGenLocatedLocation
       HIndent.Ast.LocalBinds
       HIndent.Ast.LocalBinds.Declaration
       HIndent.Ast.LocalBinds.Declaration.Collection

--- a/src/HIndent/Ast/Comment.hs
+++ b/src/HIndent/Ast/Comment.hs
@@ -1,35 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module HIndent.Ast.Comment
   ( Comment
+  , getColumn
   , mkComment
+  , mkCommentFromToken
   ) where
 
+import qualified Data.Text as Text
 import qualified GHC.Hs as GHC
+import qualified GHC.Types.SrcLoc as GHC
+import HIndent.Ast.TextValue
+import qualified HIndent.GhcLibParserWrapper.GHC.Parser.Annotation as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments (CommentExtraction(..))
 
 data Comment
-  = Line String
-  | Block String
+  = Line
+      { text :: TextValue
+      , column :: Int
+      }
+  | Block
+      { text :: TextValue
+      , column :: Int
+      }
   deriving (Eq, Show)
 
 instance CommentExtraction Comment where
   nodeComments _ = mempty
 
 instance Pretty Comment where
-  pretty' (Line c) = string c
-  pretty' (Block c) =
-    case lines c of
+  pretty' Line {..} = pretty text
+  pretty' Block {..} =
+    case Text.lines $ toText text of
       [] -> pure ()
-      [x] -> string x
+      [x] -> string $ Text.unpack x
       (x:xs) -> do
-        string x
+        string $ Text.unpack x
         newline
         -- 'indentedWithFixedLevel 0' is used because a 'BlockComment'
         -- contains indent spaces for all lines except the first one.
-        indentedWithFixedLevel 0 $ lined $ fmap string xs
+        indentedWithFixedLevel 0 $ lined $ fmap (string . Text.unpack) xs
 
-mkComment :: GHC.EpaCommentTok -> Comment
-mkComment (GHC.EpaLineComment c) = Line c
-mkComment (GHC.EpaBlockComment c) = Block c
-mkComment _ = Line ""
+mkComment :: GHC.LEpaComment -> Comment
+mkComment comment@(GHC.L _ (GHC.EpaComment (GHC.EpaLineComment text) _)) =
+  Line {text = mkTextValueFromString text, column = getColumn' comment}
+mkComment comment@(GHC.L _ (GHC.EpaComment (GHC.EpaBlockComment text) _)) =
+  Block {text = mkTextValueFromString text, column = getColumn' comment}
+mkComment comment@(GHC.L _ _) =
+  Line {text = mkTextValueFromString "", column = getColumn' comment}
+
+mkCommentFromToken :: GHC.EpaCommentTok -> Comment
+mkCommentFromToken (GHC.EpaLineComment text) =
+  Line {text = mkTextValueFromString text, column = 0}
+mkCommentFromToken (GHC.EpaBlockComment text) =
+  Block {text = mkTextValueFromString text, column = 0}
+mkCommentFromToken _ = Line {text = mkTextValueFromString "", column = 0}
+
+getColumn :: Comment -> Int
+getColumn = column
+
+getColumn' :: GHC.LEpaComment -> Int
+getColumn' =
+  subtract 1 . GHC.srcSpanStartCol . GHC.epaLocationToRealSrcSpan . GHC.getLoc

--- a/src/HIndent/Ast/Expression/Pragmatic.hs
+++ b/src/HIndent/Ast/Expression/Pragmatic.hs
@@ -10,6 +10,7 @@ import qualified GHC.Hs as GHC
 import HIndent.Ast.NodeComments (NodeComments(..))
 import HIndent.Ast.TextValue
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+import HIndent.Ast.IsGenLocatedLocation (fromNodeComments)
 import HIndent.Ast.WithComments (WithComments, addComments, mkWithComments)
 #else
 import HIndent.Ast.WithComments (WithComments, fromEpAnn)
@@ -31,7 +32,7 @@ instance Pretty ExpressionPragma where
 mkExpressionPragma :: GHC.HsPragE GHC.GhcPs -> WithComments ExpressionPragma
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExpressionPragma (GHC.HsPragSCC (ann, _) literal) =
-  addComments (nodeComments ann)
+  addComments (fromNodeComments $ nodeComments ann)
     $ mkWithComments SccPragma {label = mkTextValueFromStringLiteral literal}
 #elif MIN_VERSION_ghc_lib_parser(9, 8, 1)
 mkExpressionPragma (GHC.HsPragSCC (ann, _) literal) =

--- a/src/HIndent/Ast/IsGenLocatedLocation.hs
+++ b/src/HIndent/Ast/IsGenLocatedLocation.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+-- | Build 'CommentGroup' values from types that can appear in the
+-- location slot of 'GHC.GenLocated'.
+module HIndent.Ast.IsGenLocatedLocation
+  ( CommentGroup(..)
+  , IsGenLocatedLocation(..)
+  , fromNodeComments
+  , mkCommentGroupFromEpAnn
+  , mkCommentGroupFromEpaLocation
+  ) where
+
+import qualified GHC.Types.SrcLoc as GHC
+import HIndent.Ast.Comment (Comment, mkComment)
+import qualified HIndent.Ast.NodeComments as NodeComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import HIndent.Pragma
+
+data CommentGroup = CommentGroup
+  { commentsBefore :: [Comment]
+  , commentsOnSameLine :: [Comment]
+  , commentsAfter :: [Comment]
+  } deriving (Eq)
+
+class IsGenLocatedLocation a where
+  mkCommentGroupFromGenLocatedLocation :: a -> CommentGroup
+
+instance Semigroup CommentGroup where
+  CommentGroup beforeX sameLineX afterX <> CommentGroup beforeY sameLineY afterY =
+    CommentGroup
+      { commentsBefore = beforeX <> beforeY
+      , commentsOnSameLine = sameLineX <> sameLineY
+      , commentsAfter = afterX <> afterY
+      }
+
+instance Monoid CommentGroup where
+  mempty =
+    CommentGroup
+      {commentsBefore = [], commentsOnSameLine = [], commentsAfter = []}
+
+instance IsGenLocatedLocation GHC.EpAnnComments where
+  mkCommentGroupFromGenLocatedLocation = mkCommentGroupFromEpAnnComments
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+instance IsGenLocatedLocation (GHC.EpAnn ann) where
+  mkCommentGroupFromGenLocatedLocation = mkCommentGroupFromEpAnn
+#endif
+instance IsGenLocatedLocation GHC.SrcSpan where
+  mkCommentGroupFromGenLocatedLocation _ = mempty
+
+instance IsGenLocatedLocation GHC.NoEpAnns where
+  mkCommentGroupFromGenLocatedLocation _ = mempty
+
+fromNodeComments :: NodeComments.NodeComments -> CommentGroup
+fromNodeComments (NodeComments.NodeComments before sameLine after) =
+  CommentGroup
+    { commentsBefore = mkComment <$> before
+    , commentsOnSameLine = mkComment <$> sameLine
+    , commentsAfter = mkComment <$> after
+    }
+
+mkCommentGroupFromEpAnn :: GHC.EpAnn a -> CommentGroup
+mkCommentGroupFromEpAnn =
+  mkCommentGroupFromEpAnn' . filterOutEofAndPragmasFromAnn
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+mkCommentGroupFromEpaLocation :: GHC.EpaLocation -> CommentGroup
+mkCommentGroupFromEpaLocation GHC.EpaSpan {} = mempty
+#if MIN_VERSION_ghc_lib_parser(9, 12, 1)
+mkCommentGroupFromEpaLocation (GHC.EpaDelta _ _ trailing) =
+  foldMap mkCommentGroupFromTrailingComment trailing
+#else
+mkCommentGroupFromEpaLocation (GHC.EpaDelta _ trailing) =
+  foldMap mkCommentGroupFromTrailingComment trailing
+#endif
+#else
+mkCommentGroupFromEpaLocation :: GHC.Anchor -> CommentGroup
+mkCommentGroupFromEpaLocation _ = mempty
+#endif
+mkCommentGroupFromEpAnnComments :: GHC.EpAnnComments -> CommentGroup
+mkCommentGroupFromEpAnnComments comments = CommentGroup {..}
+  where
+    commentsBefore = mkComment <$> GHC.priorComments filteredComments
+    commentsOnSameLine = []
+    commentsAfter = mkComment <$> GHC.getFollowingComments filteredComments
+    filteredComments = filterOutEofAndPragmasFromComments comments
+
+filterOutEofAndPragmasFromAnn :: GHC.EpAnn ann -> GHC.EpAnn ann
+filterOutEofAndPragmasFromAnn GHC.EpAnn {..} =
+  GHC.EpAnn {comments = filterOutEofAndPragmasFromComments comments, ..}
+#if !MIN_VERSION_ghc_lib_parser(9, 10, 1)
+filterOutEofAndPragmasFromAnn GHC.EpAnnNotUsed = GHC.EpAnnNotUsed
+#endif
+mkCommentGroupFromEpAnn' :: GHC.EpAnn a -> CommentGroup
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+mkCommentGroupFromEpAnn' GHC.EpAnn {..} =
+  mkCommentGroupFromEntry entry <> CommentGroup {..}
+  where
+    commentsBefore = mkComment <$> GHC.priorComments comments
+    commentsOnSameLine =
+      fmap mkComment
+        $ filter isCommentOnSameLine
+        $ GHC.getFollowingComments comments
+    commentsAfter =
+      fmap mkComment
+        $ filter (not . isCommentOnSameLine)
+        $ GHC.getFollowingComments comments
+    isCommentOnSameLine (GHC.L commentLoc _) =
+      GHC.srcSpanEndLine (epaLocationToRealSrcSpan entry)
+        == GHC.srcSpanStartLine (epaLocationToRealSrcSpan commentLoc)
+#else
+mkCommentGroupFromEpAnn' GHC.EpAnn {..} =
+  mkCommentGroupFromEntry entry <> CommentGroup {..}
+  where
+    commentsBefore = mkComment <$> GHC.priorComments comments
+    commentsOnSameLine =
+      fmap mkComment
+        $ filter isCommentOnSameLine
+        $ GHC.getFollowingComments comments
+    commentsAfter =
+      fmap mkComment
+        $ filter (not . isCommentOnSameLine)
+        $ GHC.getFollowingComments comments
+    isCommentOnSameLine (GHC.L commentLoc _) =
+      GHC.srcSpanEndLine (epaLocationToRealSrcSpan entry)
+        == GHC.srcSpanStartLine (epaLocationToRealSrcSpan commentLoc)
+mkCommentGroupFromEpAnn' GHC.EpAnnNotUsed = mempty
+#endif
+filterOutEofAndPragmasFromComments :: GHC.EpAnnComments -> GHC.EpAnnComments
+filterOutEofAndPragmasFromComments comments =
+  GHC.EpaCommentsBalanced
+    { priorComments = filterOutEofAndPragmas $ GHC.priorComments comments
+    , followingComments =
+        filterOutEofAndPragmas $ GHC.getFollowingComments comments
+    }
+
+filterOutEofAndPragmas ::
+     [GHC.GenLocated l GHC.EpaComment] -> [GHC.GenLocated l GHC.EpaComment]
+filterOutEofAndPragmas = filter isNeitherEofNorPragmaComment
+
+isNeitherEofNorPragmaComment :: GHC.GenLocated l GHC.EpaComment -> Bool
+#if !MIN_VERSION_ghc_lib_parser(9, 10, 1)
+isNeitherEofNorPragmaComment (GHC.L _ (GHC.EpaComment GHC.EpaEofComment _)) =
+  False
+#endif
+isNeitherEofNorPragmaComment (GHC.L _ (GHC.EpaComment token _)) =
+  not $ isPragma token
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+mkCommentGroupFromTrailingComment :: GHC.LEpaComment -> CommentGroup
+mkCommentGroupFromTrailingComment comment =
+  mempty {commentsAfter = [mkComment comment]}
+#endif
+
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+mkCommentGroupFromEntry :: GHC.EpaLocation -> CommentGroup
+#else
+mkCommentGroupFromEntry :: GHC.Anchor -> CommentGroup
+#endif
+mkCommentGroupFromEntry = mkCommentGroupFromEpaLocation
+#if MIN_VERSION_ghc_lib_parser(9, 12, 1)
+epaLocationToRealSrcSpan :: GHC.EpaLocation' a -> GHC.RealSrcSpan
+epaLocationToRealSrcSpan = GHC.epaLocationRealSrcSpan
+#elif MIN_VERSION_ghc_lib_parser(9, 10, 1)
+epaLocationToRealSrcSpan :: GHC.EpaLocation' a -> GHC.RealSrcSpan
+epaLocationToRealSrcSpan = GHC.anchor
+#else
+epaLocationToRealSrcSpan :: GHC.Anchor -> GHC.RealSrcSpan
+epaLocationToRealSrcSpan = GHC.anchor
+#endif

--- a/src/HIndent/Ast/MatchGroup.hs
+++ b/src/HIndent/Ast/MatchGroup.hs
@@ -10,7 +10,6 @@ import HIndent.Ast.Match (Match, mkCmdMatch, mkExprMatch)
 import HIndent.Ast.WithComments
   ( WithComments
   , fromGenLocated
-  , getComments
   , getNode
   , prettyWith
   )
@@ -22,7 +21,7 @@ newtype MatchGroup =
   MatchGroup (WithComments [WithComments Match])
 
 instance CommentExtraction MatchGroup where
-  nodeComments (MatchGroup alts) = getComments alts
+  nodeComments _ = mempty
 
 instance Pretty MatchGroup where
   pretty' (MatchGroup alts) = prettyWith alts (lined . fmap pretty)

--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -19,15 +19,19 @@ import Control.Monad
 import Control.Monad.RWS
 import qualified GHC.Hs as GHC
 import qualified GHC.Types.SrcLoc as GHC
-import HIndent.Ast.NodeComments (NodeComments(..))
-import qualified HIndent.Ast.NodeComments as NodeComments
+import HIndent.Ast.Comment (Comment, getColumn)
+import HIndent.Ast.IsGenLocatedLocation
+  ( CommentGroup(..)
+  , fromNodeComments
+  , mkCommentGroupFromEpAnn
+  )
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
 import HIndent.Printer
 
 data WithComments a = WithComments
-  { comments :: NodeComments
+  { comments :: CommentGroup
   , node :: a
   } deriving (Foldable, Traversable, Eq)
 
@@ -35,10 +39,10 @@ instance Functor WithComments where
   fmap f WithComments {..} = WithComments comments (f node)
 
 instance CommentExtraction (WithComments a) where
-  nodeComments WithComments {..} = comments
+  nodeComments _ = mempty
 
 instance (Pretty a) => Pretty (WithComments a) where
-  pretty' WithComments {..} = pretty' node
+  pretty' withComments = prettyWith withComments pretty
 
 -- | Prints comments included in the location information and then the
 -- AST node body.
@@ -50,84 +54,44 @@ prettyWith WithComments {..} f = do
   printCommentsAfter comments
 
 -- | Prints comments that are before the given AST node.
-printCommentsBefore :: NodeComments -> Printer ()
-#if MIN_VERSION_ghc_lib_parser(9, 12, 1)
+printCommentsBefore :: CommentGroup -> Printer ()
 printCommentsBefore p =
-  forM_ (commentsBefore p) $ \(GHC.L loc c) -> do
-    let col =
-          fromIntegral
-            $ GHC.srcSpanStartCol (GHC.epaLocationRealSrcSpan loc) - 1
-    indentedWithFixedLevel col $ pretty c
+  forM_ (commentsBefore p) $ \comment -> do
+    indentedWithFixedLevel (fromIntegral $ getCommentColumn comment)
+      $ pretty comment
     newline
-#else
-printCommentsBefore p =
-  forM_ (commentsBefore p) $ \(GHC.L loc c) -> do
-    let col = fromIntegral $ GHC.srcSpanStartCol (GHC.anchor loc) - 1
-    indentedWithFixedLevel col $ pretty c
-    newline
-#endif
+
 -- | Prints comments that are on the same line as the given AST node.
-printCommentOnSameLine :: NodeComments -> Printer ()
-#if MIN_VERSION_ghc_lib_parser(9, 12, 1)
+printCommentOnSameLine :: CommentGroup -> Printer ()
 printCommentOnSameLine (commentsOnSameLine -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
-    then indentedWithFixedLevel
-           (fromIntegral
-              $ GHC.srcSpanStartCol
-              $ GHC.epaLocationRealSrcSpan
-              $ GHC.getLoc c)
+    then indentedWithFixedLevel (fromIntegral $ getCommentColumn c)
            $ spaced
            $ fmap pretty
            $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
-#else
-printCommentOnSameLine (commentsOnSameLine -> (c:cs)) = do
-  col <- gets psColumn
-  if col == 0
-    then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ GHC.anchor $ GHC.getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
-    else spacePrefixed $ fmap pretty $ c : cs
-  eolCommentsArePrinted
-#endif
 printCommentOnSameLine _ = return ()
 
 -- | Prints comments that are after the given AST node.
-printCommentsAfter :: NodeComments -> Printer ()
-#if MIN_VERSION_ghc_lib_parser(9, 12, 1)
+printCommentsAfter :: CommentGroup -> Printer ()
 printCommentsAfter p =
   case commentsAfter p of
     [] -> return ()
     xs -> do
       isThereCommentsOnSameLine <- gets psEolComment
       unless isThereCommentsOnSameLine newline
-      forM_ xs $ \(GHC.L loc c) -> do
-        let col =
-              fromIntegral
-                $ GHC.srcSpanStartCol (GHC.epaLocationRealSrcSpan loc) - 1
-        indentedWithFixedLevel col $ pretty c
+      forM_ xs $ \comment -> do
+        indentedWithFixedLevel (fromIntegral $ getCommentColumn comment)
+          $ pretty comment
         eolCommentsArePrinted
-#else
-printCommentsAfter p =
-  case commentsAfter p of
-    [] -> return ()
-    xs -> do
-      isThereCommentsOnSameLine <- gets psEolComment
-      unless isThereCommentsOnSameLine newline
-      forM_ xs $ \(GHC.L loc c) -> do
-        let col = fromIntegral $ GHC.srcSpanStartCol (GHC.anchor loc) - 1
-        indentedWithFixedLevel col $ pretty c
-        eolCommentsArePrinted
-#endif
+
 fromGenLocated :: (CommentExtraction l) => GHC.GenLocated l a -> WithComments a
-fromGenLocated (GHC.L l a) = WithComments (nodeComments l) a
+fromGenLocated (GHC.L l a) = WithComments (fromNodeComments $ nodeComments l) a
 
 fromEpAnn :: GHC.EpAnn a -> b -> WithComments b
-fromEpAnn ann = WithComments (NodeComments.fromEpAnn ann)
+fromEpAnn ann = WithComments (mkCommentGroupFromEpAnn ann)
 
 mkWithComments :: a -> WithComments a
 mkWithComments = WithComments mempty
@@ -135,13 +99,16 @@ mkWithComments = WithComments mempty
 getNode :: WithComments a -> a
 getNode = node
 
-getComments :: WithComments a -> NodeComments
+getComments :: WithComments a -> CommentGroup
 getComments = comments
 
 flattenComments :: WithComments (WithComments a) -> WithComments a
 flattenComments (WithComments outerComments (WithComments innerComments node)) =
   WithComments (outerComments <> innerComments) node
 
-addComments :: NodeComments -> WithComments a -> WithComments a
+addComments :: CommentGroup -> WithComments a -> WithComments a
 addComments extra (WithComments current node) =
   WithComments (extra <> current) node
+
+getCommentColumn :: Comment -> Int
+getCommentColumn = getColumn

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -28,7 +28,7 @@ import GHC.Stack
 import qualified GHC.Types.SourceText as GHC
 import qualified GHC.Types.SrcLoc as GHC
 import HIndent.Applicative (whenJust)
-import HIndent.Ast.Comment (mkComment)
+import HIndent.Ast.Comment (mkCommentFromToken)
 import HIndent.Ast.Declaration.Bind
 import HIndent.Ast.Declaration.Data.Body
 import HIndent.Ast.Declaration.Family.Data
@@ -188,7 +188,7 @@ instance Pretty SBF.SigBindFamily where
   pretty' (SBF.DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty GHC.EpaComment where
-  pretty' GHC.EpaComment {..} = pretty $ mkComment ac_tok
+  pretty' GHC.EpaComment {..} = pretty $ mkCommentFromToken ac_tok
 #if !MIN_VERSION_ghc_lib_parser(9, 14, 0)
 instance Pretty
            (GHC.HsScaled


### PR DESCRIPTION
### Description of the PR

Introduces `CommentGroup` to represent comments without using GHC's AST node types.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
