### PR TITLE
refactor: migrate GenLocated comment extraction

### DIFF
--- a/src/HIndent/Ast/Cmd.hs
+++ b/src/HIndent/Ast/Cmd.hs
@@ -18,7 +18,7 @@ import HIndent.Ast.Statement (CmdStatement, mkCmdStatement)
 import HIndent.Ast.WithComments
   ( WithComments
   , flattenComments
-  , fromGenLocated
+  , mkWithCommentsFromGenLocated
   , prettyWith
   )
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
@@ -134,28 +134,36 @@ mkCmd (GHC.HsCmdArrApp _ f arg appKind isFwd) =
         if isFwd
           then FunctionThenArgument
           else ArgumentThenFunction
-    , function = mkExpression <$> fromGenLocated f
-    , argument = mkExpression <$> fromGenLocated arg
+    , function = mkExpression <$> mkWithCommentsFromGenLocated f
+    , argument = mkExpression <$> mkWithCommentsFromGenLocated arg
     }
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkCmd (GHC.HsCmdArrForm _ f _ args) =
   ArrowForm
-    { function = mkExpression <$> fromGenLocated f
+    { function = mkExpression <$> mkWithCommentsFromGenLocated f
     , arguments =
-        fmap (flattenComments . fmap mkCmdFromHsCmdTop . fromGenLocated) args
+        fmap
+          (flattenComments
+             . fmap mkCmdFromHsCmdTop
+             . mkWithCommentsFromGenLocated)
+          args
     }
 #else
 mkCmd (GHC.HsCmdArrForm _ f _ _ args) =
   ArrowForm
-    { function = mkExpression <$> fromGenLocated f
+    { function = mkExpression <$> mkWithCommentsFromGenLocated f
     , arguments =
-        fmap (flattenComments . fmap mkCmdFromHsCmdTop . fromGenLocated) args
+        fmap
+          (flattenComments
+             . fmap mkCmdFromHsCmdTop
+             . mkWithCommentsFromGenLocated)
+          args
     }
 #endif
 mkCmd (GHC.HsCmdApp _ cmd arg) =
   CmdApp
-    { cmd = mkCmd <$> fromGenLocated cmd
-    , argument = mkExpression <$> fromGenLocated arg
+    { cmd = mkCmd <$> mkWithCommentsFromGenLocated cmd
+    , argument = mkExpression <$> mkWithCommentsFromGenLocated arg
     }
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkCmd (GHC.HsCmdLam _ GHC.LamSingle matches) =
@@ -168,13 +176,15 @@ mkCmd (GHC.HsCmdLam _ GHC.LamCases matches) =
 mkCmd (GHC.HsCmdLam _ matches) = Lambda {matches = mkCmdMatchGroup matches}
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1) && !MIN_VERSION_ghc_lib_parser(9, 10, 1)
-mkCmd (GHC.HsCmdPar _ _ cmd _) = Parenthesized $ mkCmd <$> fromGenLocated cmd
+mkCmd (GHC.HsCmdPar _ _ cmd _) =
+  Parenthesized $ mkCmd <$> mkWithCommentsFromGenLocated cmd
 #else
-mkCmd (GHC.HsCmdPar _ cmd) = Parenthesized $ mkCmd <$> fromGenLocated cmd
+mkCmd (GHC.HsCmdPar _ cmd) =
+  Parenthesized $ mkCmd <$> mkWithCommentsFromGenLocated cmd
 #endif
 mkCmd (GHC.HsCmdCase _ expr matches) =
   Case
-    { scrutinee = mkExpression <$> fromGenLocated expr
+    { scrutinee = mkExpression <$> mkWithCommentsFromGenLocated expr
     , matches = mkCmdMatchGroup matches
     }
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1) && !MIN_VERSION_ghc_lib_parser(9, 10, 1)
@@ -186,9 +196,9 @@ mkCmd (GHC.HsCmdLamCase _ matches) =
 #endif
 mkCmd (GHC.HsCmdIf _ _ predicate thenCmd elseCmd) =
   If
-    { predicate = mkExpression <$> fromGenLocated predicate
-    , thenBranch = mkCmd <$> fromGenLocated thenCmd
-    , elseBranch = mkCmd <$> fromGenLocated elseCmd
+    { predicate = mkExpression <$> mkWithCommentsFromGenLocated predicate
+    , thenBranch = mkCmd <$> mkWithCommentsFromGenLocated thenCmd
+    , elseBranch = mkCmd <$> mkWithCommentsFromGenLocated elseCmd
     }
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1) && !MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkCmd (GHC.HsCmdLet _ _ binds _ cmd) =
@@ -197,7 +207,7 @@ mkCmd (GHC.HsCmdLet _ _ binds _ cmd) =
         fromMaybe
           (error "`ghc-lib-parser` never generates an empty `HsCmdLet` node.")
           $ mkLocalBinds binds
-    , inCommand = mkCmd <$> fromGenLocated cmd
+    , inCommand = mkCmd <$> mkWithCommentsFromGenLocated cmd
     }
 #else
 mkCmd (GHC.HsCmdLet _ binds cmd) =
@@ -206,17 +216,19 @@ mkCmd (GHC.HsCmdLet _ binds cmd) =
         fromMaybe
           (error "`ghc-lib-parser` never generates an empty `HsCmdLet` node.")
           $ mkLocalBinds binds
-    , inCommand = mkCmd <$> fromGenLocated cmd
+    , inCommand = mkCmd <$> mkWithCommentsFromGenLocated cmd
     }
 #endif
 mkCmd (GHC.HsCmdDo _ stmts) =
   DoBlock
     { statements =
-        fmap (fmap mkCmdStatement . fromGenLocated) <$> fromGenLocated stmts
+        fmap (fmap mkCmdStatement . mkWithCommentsFromGenLocated)
+          <$> mkWithCommentsFromGenLocated stmts
     }
 
 mkCmdFromHsCmdTop :: GHC.HsCmdTop GHC.GhcPs -> WithComments Cmd
-mkCmdFromHsCmdTop (GHC.HsCmdTop _ cmd) = mkCmd <$> fromGenLocated cmd
+mkCmdFromHsCmdTop (GHC.HsCmdTop _ cmd) =
+  mkCmd <$> mkWithCommentsFromGenLocated cmd
 
 newtype CmdDoBlock =
   CmdDoBlock Cmd

--- a/src/HIndent/Ast/Context.hs
+++ b/src/HIndent/Ast/Context.hs
@@ -35,4 +35,4 @@ instance Pretty Context where
           _ -> vTuple $ fmap pretty xs
 
 mkContext :: GHC.HsContext GHC.GhcPs -> Context
-mkContext = Context . fmap (fmap mkType . fromGenLocated)
+mkContext = Context . fmap (fmap mkType . mkWithCommentsFromGenLocated)

--- a/src/HIndent/Ast/Declaration/Annotation.hs
+++ b/src/HIndent/Ast/Declaration/Annotation.hs
@@ -32,10 +32,10 @@ mkAnnotation :: GHC.AnnDecl GHC.GhcPs -> Annotation
 mkAnnotation (GHC.HsAnnotation _ prov expression) = Annotation {..}
   where
     provenance = mkProvenance prov
-    expr = mkExpression <$> fromGenLocated expression
+    expr = mkExpression <$> mkWithCommentsFromGenLocated expression
 #else
 mkAnnotation (GHC.HsAnnotation _ _ prov expression) = Annotation {..}
   where
     provenance = mkProvenance prov
-    expr = mkExpression <$> fromGenLocated expression
+    expr = mkExpression <$> mkWithCommentsFromGenLocated expression
 #endif

--- a/src/HIndent/Ast/Declaration/Annotation/Provenance.hs
+++ b/src/HIndent/Ast/Declaration/Annotation/Provenance.hs
@@ -28,7 +28,7 @@ instance Pretty Provenance where
 
 mkProvenance :: GHC.AnnProvenance GHC.GhcPs -> Provenance
 mkProvenance (GHC.ValueAnnProvenance x) =
-  Value $ fromGenLocated $ fmap mkPrefixName x
+  Value $ mkWithCommentsFromGenLocated $ fmap mkPrefixName x
 mkProvenance (GHC.TypeAnnProvenance x) =
-  Type $ fromGenLocated $ fmap mkPrefixName x
+  Type $ mkWithCommentsFromGenLocated $ fmap mkPrefixName x
 mkProvenance GHC.ModuleAnnProvenance = Module

--- a/src/HIndent/Ast/Declaration/Annotation/Role.hs
+++ b/src/HIndent/Ast/Declaration/Annotation/Role.hs
@@ -31,5 +31,5 @@ instance Pretty RoleAnnotation where
 mkRoleAnnotation :: GHC.RoleAnnotDecl GHC.GhcPs -> RoleAnnotation
 mkRoleAnnotation (GHC.RoleAnnotDecl _ nm rs) = RoleAnnotation {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName nm
-    roles = fmap (fmap (fmap mkRole) . fromGenLocated) rs
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName nm
+    roles = fmap (fmap (fmap mkRole) . mkWithCommentsFromGenLocated) rs

--- a/src/HIndent/Ast/Declaration/Bind.hs
+++ b/src/HIndent/Ast/Declaration/Bind.hs
@@ -42,7 +42,7 @@ mkBind :: GHC.HsBind GHC.GhcPs -> Bind
 mkBind GHC.FunBind {..} = Function $ mkExprMatchGroup fun_matches
 mkBind GHC.PatBind {..} = Pattern {..}
   where
-    lhs = mkPattern <$> fromGenLocated pat_lhs
+    lhs = mkPattern <$> mkWithCommentsFromGenLocated pat_lhs
     rhs = mkWithComments $ mkGuardedRhs pat_rhs
 mkBind (GHC.PatSynBind _ psb) =
   PatternSynonym $ mkWithComments $ mkPatternSynonym psb

--- a/src/HIndent/Ast/Declaration/Bind/GuardedRhs.hs
+++ b/src/HIndent/Ast/Declaration/Bind/GuardedRhs.hs
@@ -25,7 +25,11 @@ import HIndent.Ast.Guard
   )
 import HIndent.Ast.NodeComments (NodeComments(..))
 import HIndent.Ast.WhereClause (WhereClause, mkWhereClause)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated, prettyWith)
+import HIndent.Ast.WithComments
+  ( WithComments
+  , mkWithCommentsFromGenLocated
+  , prettyWith
+  )
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
@@ -48,14 +52,20 @@ instance Pretty GuardedRhs where
 mkGuardedRhs :: GHC.GRHSs GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> GuardedRhs
 mkGuardedRhs grhss@GHC.GRHSs {..} =
   GuardedRhs
-    { guards = fmap (fmap mkExprGuard . fromGenLocated) (toList grhssGRHSs)
+    { guards =
+        fmap
+          (fmap mkExprGuard . mkWithCommentsFromGenLocated)
+          (toList grhssGRHSs)
     , whereClause = mkWhereClause grhss
     }
 
 mkCaseGuardedRhs :: GHC.GRHSs GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> GuardedRhs
 mkCaseGuardedRhs grhss@GHC.GRHSs {..} =
   GuardedRhs
-    { guards = fmap (fmap mkCaseExprGuard . fromGenLocated) (toList grhssGRHSs)
+    { guards =
+        fmap
+          (fmap mkCaseExprGuard . mkWithCommentsFromGenLocated)
+          (toList grhssGRHSs)
     , whereClause = mkWhereClause grhss
     }
 
@@ -63,7 +73,9 @@ mkLambdaGuardedRhs :: GHC.GRHSs GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> GuardedRhs
 mkLambdaGuardedRhs grhss@GHC.GRHSs {..} =
   GuardedRhs
     { guards =
-        fmap (fmap mkLambdaExprGuard . fromGenLocated) (toList grhssGRHSs)
+        fmap
+          (fmap mkLambdaExprGuard . mkWithCommentsFromGenLocated)
+          (toList grhssGRHSs)
     , whereClause = mkWhereClause grhss
     }
 
@@ -72,14 +84,19 @@ mkMultiWayIfGuardedRhs ::
 mkMultiWayIfGuardedRhs grhss@GHC.GRHSs {..} =
   GuardedRhs
     { guards =
-        fmap (fmap mkMultiWayIfExprGuard . fromGenLocated) (toList grhssGRHSs)
+        fmap
+          (fmap mkMultiWayIfExprGuard . mkWithCommentsFromGenLocated)
+          (toList grhssGRHSs)
     , whereClause = mkWhereClause grhss
     }
 
 mkCaseCmdGuardedRhs :: GHC.GRHSs GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> GuardedRhs
 mkCaseCmdGuardedRhs grhss@GHC.GRHSs {..} =
   GuardedRhs
-    { guards = fmap (fmap mkCaseCmdGuard . fromGenLocated) (toList grhssGRHSs)
+    { guards =
+        fmap
+          (fmap mkCaseCmdGuard . mkWithCommentsFromGenLocated)
+          (toList grhssGRHSs)
     , whereClause = mkWhereClause grhss
     }
 
@@ -87,6 +104,9 @@ mkLambdaCmdGuardedRhs ::
      GHC.GRHSs GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> GuardedRhs
 mkLambdaCmdGuardedRhs grhss@GHC.GRHSs {..} =
   GuardedRhs
-    { guards = fmap (fmap mkLambdaCmdGuard . fromGenLocated) (toList grhssGRHSs)
+    { guards =
+        fmap
+          (fmap mkLambdaCmdGuard . mkWithCommentsFromGenLocated)
+          (toList grhssGRHSs)
     , whereClause = mkWhereClause grhss
     }

--- a/src/HIndent/Ast/Declaration/Class.hs
+++ b/src/HIndent/Ast/Declaration/Class.hs
@@ -61,18 +61,18 @@ mkClassDeclaration x@GHC.ClassDecl {..}
   | Just nameAndTypeVariables <- mkNameAndTypeVariables x =
     Just ClassDeclaration {..}
   where
-    context = fmap (fmap mkContext . fromGenLocated) tcdCtxt
+    context = fmap (fmap mkContext . mkWithCommentsFromGenLocated) tcdCtxt
     functionalDependencies =
-      fmap (fmap mkFunctionalDependency . fromGenLocated) tcdFDs
+      fmap (fmap mkFunctionalDependency . mkWithCommentsFromGenLocated) tcdFDs
     body = mkClassBody tcdSigs tcdMeths tcdATs tcdATDefs
 #else
 mkClassDeclaration x@GHC.ClassDecl {..}
   | Just nameAndTypeVariables <- mkNameAndTypeVariables x =
     Just ClassDeclaration {..}
   where
-    context = fmap (fmap mkContext . fromGenLocated) tcdCtxt
+    context = fmap (fmap mkContext . mkWithCommentsFromGenLocated) tcdCtxt
     functionalDependencies =
-      fmap (fmap mkFunctionalDependency . fromGenLocated) tcdFDs
+      fmap (fmap mkFunctionalDependency . mkWithCommentsFromGenLocated) tcdFDs
     body = mkClassBody tcdSigs (GHC.bagToList tcdMeths) tcdATs tcdATDefs
 #endif
 mkClassDeclaration _ = Nothing

--- a/src/HIndent/Ast/Declaration/Class/Body.hs
+++ b/src/HIndent/Ast/Declaration/Class/Body.hs
@@ -43,5 +43,5 @@ hasClassBody (ClassBody members) = not $ null members
 
 sortMembers :: [GHC.LocatedA ClassMember] -> [WithComments ClassMember]
 sortMembers =
-  fmap fromGenLocated
+  fmap mkWithCommentsFromGenLocated
     . sortBy (compare `on` GHC.realSrcSpan . GHC.locA . GHC.getLoc)

--- a/src/HIndent/Ast/Declaration/Class/FunctionalDependency.hs
+++ b/src/HIndent/Ast/Declaration/Class/FunctionalDependency.hs
@@ -28,5 +28,5 @@ instance Pretty FunctionalDependency where
 mkFunctionalDependency :: GHC.FunDep GHC.GhcPs -> FunctionalDependency
 mkFunctionalDependency (GHC.FunDep _ f t) = FunctionalDependency {..}
   where
-    from = fmap (fromGenLocated . fmap mkPrefixName) f
-    to = fmap (fromGenLocated . fmap mkPrefixName) t
+    from = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) f
+    to = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) t

--- a/src/HIndent/Ast/Declaration/Class/NameAndTypeVariables.hs
+++ b/src/HIndent/Ast/Declaration/Class/NameAndTypeVariables.hs
@@ -42,16 +42,17 @@ mkNameAndTypeVariables :: GHC.TyClDecl GHC.GhcPs -> Maybe NameAndTypeVariables
 mkNameAndTypeVariables GHC.ClassDecl {tcdFixity = GHC.Prefix, ..} =
   Just Prefix {..}
   where
-    pName = fromGenLocated $ fmap mkPrefixName tcdLName
+    pName = mkWithCommentsFromGenLocated $ fmap mkPrefixName tcdLName
     typeVariables =
-      fmap mkTypeVariable . fromGenLocated <$> GHC.hsq_explicit tcdTyVars
+      fmap mkTypeVariable . mkWithCommentsFromGenLocated
+        <$> GHC.hsq_explicit tcdTyVars
 mkNameAndTypeVariables GHC.ClassDecl { tcdFixity = GHC.Infix
                                      , tcdTyVars = GHC.HsQTvs {hsq_explicit = h:t:xs}
                                      , ..
                                      } = Just Infix {..}
   where
-    left = mkTypeVariable <$> fromGenLocated h
-    iName = fromGenLocated $ fmap mkInfixName tcdLName
-    right = mkTypeVariable <$> fromGenLocated t
-    remains = fmap (fmap mkTypeVariable . fromGenLocated) xs
+    left = mkTypeVariable <$> mkWithCommentsFromGenLocated h
+    iName = mkWithCommentsFromGenLocated $ fmap mkInfixName tcdLName
+    right = mkTypeVariable <$> mkWithCommentsFromGenLocated t
+    remains = fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated) xs
 mkNameAndTypeVariables _ = Nothing

--- a/src/HIndent/Ast/Declaration/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Collection.hs
@@ -37,7 +37,8 @@ instance Pretty DeclarationCollection where
 
 mkDeclarationCollection :: GHC.HsModule' -> DeclarationCollection
 mkDeclarationCollection GHC.HsModule {..} =
-  DeclarationCollection $ fmap mkDeclaration . fromGenLocated <$> hsmodDecls
+  DeclarationCollection
+    $ fmap mkDeclaration . mkWithCommentsFromGenLocated <$> hsmodDecls
 
 hasDeclarations :: DeclarationCollection -> Bool
 hasDeclarations (DeclarationCollection xs) = not $ null xs

--- a/src/HIndent/Ast/Declaration/Data/Body.hs
+++ b/src/HIndent/Ast/Declaration/Data/Body.hs
@@ -82,7 +82,8 @@ mkDataBody defn@GHC.HsDataDefn {..} =
     then GADT
            { constructors =
                fromMaybe (error "Some constructors are not GADT ones.")
-                 $ mapM (traverse mkGADTConstructor . fromGenLocated)
+                 $ mapM
+                     (traverse mkGADTConstructor . mkWithCommentsFromGenLocated)
                  $ getConDecls defn
            , ..
            }
@@ -92,12 +93,12 @@ mkDataBody defn@GHC.HsDataDefn {..} =
                  (fromMaybe
                     (error "Some constructors are not in the Haskell 98 style.")
                     . mkHaskell98Constructor)
-                 . fromGenLocated
+                 . mkWithCommentsFromGenLocated
                  <$> getConDecls defn
            , ..
            }
   where
-    kind = fmap mkType . fromGenLocated <$> dd_kindSig
+    kind = fmap mkType . mkWithCommentsFromGenLocated <$> dd_kindSig
     derivings = mkDerivingClause dd_derivs
 
 isGADT :: GHC.HsDataDefn GHC.GhcPs -> Bool

--- a/src/HIndent/Ast/Declaration/Data/Constructor/Field.hs
+++ b/src/HIndent/Ast/Declaration/Data/Constructor/Field.hs
@@ -29,5 +29,5 @@ mkConstructorField field = ConstructorField {ty = mkTypeFromConDeclField field}
 mkConstructorField ::
      GHC.HsScaled GHC.GhcPs (GHC.LBangType GHC.GhcPs) -> ConstructorField
 mkConstructorField (GHC.HsScaled _ bangTy) =
-  ConstructorField {ty = mkType <$> fromGenLocated bangTy}
+  ConstructorField {ty = mkType <$> mkWithCommentsFromGenLocated bangTy}
 #endif

--- a/src/HIndent/Ast/Declaration/Data/Deriving.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving.hs
@@ -41,11 +41,19 @@ mkDeriving :: GHC.HsDerivingClause GHC.GhcPs -> Deriving
 mkDeriving GHC.HsDerivingClause {..} = Deriving {..}
   where
     strategy =
-      fmap (fmap mkDerivingStrategy . fromGenLocated) deriv_clause_strategy
-    classes = fromGenLocated $ fmap (const rawClasses) deriv_clause_tys
+      fmap
+        (fmap mkDerivingStrategy . mkWithCommentsFromGenLocated)
+        deriv_clause_strategy
+    classes =
+      mkWithCommentsFromGenLocated $ fmap (const rawClasses) deriv_clause_tys
     rawClasses =
       case GHC.unLoc deriv_clause_tys of
         GHC.DctSingle _ ty ->
-          [flattenComments $ mkTypeFromHsSigType <$> fromGenLocated ty]
+          [ flattenComments
+              $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated ty
+          ]
         GHC.DctMulti _ tys ->
-          flattenComments . fmap mkTypeFromHsSigType . fromGenLocated <$> tys
+          flattenComments
+            . fmap mkTypeFromHsSigType
+            . mkWithCommentsFromGenLocated
+            <$> tys

--- a/src/HIndent/Ast/Declaration/Data/Deriving/Clause.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving/Clause.hs
@@ -22,7 +22,8 @@ instance Pretty DerivingClause where
   pretty' (DerivingClause xs) = lined $ fmap pretty xs
 
 mkDerivingClause :: GHC.HsDeriving GHC.GhcPs -> DerivingClause
-mkDerivingClause = DerivingClause . fmap (fmap mkDeriving . fromGenLocated)
+mkDerivingClause =
+  DerivingClause . fmap (fmap mkDeriving . mkWithCommentsFromGenLocated)
 
 hasDerivings :: DerivingClause -> Bool
 hasDerivings (DerivingClause []) = False

--- a/src/HIndent/Ast/Declaration/Data/Deriving/Strategy.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving/Strategy.hs
@@ -6,7 +6,11 @@ module HIndent.Ast.Declaration.Data.Deriving.Strategy
 
 import HIndent.Ast.NodeComments
 import HIndent.Ast.Type (Type, mkTypeFromHsSigType)
-import HIndent.Ast.WithComments (WithComments, flattenComments, fromGenLocated)
+import HIndent.Ast.WithComments
+  ( WithComments
+  , flattenComments
+  , mkWithCommentsFromGenLocated
+  )
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
@@ -35,7 +39,7 @@ mkDerivingStrategy GHC.StockStrategy {} = Stock
 mkDerivingStrategy GHC.AnyclassStrategy {} = Anyclass
 mkDerivingStrategy GHC.NewtypeStrategy {} = Newtype
 mkDerivingStrategy (GHC.ViaStrategy (GHC.XViaStrategyPs _ x)) =
-  Via $ flattenComments $ mkTypeFromHsSigType <$> fromGenLocated x
+  Via $ flattenComments $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated x
 
 isViaStrategy :: DerivingStrategy -> Bool
 isViaStrategy Via {} = True

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -72,13 +72,13 @@ mkGADTConstructor decl@GHC.ConDeclGADT {..} = Just $ GADTConstructor {..}
         GHC.L _ GHC.HsOuterImplicit {} -> Nothing
         GHC.L l GHC.HsOuterExplicit {..} ->
           Just
-            $ fromGenLocated
+            $ mkWithCommentsFromGenLocated
             $ fmap
-                (fmap (fmap mkTypeVariable . fromGenLocated))
+                (fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated))
                 (GHC.L l hso_bndrs)
     signature =
       fromMaybe (error "Couldn't get signature.") $ mkConstructorSignature decl
-    context = fmap (fmap mkContext . fromGenLocated) con_mb_cxt
+    context = fmap (fmap mkContext . mkWithCommentsFromGenLocated) con_mb_cxt
 #else
 mkGADTConstructor decl@GHC.ConDeclGADT {..} = Just $ GADTConstructor {..}
   where
@@ -88,22 +88,24 @@ mkGADTConstructor decl@GHC.ConDeclGADT {..} = Just $ GADTConstructor {..}
         GHC.L _ GHC.HsOuterImplicit {} -> Nothing
         GHC.L l GHC.HsOuterExplicit {..} ->
           Just
-            $ fromGenLocated
+            $ mkWithCommentsFromGenLocated
             $ fmap
-                (fmap (fmap mkTypeVariable . fromGenLocated))
+                (fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated))
                 (GHC.L l hso_bndrs)
     signature =
       fromMaybe (error "Couldn't get signature.") $ mkConstructorSignature decl
-    context = fmap (fmap mkContext . fromGenLocated) con_mb_cxt
+    context = fmap (fmap mkContext . mkWithCommentsFromGenLocated) con_mb_cxt
 #endif
 mkGADTConstructor _ = Nothing
 
 getNames :: GHC.ConDecl GHC.GhcPs -> Maybe [WithComments PrefixName]
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
 getNames GHC.ConDeclGADT {..} =
-  Just $ NE.toList $ fmap (fromGenLocated . fmap mkPrefixName) con_names
+  Just
+    $ NE.toList
+    $ fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) con_names
 #else
 getNames GHC.ConDeclGADT {..} =
-  Just $ fmap (fromGenLocated . fmap mkPrefixName) con_names
+  Just $ fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) con_names
 #endif
 getNames _ = Nothing

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
@@ -57,27 +57,33 @@ mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT _ xs, ..} =
   Just
     $ Record
         { fields =
-            fromGenLocated
-              $ fmap (fmap (fmap mkRecordField . fromGenLocated)) xs
-        , result = mkType <$> fromGenLocated con_res_ty
+            mkWithCommentsFromGenLocated
+              $ fmap
+                  (fmap (fmap mkRecordField . mkWithCommentsFromGenLocated))
+                  xs
+        , result = mkType <$> mkWithCommentsFromGenLocated con_res_ty
         }
 #elif MIN_VERSION_ghc_lib_parser(9, 4, 0)
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT xs _, ..} =
   Just
     $ Record
         { fields =
-            fromGenLocated
-              $ fmap (fmap (fmap mkRecordField . fromGenLocated)) xs
-        , result = mkType <$> fromGenLocated con_res_ty
+            mkWithCommentsFromGenLocated
+              $ fmap
+                  (fmap (fmap mkRecordField . mkWithCommentsFromGenLocated))
+                  xs
+        , result = mkType <$> mkWithCommentsFromGenLocated con_res_ty
         }
 #else
 mkConstructorSignature GHC.ConDeclGADT {con_g_args = GHC.RecConGADT xs, ..} =
   Just
     $ Record
         { fields =
-            fromGenLocated
-              $ fmap (fmap (fmap mkRecordField . fromGenLocated)) xs
-        , result = mkType <$> fromGenLocated con_res_ty
+            mkWithCommentsFromGenLocated
+              $ fmap
+                  (fmap (fmap mkRecordField . mkWithCommentsFromGenLocated))
+                  xs
+        , result = mkType <$> mkWithCommentsFromGenLocated con_res_ty
         }
 #endif
 mkConstructorSignature GHC.ConDeclH98 {} = Nothing
@@ -87,14 +93,14 @@ buildFunctionType ::
   -> GHC.LHsType GHC.GhcPs
   -> WithComments Type
 buildFunctionType fields resultTy =
-  mkType <$> fromGenLocated (foldr mkFun resultTy fields)
+  mkType <$> mkWithCommentsFromGenLocated (foldr mkFun resultTy fields)
 #else
 buildFunctionType ::
      [GHC.HsScaled GHC.GhcPs (GHC.LHsType GHC.GhcPs)]
   -> GHC.LHsType GHC.GhcPs
   -> WithComments Type
 buildFunctionType scaledTypes resultTy =
-  mkType <$> fromGenLocated (foldr mkFun resultTy scaledTypes)
+  mkType <$> mkWithCommentsFromGenLocated (foldr mkFun resultTy scaledTypes)
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)

--- a/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor.hs
@@ -45,9 +45,11 @@ mkHaskell98Constructor GHC.ConDeclH98 {..}
   where
     existentialVariables =
       if con_forall
-        then fmap (fmap mkTypeVariable . fromGenLocated) con_ex_tvs
+        then fmap
+               (fmap mkTypeVariable . mkWithCommentsFromGenLocated)
+               con_ex_tvs
         else []
-    context = fmap (fmap mkContext . fromGenLocated) con_mb_cxt
+    context = fmap (fmap mkContext . mkWithCommentsFromGenLocated) con_mb_cxt
 mkHaskell98Constructor _ = Nothing
 
 hasSingleRecordConstructor :: Haskell98Constructor -> Bool

--- a/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor/Body.hs
+++ b/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor/Body.hs
@@ -55,7 +55,7 @@ mkHaskell98ConstructorBody GHC.ConDeclH98 { con_args = GHC.InfixCon leftField ri
                                           , ..
                                           } = Just Infix {..}
   where
-    iName = fromGenLocated $ fmap mkInfixName con_name
+    iName = mkWithCommentsFromGenLocated $ fmap mkInfixName con_name
     left = mkConstructorField leftField
     right = mkConstructorField rightField
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
@@ -63,22 +63,23 @@ mkHaskell98ConstructorBody GHC.ConDeclH98 { con_args = GHC.PrefixCon rawTypes
                                           , ..
                                           } = Just Prefix {..}
   where
-    pName = fromGenLocated $ fmap mkPrefixName con_name
+    pName = mkWithCommentsFromGenLocated $ fmap mkPrefixName con_name
     types = fmap mkConstructorField rawTypes
 #else
 mkHaskell98ConstructorBody GHC.ConDeclH98 { con_args = GHC.PrefixCon _ rawTypes
                                           , ..
                                           } = Just Prefix {..}
   where
-    pName = fromGenLocated $ fmap mkPrefixName con_name
+    pName = mkWithCommentsFromGenLocated $ fmap mkPrefixName con_name
     types = fmap mkConstructorField rawTypes
 #endif
 mkHaskell98ConstructorBody GHC.ConDeclH98 {con_args = GHC.RecCon rs, ..} =
   Just Record {..}
   where
-    rName = fromGenLocated $ fmap mkPrefixName con_name
+    rName = mkWithCommentsFromGenLocated $ fmap mkPrefixName con_name
     records =
-      fromGenLocated $ fmap (fmap (fmap mkRecordField . fromGenLocated)) rs
+      mkWithCommentsFromGenLocated
+        $ fmap (fmap (fmap mkRecordField . mkWithCommentsFromGenLocated)) rs
 mkHaskell98ConstructorBody GHC.ConDeclGADT {} = Nothing
 
 isRecord :: Haskell98ConstructorBody -> Bool

--- a/src/HIndent/Ast/Declaration/Data/Header.hs
+++ b/src/HIndent/Ast/Declaration/Data/Header.hs
@@ -39,8 +39,9 @@ mkHeader GHC.DataDecl {tcdDataDefn = defn@GHC.HsDataDefn {..}, ..} =
   Just Header {..}
   where
     newOrData = mkNewOrData defn
-    context = fmap (fmap mkContext . fromGenLocated) dd_ctxt
-    name = fromGenLocated $ fmap mkPrefixName tcdLName
+    context = fmap (fmap mkContext . mkWithCommentsFromGenLocated) dd_ctxt
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName tcdLName
     typeVariables =
-      fmap mkTypeVariable . fromGenLocated <$> GHC.hsq_explicit tcdTyVars
+      fmap mkTypeVariable . mkWithCommentsFromGenLocated
+        <$> GHC.hsq_explicit tcdTyVars
 mkHeader _ = Nothing

--- a/src/HIndent/Ast/Declaration/Data/Record/Field.hs
+++ b/src/HIndent/Ast/Declaration/Data/Record/Field.hs
@@ -30,12 +30,15 @@ instance Pretty RecordField where
 mkRecordField :: GHC.HsConDeclRecField GHC.GhcPs -> RecordField
 mkRecordField GHC.HsConDeclRecField {..} = RecordField {..}
   where
-    names = fmap mkFieldNameFromFieldOcc . fromGenLocated <$> cdrf_names
+    names =
+      fmap mkFieldNameFromFieldOcc . mkWithCommentsFromGenLocated <$> cdrf_names
     ty = mkTypeFromConDeclField cdrf_spec
 #else
 mkRecordField :: GHC.ConDeclField GHC.GhcPs -> RecordField
 mkRecordField GHC.ConDeclField {..} = RecordField {..}
   where
-    names = fmap mkFieldNameFromFieldOcc . fromGenLocated <$> cd_fld_names
-    ty = mkType <$> fromGenLocated cd_fld_type
+    names =
+      fmap mkFieldNameFromFieldOcc . mkWithCommentsFromGenLocated
+        <$> cd_fld_names
+    ty = mkType <$> mkWithCommentsFromGenLocated cd_fld_type
 #endif

--- a/src/HIndent/Ast/Declaration/Default.hs
+++ b/src/HIndent/Ast/Declaration/Default.hs
@@ -26,8 +26,8 @@ instance Pretty DefaultDeclaration where
 mkDefaultDeclaration :: GHC.DefaultDecl GHC.GhcPs -> DefaultDeclaration
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkDefaultDeclaration (GHC.DefaultDecl _ _ xs) =
-  DefaultDeclaration $ fmap (fmap mkType . fromGenLocated) xs
+  DefaultDeclaration $ fmap (fmap mkType . mkWithCommentsFromGenLocated) xs
 #else
 mkDefaultDeclaration (GHC.DefaultDecl _ xs) =
-  DefaultDeclaration $ fmap (fmap mkType . fromGenLocated) xs
+  DefaultDeclaration $ fmap (fmap mkType . mkWithCommentsFromGenLocated) xs
 #endif

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -47,12 +47,14 @@ mkDataFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
       case fdTopLevel of
         GHC.TopLevel -> True
         GHC.NotTopLevel -> False
-    name = fromGenLocated $ fmap mkPrefixName fdLName
-    typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName fdLName
+    typeVariables =
+      fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated) hsq_explicit
     signature =
       case GHC.unLoc fdResultSig of
         GHC.NoSig {} -> Nothing
-        GHC.KindSig _ kind -> Just $ mkType <$> fromGenLocated kind
+        GHC.KindSig _ kind ->
+          Just $ mkType <$> mkWithCommentsFromGenLocated kind
         GHC.TyVarSig {} ->
           error
             "Data family should never have this AST node. If you see this error, please report it to the HIndent maintainers."

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -55,14 +55,16 @@ mkTypeFamily GHC.FamilyDecl {fdTyVars = GHC.HsQTvs {..}, ..}
       case fdTopLevel of
         GHC.TopLevel -> True
         GHC.NotTopLevel -> False
-    name = fromGenLocated $ fmap mkPrefixName fdLName
-    typeVariables = fmap (fmap mkTypeVariable . fromGenLocated) hsq_explicit
-    signature = mkResultSignature <$> fromGenLocated fdResultSig
-    injectivity = fmap (fmap mkInjectivity . fromGenLocated) fdInjectivityAnn
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName fdLName
+    typeVariables =
+      fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated) hsq_explicit
+    signature = mkResultSignature <$> mkWithCommentsFromGenLocated fdResultSig
+    injectivity =
+      fmap (fmap mkInjectivity . mkWithCommentsFromGenLocated) fdInjectivityAnn
     equations =
       case fdInfo of
         GHC.DataFamily -> error "Not a TypeFamily"
         GHC.OpenTypeFamily -> Nothing
         GHC.ClosedTypeFamily Nothing -> Just []
         GHC.ClosedTypeFamily (Just xs) ->
-          Just $ fmap (fmap mkTypeEquation . fromGenLocated) xs
+          Just $ fmap (fmap mkTypeEquation . mkWithCommentsFromGenLocated) xs

--- a/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
@@ -32,6 +32,6 @@ instance Pretty TypeEquation where
 mkTypeEquation :: GHC.TyFamInstEqn GHC.GhcPs -> TypeEquation
 mkTypeEquation GHC.FamEqn {..} = TypeEquation {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName feqn_tycon
     types = mkTypeArgumentCollection feqn_pats
-    bind = mkType <$> fromGenLocated feqn_rhs
+    bind = mkType <$> mkWithCommentsFromGenLocated feqn_rhs

--- a/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
@@ -27,5 +27,5 @@ instance Pretty Injectivity where
 mkInjectivity :: GHC.InjectivityAnn GHC.GhcPs -> Injectivity
 mkInjectivity (GHC.InjectivityAnn _ f t) = Injectivity {..}
   where
-    from = fromGenLocated $ fmap mkPrefixName f
-    to = fmap (fromGenLocated . fmap mkPrefixName) t
+    from = mkWithCommentsFromGenLocated $ fmap mkPrefixName f
+    to = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) t

--- a/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
@@ -29,7 +29,8 @@ instance Pretty ResultSignature where
 
 mkResultSignature :: GHC.FamilyResultSig GHC.GhcPs -> ResultSignature
 mkResultSignature (GHC.NoSig _) = NoSig
-mkResultSignature (GHC.KindSig _ x) = Kind $ mkType <$> fromGenLocated x
+mkResultSignature (GHC.KindSig _ x) =
+  Kind $ mkType <$> mkWithCommentsFromGenLocated x
 mkResultSignature (GHC.TyVarSig _ x) = TypeVariable var
   where
-    var = mkTypeVariable <$> fromGenLocated x
+    var = mkTypeVariable <$> mkWithCommentsFromGenLocated x

--- a/src/HIndent/Ast/Declaration/Foreign.hs
+++ b/src/HIndent/Ast/Declaration/Foreign.hs
@@ -66,9 +66,10 @@ mkForeignDeclaration GHC.ForeignImport { fd_fi = (GHC.CImport (GHC.L _ src) (GHC
       case src of
         GHC.SourceText s -> Just $ GHC.unpackFS s
         _ -> Nothing
-    dstIdent = fromGenLocated $ fmap mkPrefixName fd_name
+    dstIdent = mkWithCommentsFromGenLocated $ fmap mkPrefixName fd_name
     signature =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated fd_sig_ty
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated fd_sig_ty
 mkForeignDeclaration GHC.ForeignExport { fd_fe = (GHC.CExport (GHC.L _ src) (GHC.L _ (GHC.CExportStatic _ _ conv)))
                                        , ..
                                        } = ForeignExport {..}
@@ -78,9 +79,10 @@ mkForeignDeclaration GHC.ForeignExport { fd_fe = (GHC.CExport (GHC.L _ src) (GHC
       case src of
         GHC.SourceText s -> Just $ GHC.unpackFS s
         _ -> Nothing
-    dstIdent = fromGenLocated $ fmap mkPrefixName fd_name
+    dstIdent = mkWithCommentsFromGenLocated $ fmap mkPrefixName fd_name
     signature =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated fd_sig_ty
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated fd_sig_ty
 #elif MIN_VERSION_ghc_lib_parser(9, 6, 0)
 mkForeignDeclaration GHC.ForeignImport { fd_fi = (GHC.CImport (GHC.L _ src) (GHC.L _ conv) (GHC.L _ sfty) _ _)
                                        , ..
@@ -92,9 +94,10 @@ mkForeignDeclaration GHC.ForeignImport { fd_fi = (GHC.CImport (GHC.L _ src) (GHC
       case src of
         GHC.SourceText s -> Just s
         _ -> Nothing
-    dstIdent = fromGenLocated $ fmap mkPrefixName fd_name
+    dstIdent = mkWithCommentsFromGenLocated $ fmap mkPrefixName fd_name
     signature =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated fd_sig_ty
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated fd_sig_ty
 mkForeignDeclaration GHC.ForeignExport { fd_fe = (GHC.CExport (GHC.L _ src) (GHC.L _ (GHC.CExportStatic _ _ conv)))
                                        , ..
                                        } = ForeignExport {..}
@@ -104,9 +107,10 @@ mkForeignDeclaration GHC.ForeignExport { fd_fe = (GHC.CExport (GHC.L _ src) (GHC
       case src of
         GHC.SourceText s -> Just s
         _ -> Nothing
-    dstIdent = fromGenLocated $ fmap mkPrefixName fd_name
+    dstIdent = mkWithCommentsFromGenLocated $ fmap mkPrefixName fd_name
     signature =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated fd_sig_ty
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated fd_sig_ty
 #else
 mkForeignDeclaration GHC.ForeignImport { fd_fi = (GHC.CImport (GHC.L _ conv) (GHC.L _ sfty) _ _ (GHC.L _ src))
                                        , ..
@@ -118,9 +122,10 @@ mkForeignDeclaration GHC.ForeignImport { fd_fi = (GHC.CImport (GHC.L _ conv) (GH
       case src of
         GHC.SourceText s -> Just s
         _ -> Nothing
-    dstIdent = fromGenLocated $ fmap mkPrefixName fd_name
+    dstIdent = mkWithCommentsFromGenLocated $ fmap mkPrefixName fd_name
     signature =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated fd_sig_ty
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated fd_sig_ty
 mkForeignDeclaration GHC.ForeignExport { fd_fe = (GHC.CExport (GHC.L _ (GHC.CExportStatic _ _ conv)) (GHC.L _ src))
                                        , ..
                                        } = ForeignExport {..}
@@ -130,7 +135,8 @@ mkForeignDeclaration GHC.ForeignExport { fd_fe = (GHC.CExport (GHC.L _ (GHC.CExp
       case src of
         GHC.SourceText s -> Just s
         _ -> Nothing
-    dstIdent = fromGenLocated $ fmap mkPrefixName fd_name
+    dstIdent = mkWithCommentsFromGenLocated $ fmap mkPrefixName fd_name
     signature =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated fd_sig_ty
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated fd_sig_ty
 #endif

--- a/src/HIndent/Ast/Declaration/Instance/Class.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class.hs
@@ -46,28 +46,34 @@ mkClassInstance GHC.ClsInstD {cid_inst = GHC.ClsInstDecl {..}} =
   Just
     $ ClassInstance
         { instanceType =
-            flattenComments $ mkInstDeclType <$> fromGenLocated cid_poly_ty
+            flattenComments
+              $ mkInstDeclType <$> mkWithCommentsFromGenLocated cid_poly_ty
         , body =
             mkClassInstanceBody
               cid_sigs
               cid_binds
               cid_tyfam_insts
               cid_datafam_insts
-        , overlapMode = fmap mkOverlapMode . fromGenLocated <$> cid_overlap_mode
+        , overlapMode =
+            fmap mkOverlapMode . mkWithCommentsFromGenLocated
+              <$> cid_overlap_mode
         }
 #else
 mkClassInstance GHC.ClsInstD {cid_inst = GHC.ClsInstDecl {..}} =
   Just
     $ ClassInstance
         { instanceType =
-            flattenComments $ mkInstDeclType <$> fromGenLocated cid_poly_ty
+            flattenComments
+              $ mkInstDeclType <$> mkWithCommentsFromGenLocated cid_poly_ty
         , body =
             mkClassInstanceBody
               cid_sigs
               (GHC.bagToList cid_binds)
               cid_tyfam_insts
               cid_datafam_insts
-        , overlapMode = fmap mkOverlapMode . fromGenLocated <$> cid_overlap_mode
+        , overlapMode =
+            fmap mkOverlapMode . mkWithCommentsFromGenLocated
+              <$> cid_overlap_mode
         }
 #endif
 mkClassInstance _ = Nothing

--- a/src/HIndent/Ast/Declaration/Instance/Class/Body.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class/Body.hs
@@ -44,5 +44,5 @@ hasClassInstanceBody (ClassInstanceBody members) = not $ null members
 sortMembers ::
      [GHC.LocatedA ClassInstanceMember] -> [WithComments ClassInstanceMember]
 sortMembers =
-  fmap fromGenLocated
+  fmap mkWithCommentsFromGenLocated
     . sortBy (compare `on` GHC.realSrcSpan . GHC.locA . GHC.getLoc)

--- a/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
@@ -39,6 +39,6 @@ mkDataFamilyInstance ::
 mkDataFamilyInstance GHC.FamEqn {..} = DataFamilyInstance {..}
   where
     newOrData = mkNewOrData feqn_rhs
-    name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName feqn_tycon
     types = mkTypeArgumentCollection feqn_pats
     body = mkDataBody feqn_rhs

--- a/src/HIndent/Ast/Declaration/Instance/Family/Data/Associated.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Data/Associated.hs
@@ -41,7 +41,7 @@ mkAssociatedDataFamilyInstance ::
 mkAssociatedDataFamilyInstance GHC.DataFamInstDecl {GHC.dfid_eqn = GHC.FamEqn {..}} =
   AssociatedDataFamilyInstance
     { newOrData = mkNewOrData feqn_rhs
-    , name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    , name = mkWithCommentsFromGenLocated $ fmap mkPrefixName feqn_tycon
     , types = mkTypeArgumentCollection feqn_pats
     , body = mkDataBody feqn_rhs
     }

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
@@ -36,7 +36,7 @@ mkTypeFamilyInstance :: GHC.InstDecl GHC.GhcPs -> Maybe TypeFamilyInstance
 mkTypeFamilyInstance GHC.TyFamInstD {GHC.tfid_inst = GHC.TyFamInstDecl {GHC.tfid_eqn = GHC.FamEqn {..}}} =
   Just $ TypeFamilyInstance {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName feqn_tycon
     types = mkTypeArgumentCollection feqn_pats
-    bind = mkType <$> fromGenLocated feqn_rhs
+    bind = mkType <$> mkWithCommentsFromGenLocated feqn_rhs
 mkTypeFamilyInstance _ = Nothing

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
@@ -35,7 +35,7 @@ instance Pretty AssociatedType where
 mkAssociatedType :: GHC.TyFamInstDecl GHC.GhcPs -> AssociatedType
 mkAssociatedType GHC.TyFamInstDecl {GHC.tfid_eqn = GHC.FamEqn {..}} =
   AssociatedType
-    { name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    { name = mkWithCommentsFromGenLocated $ fmap mkPrefixName feqn_tycon
     , types = mkTypeArgumentCollection feqn_pats
-    , bind = mkType <$> fromGenLocated feqn_rhs
+    , bind = mkType <$> mkWithCommentsFromGenLocated feqn_rhs
     }

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
@@ -35,7 +35,7 @@ instance Pretty AssociatedTypeDefault where
 mkAssociatedTypeDefault :: GHC.TyFamInstDecl GHC.GhcPs -> AssociatedTypeDefault
 mkAssociatedTypeDefault GHC.TyFamInstDecl {GHC.tfid_eqn = GHC.FamEqn {..}} =
   AssociatedTypeDefault
-    { name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    { name = mkWithCommentsFromGenLocated $ fmap mkPrefixName feqn_tycon
     , types = mkTypeArgumentCollection feqn_pats
-    , bind = mkType <$> fromGenLocated feqn_rhs
+    , bind = mkType <$> mkWithCommentsFromGenLocated feqn_rhs
     }

--- a/src/HIndent/Ast/Declaration/PatternSynonym.hs
+++ b/src/HIndent/Ast/Declaration/PatternSynonym.hs
@@ -66,9 +66,9 @@ mkPatternSynonym :: GHC.PatSynBind GHC.GhcPs GHC.GhcPs -> PatternSynonym
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.PrefixCon prefixArgs, ..} =
   Prefix
-    { name = fromGenLocated $ fmap mkPrefixName psb_id
-    , args = map (fromGenLocated . fmap mkPrefixName) prefixArgs
-    , definition = mkPatInsidePatDecl <$> fromGenLocated psb_def
+    { name = mkWithCommentsFromGenLocated $ fmap mkPrefixName psb_id
+    , args = map (mkWithCommentsFromGenLocated . fmap mkPrefixName) prefixArgs
+    , definition = mkPatInsidePatDecl <$> mkWithCommentsFromGenLocated psb_def
     , ..
     }
   where
@@ -81,9 +81,9 @@ mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.PrefixCon prefixArgs, ..} =
 #else
 mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.PrefixCon _ prefixArgs, ..} =
   Prefix
-    { name = fromGenLocated $ fmap mkPrefixName psb_id
-    , args = map (fromGenLocated . fmap mkPrefixName) prefixArgs
-    , definition = mkPatInsidePatDecl <$> fromGenLocated psb_def
+    { name = mkWithCommentsFromGenLocated $ fmap mkPrefixName psb_id
+    , args = map (mkWithCommentsFromGenLocated . fmap mkPrefixName) prefixArgs
+    , definition = mkPatInsidePatDecl <$> mkWithCommentsFromGenLocated psb_def
     , ..
     }
   where
@@ -96,10 +96,10 @@ mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.PrefixCon _ prefixArgs, ..} =
 #endif
 mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.InfixCon leftArg rightArg, ..} =
   Infix
-    { leftArg = fromGenLocated $ fmap mkPrefixName leftArg
-    , operator = fromGenLocated $ fmap mkInfixName psb_id
-    , rightArg = fromGenLocated $ fmap mkPrefixName rightArg
-    , definition = mkPatInsidePatDecl <$> fromGenLocated psb_def
+    { leftArg = mkWithCommentsFromGenLocated $ fmap mkPrefixName leftArg
+    , operator = mkWithCommentsFromGenLocated $ fmap mkInfixName psb_id
+    , rightArg = mkWithCommentsFromGenLocated $ fmap mkPrefixName rightArg
+    , definition = mkPatInsidePatDecl <$> mkWithCommentsFromGenLocated psb_def
     , ..
     }
   where
@@ -111,12 +111,12 @@ mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.InfixCon leftArg rightArg, ..} =
           (False, Just $ mkExprMatchGroup matches)
 mkPatternSynonym GHC.PSB {GHC.psb_args = GHC.RecCon recordFields, ..} =
   Record
-    { name = fromGenLocated $ fmap mkPrefixName psb_id
+    { name = mkWithCommentsFromGenLocated $ fmap mkPrefixName psb_id
     , fields =
         map
           (mkWithComments . mkFieldNameFromFieldOcc . GHC.recordPatSynField)
           recordFields
-    , definition = mkPatInsidePatDecl <$> fromGenLocated psb_def
+    , definition = mkPatInsidePatDecl <$> mkWithCommentsFromGenLocated psb_def
     , ..
     }
   where

--- a/src/HIndent/Ast/Declaration/Rule.hs
+++ b/src/HIndent/Ast/Declaration/Rule.hs
@@ -46,20 +46,20 @@ mkRuleDeclaration rule@GHC.HsRule {..} = RuleDeclaration {..}
   where
     name = mkRuleName <$> getName rule
     binders = mkRuleBinders rule
-    lhs = mkExpression <$> fromGenLocated rd_lhs
-    rhs = mkExpression <$> fromGenLocated rd_rhs
+    lhs = mkExpression <$> mkWithCommentsFromGenLocated rd_lhs
+    rhs = mkExpression <$> mkWithCommentsFromGenLocated rd_rhs
 
 mkRuleBinders :: GHC.RuleDecl GHC.GhcPs -> [WithComments RuleBinder]
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkRuleBinders GHC.HsRule {rd_bndrs = GHC.RuleBndrs {..}} =
-  fmap (fmap mkRuleBinder . fromGenLocated) rb_tmvs
+  fmap (fmap mkRuleBinder . mkWithCommentsFromGenLocated) rb_tmvs
 #else
 mkRuleBinders GHC.HsRule {..} =
-  fmap (fmap mkRuleBinder . fromGenLocated) rd_tmvs
+  fmap (fmap mkRuleBinder . mkWithCommentsFromGenLocated) rd_tmvs
 #endif
 getName :: GHC.RuleDecl GHC.GhcPs -> WithComments GHC.RuleName
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
-getName = fromGenLocated . GHC.rd_name
+getName = mkWithCommentsFromGenLocated . GHC.rd_name
 #else
-getName = fromGenLocated . fmap snd . GHC.rd_name
+getName = mkWithCommentsFromGenLocated . fmap snd . GHC.rd_name
 #endif

--- a/src/HIndent/Ast/Declaration/Rule/Binder.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Binder.hs
@@ -31,8 +31,8 @@ mkRuleBinder :: GHC.RuleBndr GHC.GhcPs -> RuleBinder
 mkRuleBinder (GHC.RuleBndr _ n) = RuleBinder {..}
   where
     signature = Nothing
-    name = fromGenLocated $ fmap mkPrefixName n
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
 mkRuleBinder (GHC.RuleBndrSig _ n GHC.HsPS {..}) = RuleBinder {..}
   where
-    signature = Just $ fromGenLocated $ fmap mkType hsps_body
-    name = fromGenLocated $ fmap mkPrefixName n
+    signature = Just $ mkWithCommentsFromGenLocated $ fmap mkType hsps_body
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n

--- a/src/HIndent/Ast/Declaration/Rule/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Collection.hs
@@ -25,4 +25,5 @@ instance Pretty RuleCollection where
 
 mkRuleCollection :: GHC.RuleDecls GHC.GhcPs -> RuleCollection
 mkRuleCollection GHC.HsRules {..} =
-  RuleCollection $ fmap (fmap mkRuleDeclaration . fromGenLocated) rds_rules
+  RuleCollection
+    $ fmap (fmap mkRuleDeclaration . mkWithCommentsFromGenLocated) rds_rules

--- a/src/HIndent/Ast/Declaration/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Signature.hs
@@ -160,74 +160,83 @@ mkSignature (GHC.TypeSig _ ns GHC.HsWC { hswc_ext = GHC.NoExtField
                                        , GHC.hswc_body = params
                                        }) = Type {..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    parameters = flattenComments $ mkDeclSigType <$> fromGenLocated params
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
+    parameters =
+      flattenComments $ mkDeclSigType <$> mkWithCommentsFromGenLocated params
 mkSignature (GHC.PatSynSig _ ns s) = Pattern {..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    signature = flattenComments $ mkTypeFromHsSigType <$> fromGenLocated s
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
+    signature =
+      flattenComments $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated s
 mkSignature (GHC.ClassOpSig _ True ns s) = DefaultClassMethod {..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    methodSig = flattenComments $ mkDeclSigType <$> fromGenLocated s
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
+    methodSig =
+      flattenComments $ mkDeclSigType <$> mkWithCommentsFromGenLocated s
 mkSignature (GHC.ClassOpSig _ False ns s) = ClassMethod {..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
-    methodSig = flattenComments $ mkDeclSigType <$> fromGenLocated s
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
+    methodSig =
+      flattenComments $ mkDeclSigType <$> mkWithCommentsFromGenLocated s
 mkSignature (GHC.FixSig _ (GHC.FixitySig _ ops fy)) = Fixity {..}
   where
     fixity = mkFixity fy
-    opNames = fmap (fromGenLocated . fmap mkInfixName) ops
+    opNames = fmap (mkWithCommentsFromGenLocated . fmap mkInfixName) ops
 mkSignature (GHC.InlineSig _ n GHC.InlinePragma {..}) = Inline {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName n
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
     spec = mkInlineSpec inl_inline
     phase = mkInlinePhase inl_act
 mkSignature (GHC.SpecSig _ n s _) = Specialise {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName n
-    sigs = flattenComments . fmap mkTypeFromHsSigType . fromGenLocated <$> s
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
+    sigs =
+      flattenComments . fmap mkTypeFromHsSigType . mkWithCommentsFromGenLocated
+        <$> s
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkSignature (GHC.SpecSigE _ _ expr _) = SpecialiseExpr {..}
   where
-    expression = mkExpression <$> fromGenLocated expr
+    expression = mkExpression <$> mkWithCommentsFromGenLocated expr
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkSignature (GHC.SCCFunSig _ n _) = Scc name
   where
-    name = fromGenLocated $ fmap mkPrefixName n
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
 mkSignature (GHC.CompleteMatchSig _ ns _) = Complete names
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
 #elif MIN_VERSION_ghc_lib_parser(9, 6, 0)
 mkSignature (GHC.SCCFunSig _ n _) = Scc name
   where
-    name = fromGenLocated $ fmap mkPrefixName n
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
 mkSignature (GHC.CompleteMatchSig _ ns _) = Complete names
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) $ GHC.unLoc ns
+    names =
+      fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) $ GHC.unLoc ns
 #elif MIN_VERSION_ghc_lib_parser(9, 4, 0)
 mkSignature (GHC.SCCFunSig _ _ name _) =
-  Scc $ fromGenLocated $ fmap mkPrefixName name
+  Scc $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 mkSignature (GHC.CompleteMatchSig _ _ names _) =
-  Complete $ fromGenLocated . fmap mkPrefixName <$> GHC.unLoc names
+  Complete
+    $ mkWithCommentsFromGenLocated . fmap mkPrefixName <$> GHC.unLoc names
 #else
 mkSignature (GHC.SCCFunSig _ _ name _) =
-  Scc $ fromGenLocated $ fmap mkPrefixName name
+  Scc $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 mkSignature (GHC.CompleteMatchSig _ _ names _) =
-  Complete $ fromGenLocated . fmap mkPrefixName <$> GHC.unLoc names
+  Complete
+    $ mkWithCommentsFromGenLocated . fmap mkPrefixName <$> GHC.unLoc names
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)
 mkSignature (GHC.SpecInstSig _ sig) =
   SpecialiseInstance
     $ flattenComments
-    $ mkTypeFromHsSigType <$> fromGenLocated sig
+    $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated sig
 mkSignature (GHC.MinimalSig _ xs) =
-  Minimal $ mkBooleanFormula <$> fromGenLocated xs
+  Minimal $ mkBooleanFormula <$> mkWithCommentsFromGenLocated xs
 #else
 mkSignature (GHC.SpecInstSig _ _ sig) = SpecialiseInstance sig
 mkSignature (GHC.MinimalSig _ _ xs) =
-  Minimal $ mkBooleanFormula <$> fromGenLocated xs
+  Minimal $ mkBooleanFormula <$> mkWithCommentsFromGenLocated xs
 mkSignature GHC.IdSig {} =
   error "`ghc-lib-parser` never generates this AST node."
 #endif

--- a/src/HIndent/Ast/Declaration/Signature/BooleanFormula.hs
+++ b/src/HIndent/Ast/Declaration/Signature/BooleanFormula.hs
@@ -36,9 +36,11 @@ mkBooleanFormula :: GHC.BooleanFormula GHC.GhcPs -> BooleanFormula
 #else
 mkBooleanFormula :: GHC.BooleanFormula (GHC.LIdP GHC.GhcPs) -> BooleanFormula
 #endif
-mkBooleanFormula (GHC.Var x) = Var $ fromGenLocated $ fmap mkPrefixName x
+mkBooleanFormula (GHC.Var x) =
+  Var $ mkWithCommentsFromGenLocated $ fmap mkPrefixName x
 mkBooleanFormula (GHC.And xs) =
-  And $ fmap (fmap mkBooleanFormula . fromGenLocated) xs
+  And $ fmap (fmap mkBooleanFormula . mkWithCommentsFromGenLocated) xs
 mkBooleanFormula (GHC.Or xs) =
-  Or $ fmap (fmap mkBooleanFormula . fromGenLocated) xs
-mkBooleanFormula (GHC.Parens x) = Parens $ mkBooleanFormula <$> fromGenLocated x
+  Or $ fmap (fmap mkBooleanFormula . mkWithCommentsFromGenLocated) xs
+mkBooleanFormula (GHC.Parens x) =
+  Parens $ mkBooleanFormula <$> mkWithCommentsFromGenLocated x

--- a/src/HIndent/Ast/Declaration/Signature/StandaloneKind.hs
+++ b/src/HIndent/Ast/Declaration/Signature/StandaloneKind.hs
@@ -29,5 +29,6 @@ instance Pretty StandaloneKind where
 mkStandaloneKind :: GHC.StandaloneKindSig GHC.GhcPs -> StandaloneKind
 mkStandaloneKind (GHC.StandaloneKindSig _ n k) = StandaloneKind {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName n
-    kind = flattenComments $ mkTypeFromHsSigType <$> fromGenLocated k
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
+    kind =
+      flattenComments $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated k

--- a/src/HIndent/Ast/Declaration/Splice.hs
+++ b/src/HIndent/Ast/Declaration/Splice.hs
@@ -21,4 +21,4 @@ instance Pretty SpliceDeclaration where
 
 mkSpliceDeclaration :: GHC.SpliceDecl GHC.GhcPs -> SpliceDeclaration
 mkSpliceDeclaration (GHC.SpliceDecl _ sp _) =
-  SpliceDeclaration $ mkSplice <$> fromGenLocated sp
+  SpliceDeclaration $ mkSplice <$> mkWithCommentsFromGenLocated sp

--- a/src/HIndent/Ast/Declaration/StandAloneDeriving.hs
+++ b/src/HIndent/Ast/Declaration/StandAloneDeriving.hs
@@ -42,6 +42,10 @@ mkStandAloneDeriving :: GHC.DerivDecl GHC.GhcPs -> StandAloneDeriving
 mkStandAloneDeriving GHC.DerivDecl {deriv_type = GHC.HsWC {..}, ..} =
   StandAloneDeriving {..}
   where
-    strategy = fmap (fmap mkDerivingStrategy . fromGenLocated) deriv_strategy
+    strategy =
+      fmap
+        (fmap mkDerivingStrategy . mkWithCommentsFromGenLocated)
+        deriv_strategy
     className =
-      flattenComments $ mkTypeFromHsSigType <$> fromGenLocated hswc_body
+      flattenComments
+        $ mkTypeFromHsSigType <$> mkWithCommentsFromGenLocated hswc_body

--- a/src/HIndent/Ast/Declaration/TypeSynonym.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym.hs
@@ -35,5 +35,5 @@ mkTypeSynonym :: GHC.TyClDecl GHC.GhcPs -> TypeSynonym
 mkTypeSynonym synonym@GHC.SynDecl {..} = TypeSynonym {..}
   where
     lhs = mkTypeSynonymLhs synonym
-    rhs = mkType <$> fromGenLocated tcdRhs
+    rhs = mkType <$> mkWithCommentsFromGenLocated tcdRhs
 mkTypeSynonym _ = error "Not a type synonym."

--- a/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
@@ -38,15 +38,16 @@ instance Pretty TypeSynonymLhs where
 mkTypeSynonymLhs :: GHC.TyClDecl GHC.GhcPs -> TypeSynonymLhs
 mkTypeSynonymLhs GHC.SynDecl {tcdFixity = GHC.Prefix, ..} = Prefix {..}
   where
-    pName = fromGenLocated $ fmap mkPrefixName tcdLName
+    pName = mkWithCommentsFromGenLocated $ fmap mkPrefixName tcdLName
     typeVariables =
-      fmap mkTypeVariable . fromGenLocated <$> GHC.hsq_explicit tcdTyVars
+      fmap mkTypeVariable . mkWithCommentsFromGenLocated
+        <$> GHC.hsq_explicit tcdTyVars
 mkTypeSynonymLhs GHC.SynDecl {tcdFixity = GHC.Infix, ..} =
   case GHC.hsq_explicit tcdTyVars of
     [l, r] -> Infix {..}
       where
-        left = mkTypeVariable <$> fromGenLocated l
-        iName = fromGenLocated $ fmap mkInfixName tcdLName
-        right = mkTypeVariable <$> fromGenLocated r
+        left = mkTypeVariable <$> mkWithCommentsFromGenLocated l
+        iName = mkWithCommentsFromGenLocated $ fmap mkInfixName tcdLName
+        right = mkTypeVariable <$> mkWithCommentsFromGenLocated r
     _ -> error "Unexpected number of type variables for infix type synonym."
 mkTypeSynonymLhs _ = error "Not a type synonym."

--- a/src/HIndent/Ast/Declaration/Warning.hs
+++ b/src/HIndent/Ast/Declaration/Warning.hs
@@ -40,52 +40,52 @@ mkWarningDeclaration :: GHC.WarnDecl GHC.GhcPs -> WarningDeclaration
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 #elif MIN_VERSION_ghc_lib_parser(9, 8, 1)
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 #elif MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 #else
 mkWarningDeclaration (GHC.Warning _ ns (GHC.DeprecatedTxt _ rs)) =
   WarningDeclaration {kind = Deprecated, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 mkWarningDeclaration (GHC.Warning _ ns (GHC.WarningTxt _ rs)) =
   WarningDeclaration {kind = Warning, ..}
   where
-    names = fmap (fromGenLocated . fmap mkPrefixName) ns
+    names = fmap (mkWithCommentsFromGenLocated . fmap mkPrefixName) ns
     reasons =
       fmap (mkTextValueFromStringLiteral . GHC.hsDocString . GHC.unLoc) rs
 #endif

--- a/src/HIndent/Ast/Declaration/Warning/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Warning/Collection.hs
@@ -25,8 +25,10 @@ instance Pretty WarningCollection where
 mkWarningCollection :: GHC.WarnDecls GHC.GhcPs -> WarningCollection
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 mkWarningCollection (GHC.Warnings _ xs) =
-  WarningCollection $ fmap (fmap mkWarningDeclaration . fromGenLocated) xs
+  WarningCollection
+    $ fmap (fmap mkWarningDeclaration . mkWithCommentsFromGenLocated) xs
 #else
 mkWarningCollection (GHC.Warnings _ _ xs) =
-  WarningCollection $ fmap (fmap mkWarningDeclaration . fromGenLocated) xs
+  WarningCollection
+    $ fmap (fmap mkWarningDeclaration . mkWithCommentsFromGenLocated) xs
 #endif

--- a/src/HIndent/Ast/Expression.hs
+++ b/src/HIndent/Ast/Expression.hs
@@ -333,10 +333,10 @@ instance Pretty Expression where
 
 mkExpression :: GHC.HsExpr GHC.GhcPs -> Expression
 mkExpression (GHC.HsVar _ name) =
-  Variable $ mkPrefixName <$> fromGenLocated name
+  Variable $ mkPrefixName <$> mkWithCommentsFromGenLocated name
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkExpression (GHC.HsHole (GHC.HoleVar name)) =
-  UnboundVariable $ mkPrefixName <$> fromGenLocated name
+  UnboundVariable $ mkPrefixName <$> mkWithCommentsFromGenLocated name
 mkExpression (GHC.HsHole GHC.HoleError) =
   error "`ghc-lib-parser` never generates this AST node."
 #elif MIN_VERSION_ghc_lib_parser(9, 6, 0)
@@ -385,8 +385,8 @@ mkExpression (GHC.HsApp _ function argument) =
     Application (h :| as) -> Application $ h :| push as
     _ -> Application $ f :| [a]
   where
-    f = mkExpression <$> fromGenLocated function
-    a = mkExpression <$> fromGenLocated argument
+    f = mkExpression <$> mkWithCommentsFromGenLocated function
+    a = mkExpression <$> mkWithCommentsFromGenLocated argument
     push [] = [a]
     push (x:xs) = go x xs
       where
@@ -395,13 +395,13 @@ mkExpression (GHC.HsApp _ function argument) =
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExpression (GHC.HsAppType _ fun typeArg) =
   TypeApplication
-    { expression = mkExpression <$> fromGenLocated fun
+    { expression = mkExpression <$> mkWithCommentsFromGenLocated fun
     , typeArg = mkTypeFromLHsWcType typeArg
     }
 #else
 mkExpression (GHC.HsAppType _ fun _ typeArg) =
   TypeApplication
-    { expression = mkExpression <$> fromGenLocated fun
+    { expression = mkExpression <$> mkWithCommentsFromGenLocated fun
     , typeArg = mkTypeFromLHsWcType typeArg
     }
 #endif
@@ -416,15 +416,15 @@ mkExpression (GHC.OpApp _ lhs op rhs) = OperatorApplication {..}
           , isSameAssoc o -> build leftChain
           | otherwise -> build rightChain
     operatorFixity = findFixity op
-    build (x:xs) = (mkExpression <$> fromGenLocated x, f xs)
+    build (x:xs) = (mkExpression <$> mkWithCommentsFromGenLocated x, f xs)
       where
         f [l, o] =
           NonEmpty.singleton
-            ( InfixExpr . mkExpression <$> fromGenLocated l
-            , mkExpression <$> fromGenLocated o)
+            ( InfixExpr . mkExpression <$> mkWithCommentsFromGenLocated l
+            , mkExpression <$> mkWithCommentsFromGenLocated o)
         f (l:o:rs) =
-          ( InfixExpr . mkExpression <$> fromGenLocated l
-          , mkExpression <$> fromGenLocated o)
+          ( InfixExpr . mkExpression <$> mkWithCommentsFromGenLocated l
+          , mkExpression <$> mkWithCommentsFromGenLocated o)
             <| f rs
         f _ = error "Malformed operator chain"
     build _ = error "Empty operator chain"
@@ -456,26 +456,26 @@ mkExpression (GHC.OpApp _ lhs op rhs) = OperatorApplication {..}
     fixityDir (GHC.Fixity _ _ direction) = direction
 #endif
 mkExpression (GHC.NegApp _ expr _) =
-  Negation $ mkExpression <$> fromGenLocated expr
+  Negation $ mkExpression <$> mkWithCommentsFromGenLocated expr
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExpression (GHC.HsPar _ expr) =
-  Parenthesized $ mkExpression <$> fromGenLocated expr
+  Parenthesized $ mkExpression <$> mkWithCommentsFromGenLocated expr
 #elif MIN_VERSION_ghc_lib_parser(9, 8, 1)
 mkExpression (GHC.HsPar _ _ expr _) =
-  Parenthesized $ mkExpression <$> fromGenLocated expr
+  Parenthesized $ mkExpression <$> mkWithCommentsFromGenLocated expr
 #else
 mkExpression (GHC.HsPar _ expr) =
-  Parenthesized $ mkExpression <$> fromGenLocated expr
+  Parenthesized $ mkExpression <$> mkWithCommentsFromGenLocated expr
 #endif
 mkExpression (GHC.SectionL _ l r) =
   LeftSection
-    { left = mkExpression <$> fromGenLocated l
-    , operator = InfixExpr . mkExpression <$> fromGenLocated r
+    { left = mkExpression <$> mkWithCommentsFromGenLocated l
+    , operator = InfixExpr . mkExpression <$> mkWithCommentsFromGenLocated r
     }
 mkExpression (GHC.SectionR _ l r) =
   RightSection
-    { operator = InfixExpr . mkExpression <$> fromGenLocated l
-    , right = mkExpression <$> fromGenLocated r
+    { operator = InfixExpr . mkExpression <$> mkWithCommentsFromGenLocated l
+    , right = mkExpression <$> mkWithCommentsFromGenLocated r
     }
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExpression (GHC.ExplicitTuple _ tupleArgs boxity) =
@@ -488,7 +488,7 @@ mkExpression (GHC.ExplicitTuple _ tupleArgs boxity) =
     }
   where
     mkTupleArgument (GHC.Present _ expr) =
-      mkWithComments $ Just $ mkExpression <$> fromGenLocated expr
+      mkWithComments $ Just $ mkExpression <$> mkWithCommentsFromGenLocated expr
     mkTupleArgument (GHC.Missing ann) = fromEpAnn ann Nothing
 #else
 mkExpression (GHC.ExplicitTuple _ tupleArgs boxity) =
@@ -501,24 +501,27 @@ mkExpression (GHC.ExplicitTuple _ tupleArgs boxity) =
     }
   where
     mkTupleArgument (GHC.Present ann expr) =
-      fromEpAnn ann $ Just $ mkExpression <$> fromGenLocated expr
+      fromEpAnn ann $ Just $ mkExpression <$> mkWithCommentsFromGenLocated expr
     mkTupleArgument (GHC.Missing ann) = fromEpAnn ann Nothing
 #endif
 mkExpression (GHC.ExplicitSum _ position arity expr) =
-  Sum {expression = mkExpression <$> fromGenLocated expr, ..}
+  Sum {expression = mkExpression <$> mkWithCommentsFromGenLocated expr, ..}
 mkExpression (GHC.HsCase _ scrut matches) =
   CaseExpression
-    { scrutinee = mkExpression <$> fromGenLocated scrut
+    { scrutinee = mkExpression <$> mkWithCommentsFromGenLocated scrut
     , matches = mkExprMatchGroup matches
     }
 mkExpression (GHC.HsIf _ predicateExpr thenExpr elseExpr) =
   IfExpression
-    { predicate = mkExpression <$> fromGenLocated predicateExpr
-    , thenBranch = mkExpression <$> fromGenLocated thenExpr
-    , elseBranch = mkExpression <$> fromGenLocated elseExpr
+    { predicate = mkExpression <$> mkWithCommentsFromGenLocated predicateExpr
+    , thenBranch = mkExpression <$> mkWithCommentsFromGenLocated thenExpr
+    , elseBranch = mkExpression <$> mkWithCommentsFromGenLocated elseExpr
     }
 mkExpression (GHC.HsMultiIf _ clauses) =
-  MultiIf $ fmap (fmap mkMultiWayIfExprGuard . fromGenLocated) (toList clauses)
+  MultiIf
+    $ fmap
+        (fmap mkMultiWayIfExprGuard . mkWithCommentsFromGenLocated)
+        (toList clauses)
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExpression (GHC.HsLet _ localBinds body) =
   case mkLocalBinds localBinds of
@@ -526,7 +529,8 @@ mkExpression (GHC.HsLet _ localBinds body) =
       error
         "`ghc-lib-parser` never generates a `HsLet` node with empty bindings."
     Just bindings ->
-      LetBinding {expression = mkExpression <$> fromGenLocated body, ..}
+      LetBinding
+        {expression = mkExpression <$> mkWithCommentsFromGenLocated body, ..}
 #elif MIN_VERSION_ghc_lib_parser(9, 8, 1)
 mkExpression (GHC.HsLet _ _ localBinds _ body) =
   case mkLocalBinds localBinds of
@@ -534,7 +538,8 @@ mkExpression (GHC.HsLet _ _ localBinds _ body) =
       error
         "`ghc-lib-parser` never generates a `HsLet` node with empty bindings."
     Just bindings ->
-      LetBinding {expression = mkExpression <$> fromGenLocated body, ..}
+      LetBinding
+        {expression = mkExpression <$> mkWithCommentsFromGenLocated body, ..}
 #else
 mkExpression (GHC.HsLet _ localBinds body) =
   case mkLocalBinds localBinds of
@@ -542,69 +547,75 @@ mkExpression (GHC.HsLet _ localBinds body) =
       error
         "`ghc-lib-parser` never generates a `HsLet` node with empty bindings."
     Just bindings ->
-      LetBinding {expression = mkExpression <$> fromGenLocated body, ..}
+      LetBinding
+        {expression = mkExpression <$> mkWithCommentsFromGenLocated body, ..}
 #endif
 mkExpression (GHC.HsDo _ GHC.ListComp statements) =
   ListComprehension
-    $ LC.mkListComprehension . fmap (fmap mkExprStatement . fromGenLocated)
-        <$> fromGenLocated statements
+    $ LC.mkListComprehension
+        . fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated)
+        <$> mkWithCommentsFromGenLocated statements
 mkExpression (GHC.HsDo _ GHC.MonadComp statements) =
   ListComprehension
-    $ LC.mkListComprehension . fmap (fmap mkExprStatement . fromGenLocated)
-        <$> fromGenLocated statements
+    $ LC.mkListComprehension
+        . fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated)
+        <$> mkWithCommentsFromGenLocated statements
 mkExpression (GHC.HsDo _ stmtContext@(GHC.DoExpr _) statements) =
   DoBlock
     { qualifiedDo = mkQualifiedDo stmtContext
     , statements =
-        fmap (fmap mkExprStatement . fromGenLocated)
-          <$> fromGenLocated statements
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated)
+          <$> mkWithCommentsFromGenLocated statements
     }
 mkExpression (GHC.HsDo _ stmtContext@(GHC.MDoExpr _) statements) =
   DoBlock
     { qualifiedDo = mkQualifiedDo stmtContext
     , statements =
-        fmap (fmap mkExprStatement . fromGenLocated)
-          <$> fromGenLocated statements
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated)
+          <$> mkWithCommentsFromGenLocated statements
     }
 mkExpression (GHC.HsDo _ GHC.GhciStmtCtxt {} _) =
   error "`ghc-lib-parser` never generates this AST node."
 mkExpression (GHC.ExplicitList _ items) =
-  ListLiteral (fmap (fmap mkExpression . fromGenLocated) items)
+  ListLiteral (fmap (fmap mkExpression . mkWithCommentsFromGenLocated) items)
 mkExpression (GHC.RecordCon { GHC.rcon_con = conName
                             , GHC.rcon_flds = recordFields
                             }) =
   RecordConstruction
-    { name = mkPrefixName <$> fromGenLocated conName
+    { name = mkPrefixName <$> mkWithCommentsFromGenLocated conName
     , fields = mkRecordConstructionFields recordFields
     }
 mkExpression (GHC.RecordUpd { GHC.rupd_expr = recordExpr
                             , GHC.rupd_flds = updates
                             }) =
   RecordUpdate
-    $ mkRecordUpdateFields (mkExpression <$> fromGenLocated recordExpr) updates
+    $ mkRecordUpdateFields
+        (mkExpression <$> mkWithCommentsFromGenLocated recordExpr)
+        updates
 mkExpression (GHC.HsGetField {GHC.gf_expr = fieldExpr, GHC.gf_field = selector}) =
   FieldProjection
-    { expression = mkExpression <$> fromGenLocated fieldExpr
-    , selector = fmap mkFieldSelector (fromGenLocated selector)
+    { expression = mkExpression <$> mkWithCommentsFromGenLocated fieldExpr
+    , selector = fmap mkFieldSelector (mkWithCommentsFromGenLocated selector)
     }
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkExpression (GHC.HsProjection {GHC.proj_flds = fields}) =
   Projection $ fmap (mkWithComments . mkFieldSelector) fields
 #else
 mkExpression (GHC.HsProjection {GHC.proj_flds = fields}) =
-  Projection $ fmap (fmap mkFieldSelector . fromGenLocated) fields
+  Projection $ fmap (fmap mkFieldSelector . mkWithCommentsFromGenLocated) fields
 #endif
 mkExpression (GHC.ExprWithTySig _ signatureExpr ty) =
   TypeSignature
-    { expression = mkExpression <$> fromGenLocated signatureExpr
+    { expression = mkExpression <$> mkWithCommentsFromGenLocated signatureExpr
     , signature =
         flattenComments
-          $ mkTypeFromHsSigType <$> fromGenLocated (GHC.hswc_body ty)
+          $ mkTypeFromHsSigType
+              <$> mkWithCommentsFromGenLocated (GHC.hswc_body ty)
     }
 mkExpression (GHC.ArithSeq _ _ info) =
   ArithmeticSequence $ mkRangeExpression info
 mkExpression (GHC.HsTypedBracket _ typedExpr) =
-  TypedQuotation $ mkExpression <$> fromGenLocated typedExpr
+  TypedQuotation $ mkExpression <$> mkWithCommentsFromGenLocated typedExpr
 mkExpression (GHC.HsUntypedBracket _ content) =
   UntypedQuotation $ mkBracket content
 #if MIN_VERSION_ghc_lib_parser(9, 12, 2)
@@ -629,15 +640,19 @@ mkExpression (GHC.HsUntypedSplice _ splice) = Splice $ mkSplice splice
 #endif
 mkExpression (GHC.HsProc _ pat command) =
   case getFirst $ foldMap (First . mkCmdDoBlock) cmd of
-    Just block -> ProcDo {pat = mkPattern <$> fromGenLocated pat, block}
-    Nothing -> ProcExpression {pat = mkPattern <$> fromGenLocated pat, cmd}
+    Just block ->
+      ProcDo {pat = mkPattern <$> mkWithCommentsFromGenLocated pat, block}
+    Nothing ->
+      ProcExpression {pat = mkPattern <$> mkWithCommentsFromGenLocated pat, cmd}
   where
-    cmd = flattenComments $ mkCmdFromHsCmdTop <$> fromGenLocated command
+    cmd =
+      flattenComments
+        $ mkCmdFromHsCmdTop <$> mkWithCommentsFromGenLocated command
 mkExpression (GHC.HsStatic _ staticExpr) =
-  StaticExpression $ mkExpression <$> fromGenLocated staticExpr
+  StaticExpression $ mkExpression <$> mkWithCommentsFromGenLocated staticExpr
 mkExpression (GHC.HsPragE _ pragma pragmaticExpr) =
   PragmaticExpression
-    { expression = mkExpression <$> fromGenLocated pragmaticExpr
+    { expression = mkExpression <$> mkWithCommentsFromGenLocated pragmaticExpr
     , pragma = mkExpressionPragma pragma
     }
 #if !MIN_VERSION_ghc_lib_parser(9, 12, 1)

--- a/src/HIndent/Ast/Expression/Bracket.hs
+++ b/src/HIndent/Ast/Expression/Bracket.hs
@@ -48,13 +48,16 @@ mkBracket :: GHC.HsQuote GHC.GhcPs -> Bracket
 mkBracket :: GHC.HsBracket GHC.GhcPs -> Bracket
 #endif
 mkBracket (GHC.ExpBr _ x) =
-  UntypedExpression $ mkExpression <$> fromGenLocated x
-mkBracket (GHC.PatBr _ x) = Pattern $ mkPattern <$> fromGenLocated x
+  UntypedExpression $ mkExpression <$> mkWithCommentsFromGenLocated x
+mkBracket (GHC.PatBr _ x) =
+  Pattern $ mkPattern <$> mkWithCommentsFromGenLocated x
 mkBracket (GHC.DecBrL _ x) =
-  Declaration $ fmap (fmap mkDeclaration . fromGenLocated) x
-mkBracket (GHC.TypBr _ x) = Type $ mkType <$> fromGenLocated x
-mkBracket (GHC.VarBr _ b x) = Variable b $ fromGenLocated $ fmap mkPrefixName x
+  Declaration $ fmap (fmap mkDeclaration . mkWithCommentsFromGenLocated) x
+mkBracket (GHC.TypBr _ x) = Type $ mkType <$> mkWithCommentsFromGenLocated x
+mkBracket (GHC.VarBr _ b x) =
+  Variable b $ mkWithCommentsFromGenLocated $ fmap mkPrefixName x
 mkBracket (GHC.DecBrG {}) = error "This AST node should never appear."
 #if !MIN_VERSION_ghc_lib_parser(9, 4, 1)
-mkBracket (GHC.TExpBr _ x) = TypedExpression $ mkExpression <$> fromGenLocated x
+mkBracket (GHC.TExpBr _ x) =
+  TypedExpression $ mkExpression <$> mkWithCommentsFromGenLocated x
 #endif

--- a/src/HIndent/Ast/Expression/FieldSelector.hs
+++ b/src/HIndent/Ast/Expression/FieldSelector.hs
@@ -9,7 +9,7 @@ import qualified GHC.Data.FastString as GHC
 import qualified GHC.Hs as GHC
 import HIndent.Ast.Name.Prefix (PrefixName, fromString)
 import HIndent.Ast.NodeComments (NodeComments(..))
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.NodeComments (CommentExtraction(..))
 import qualified Language.Haskell.Syntax.Basic as GHC
@@ -30,5 +30,5 @@ mkFieldSelector GHC.DotFieldOcc {..} =
     { name =
         fmap
           (fromString . GHC.unpackFS . GHC.field_label)
-          (fromGenLocated dfoLabel)
+          (mkWithCommentsFromGenLocated dfoLabel)
     }

--- a/src/HIndent/Ast/Expression/RangeExpression.hs
+++ b/src/HIndent/Ast/Expression/RangeExpression.hs
@@ -7,7 +7,7 @@ module HIndent.Ast.Expression.RangeExpression
   ) where
 
 import {-# SOURCE #-} HIndent.Ast.Expression (Expression, mkExpression)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
@@ -45,20 +45,21 @@ instance Pretty RangeExpression where
       $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 mkRangeExpression :: GHC.ArithSeqInfo GHC.GhcPs -> RangeExpression
-mkRangeExpression (GHC.From f) = From $ mkExpression <$> fromGenLocated f
+mkRangeExpression (GHC.From f) =
+  From $ mkExpression <$> mkWithCommentsFromGenLocated f
 mkRangeExpression (GHC.FromThen f n) =
   FromThen
-    { from = mkExpression <$> fromGenLocated f
-    , next = mkExpression <$> fromGenLocated n
+    { from = mkExpression <$> mkWithCommentsFromGenLocated f
+    , next = mkExpression <$> mkWithCommentsFromGenLocated n
     }
 mkRangeExpression (GHC.FromTo f t) =
   FromTo
-    { from = mkExpression <$> fromGenLocated f
-    , to = mkExpression <$> fromGenLocated t
+    { from = mkExpression <$> mkWithCommentsFromGenLocated f
+    , to = mkExpression <$> mkWithCommentsFromGenLocated t
     }
 mkRangeExpression (GHC.FromThenTo f n t) =
   FromThenTo
-    { from = mkExpression <$> fromGenLocated f
-    , next = mkExpression <$> fromGenLocated n
-    , to = mkExpression <$> fromGenLocated t
+    { from = mkExpression <$> mkWithCommentsFromGenLocated f
+    , next = mkExpression <$> mkWithCommentsFromGenLocated n
+    , to = mkExpression <$> mkWithCommentsFromGenLocated t
     }

--- a/src/HIndent/Ast/Expression/RecordConstructionField.hs
+++ b/src/HIndent/Ast/Expression/RecordConstructionField.hs
@@ -10,7 +10,7 @@ import Data.Maybe (isJust)
 import qualified GHC.Hs as GHC
 import HIndent.Ast.NodeComments (NodeComments(..))
 import HIndent.Ast.Record.Field (ExprField, mkExprField)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
@@ -31,6 +31,6 @@ mkRecordConstructionFields ::
      GHC.HsRecordBinds GHC.GhcPs -> RecordConstructionFields
 mkRecordConstructionFields GHC.HsRecFields {..} =
   RecordConstructionFields
-    { fields = fmap (fmap mkExprField . fromGenLocated) rec_flds
+    { fields = fmap (fmap mkExprField . mkWithCommentsFromGenLocated) rec_flds
     , dotdot = isJust rec_dotdot
     }

--- a/src/HIndent/Ast/Expression/RecordUpdateField.hs
+++ b/src/HIndent/Ast/Expression/RecordUpdateField.hs
@@ -89,16 +89,17 @@ prettyFieldVertical Field {..} = do
 collectFields :: GHC.LHsRecUpdFields GHC.GhcPs -> [WithComments Field]
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 collectFields GHC.RegularRecUpdFields {..} =
-  fmap (fmap mkRegularField . fromGenLocated) recUpdFields
+  fmap (fmap mkRegularField . mkWithCommentsFromGenLocated) recUpdFields
 collectFields GHC.OverloadedRecUpdFields {..} =
-  fmap (fmap mkOverloadedField . fromGenLocated) olRecUpdFields
+  fmap (fmap mkOverloadedField . mkWithCommentsFromGenLocated) olRecUpdFields
 #elif MIN_VERSION_ghc_lib_parser(9, 6, 1)
 collectFields GHC.RegularRecUpdFields {..} =
-  fmap (fmap mkRegularField . fromGenLocated) recUpdFields
+  fmap (fmap mkRegularField . mkWithCommentsFromGenLocated) recUpdFields
 collectFields GHC.OverloadedRecUpdFields {..} =
-  fmap (fmap mkOverloadedField . fromGenLocated) olRecUpdFields
+  fmap (fmap mkOverloadedField . mkWithCommentsFromGenLocated) olRecUpdFields
 #else
-collectFields = fmap (fmap mkRegularField . fromGenLocated) . either id id
+collectFields =
+  fmap (fmap mkRegularField . mkWithCommentsFromGenLocated) . either id id
 #endif
 
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
@@ -106,11 +107,12 @@ mkRegularField ::
      GHC.HsFieldBind (GHC.LFieldOcc GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs) -> Field
 mkRegularField GHC.HsFieldBind {..} =
   Field
-    { fieldName = mkFieldNameFromFieldOcc <$> fromGenLocated hfbLHS
+    { fieldName =
+        mkFieldNameFromFieldOcc <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just $ mkExpression <$> fromGenLocated hfbRHS
+          else Just $ mkExpression <$> mkWithCommentsFromGenLocated hfbRHS
     }
 
 mkOverloadedField ::
@@ -118,11 +120,12 @@ mkOverloadedField ::
   -> Field
 mkOverloadedField GHC.HsFieldBind {..} =
   Field
-    { fieldName = mkFieldNameFromFieldLabelStrings <$> fromGenLocated hfbLHS
+    { fieldName =
+        mkFieldNameFromFieldLabelStrings <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just $ mkExpression <$> fromGenLocated hfbRHS
+          else Just $ mkExpression <$> mkWithCommentsFromGenLocated hfbRHS
     }
 #elif MIN_VERSION_ghc_lib_parser(9, 6, 1)
 mkRegularField ::
@@ -130,11 +133,12 @@ mkRegularField ::
   -> Field
 mkRegularField GHC.HsFieldBind {..} =
   Field
-    { fieldName = mkFieldNameFromAmbiguousFieldOcc <$> fromGenLocated hfbLHS
+    { fieldName =
+        mkFieldNameFromAmbiguousFieldOcc <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just $ mkExpression <$> fromGenLocated hfbRHS
+          else Just $ mkExpression <$> mkWithCommentsFromGenLocated hfbRHS
     }
 
 mkOverloadedField ::
@@ -142,21 +146,23 @@ mkOverloadedField ::
   -> Field
 mkOverloadedField GHC.HsFieldBind {..} =
   Field
-    { fieldName = mkFieldNameFromFieldLabelStrings <$> fromGenLocated hfbLHS
+    { fieldName =
+        mkFieldNameFromFieldLabelStrings <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just $ mkExpression <$> fromGenLocated hfbRHS
+          else Just $ mkExpression <$> mkWithCommentsFromGenLocated hfbRHS
     }
 #else
 mkRegularField ::
      GHC.HsFieldBind (GHC.LFieldOcc GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs) -> Field
 mkRegularField GHC.HsFieldBind {..} =
   Field
-    { fieldName = mkFieldNameFromFieldOcc <$> fromGenLocated hfbLHS
+    { fieldName =
+        mkFieldNameFromFieldOcc <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just $ mkExpression <$> fromGenLocated hfbRHS
+          else Just $ mkExpression <$> mkWithCommentsFromGenLocated hfbRHS
     }
 #endif

--- a/src/HIndent/Ast/Expression/Splice.hs
+++ b/src/HIndent/Ast/Expression/Splice.hs
@@ -11,9 +11,13 @@ import {-# SOURCE #-} HIndent.Ast.Expression (Expression, mkExpression)
 import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 #else
-import HIndent.Ast.WithComments (WithComments, fromGenLocated, mkWithComments)
+import HIndent.Ast.WithComments
+  ( WithComments
+  , mkWithComments
+  , mkWithCommentsFromGenLocated
+  )
 #endif
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
@@ -54,11 +58,12 @@ instance Pretty Splice where
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 mkSplice :: GHC.HsUntypedSplice GHC.GhcPs -> Splice
 mkSplice (GHC.HsUntypedSpliceExpr anns x)
-  | hasDollarToken anns = UntypedDollar $ mkExpression <$> fromGenLocated x
-  | otherwise = UntypedBare $ mkExpression <$> fromGenLocated x
+  | hasDollarToken anns =
+    UntypedDollar $ mkExpression <$> mkWithCommentsFromGenLocated x
+  | otherwise = UntypedBare $ mkExpression <$> mkWithCommentsFromGenLocated x
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkSplice (GHC.HsQuasiQuote _ l (GHC.L _ r)) =
-  QuasiQuote (mkPrefixName <$> fromGenLocated l) r
+  QuasiQuote (mkPrefixName <$> mkWithCommentsFromGenLocated l) r
 #else
 mkSplice (GHC.HsQuasiQuote _ l (GHC.L _ r)) =
   QuasiQuote (mkPrefixName <$> mkWithComments l) r
@@ -66,11 +71,11 @@ mkSplice (GHC.HsQuasiQuote _ l (GHC.L _ r)) =
 #else
 mkSplice :: GHC.HsSplice GHC.GhcPs -> Splice
 mkSplice (GHC.HsTypedSplice _ _ _ body) =
-  Typed $ mkExpression <$> fromGenLocated body
+  Typed $ mkExpression <$> mkWithCommentsFromGenLocated body
 mkSplice (GHC.HsUntypedSplice _ GHC.DollarSplice _ body) =
-  UntypedDollar $ mkExpression <$> fromGenLocated body
+  UntypedDollar $ mkExpression <$> mkWithCommentsFromGenLocated body
 mkSplice (GHC.HsUntypedSplice _ GHC.BareSplice _ body) =
-  UntypedBare $ mkExpression <$> fromGenLocated body
+  UntypedBare $ mkExpression <$> mkWithCommentsFromGenLocated body
 mkSplice (GHC.HsQuasiQuote _ _ l _ r) = QuasiQuote (mkPrefixName l) r
 mkSplice GHC.HsSpliced {} = error "This AST node should never appear."
 #endif
@@ -94,4 +99,4 @@ hasDollarToken (GHC.EpAnn _ anns _) = any isDollarAnn anns
 hasDollarToken GHC.EpAnnNotUsed = False
 #endif
 mkTypedSplice :: GHC.LHsExpr GHC.GhcPs -> Splice
-mkTypedSplice = Typed . fmap mkExpression . fromGenLocated
+mkTypedSplice = Typed . fmap mkExpression . mkWithCommentsFromGenLocated

--- a/src/HIndent/Ast/Guard.hs
+++ b/src/HIndent/Ast/Guard.hs
@@ -21,7 +21,7 @@ import {-# SOURCE #-} HIndent.Ast.Expression
   )
 import HIndent.Ast.NodeComments
 import HIndent.Ast.Statement (ExprStatement, mkExprStatement)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
@@ -93,46 +93,60 @@ mkExprGuard :: GHC.GRHS GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Guard
 mkExprGuard (GHC.GRHS _ conditions resultExpr) =
   ExprGuard
     { guardContext = PlainGuard
-    , conditions = fmap (fmap mkExprStatement . fromGenLocated) conditions
-    , expr = mkGuardExpression . mkExpression <$> fromGenLocated resultExpr
+    , conditions =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) conditions
+    , expr =
+        mkGuardExpression . mkExpression
+          <$> mkWithCommentsFromGenLocated resultExpr
     }
 
 mkCaseExprGuard :: GHC.GRHS GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Guard
 mkCaseExprGuard (GHC.GRHS _ conditions resultExpr) =
   ExprGuard
     { guardContext = CaseGuard
-    , conditions = fmap (fmap mkExprStatement . fromGenLocated) conditions
-    , expr = mkGuardExpression . mkExpression <$> fromGenLocated resultExpr
+    , conditions =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) conditions
+    , expr =
+        mkGuardExpression . mkExpression
+          <$> mkWithCommentsFromGenLocated resultExpr
     }
 
 mkLambdaExprGuard :: GHC.GRHS GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Guard
 mkLambdaExprGuard (GHC.GRHS _ conditions resultExpr) =
   ExprGuard
     { guardContext = LambdaGuard
-    , conditions = fmap (fmap mkExprStatement . fromGenLocated) conditions
-    , expr = mkGuardExpression . mkExpression <$> fromGenLocated resultExpr
+    , conditions =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) conditions
+    , expr =
+        mkGuardExpression . mkExpression
+          <$> mkWithCommentsFromGenLocated resultExpr
     }
 
 mkMultiWayIfExprGuard :: GHC.GRHS GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Guard
 mkMultiWayIfExprGuard (GHC.GRHS _ conditions resultExpr) =
   ExprGuard
     { guardContext = MultiWayIfGuard
-    , conditions = fmap (fmap mkExprStatement . fromGenLocated) conditions
-    , expr = mkGuardExpression . mkExpression <$> fromGenLocated resultExpr
+    , conditions =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) conditions
+    , expr =
+        mkGuardExpression . mkExpression
+          <$> mkWithCommentsFromGenLocated resultExpr
     }
 
 mkCaseCmdGuard :: GHC.GRHS GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Guard
 mkCaseCmdGuard (GHC.GRHS _ conditions cmd) =
   CmdGuard
     { guardContext = CaseGuard
-    , conditions = fmap (fmap mkExprStatement . fromGenLocated) conditions
-    , cmd = fmap mkCmd (fromGenLocated cmd)
+    , conditions =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) conditions
+    , cmd = fmap mkCmd (mkWithCommentsFromGenLocated cmd)
     }
 
 mkLambdaCmdGuard :: GHC.GRHS GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Guard
 mkLambdaCmdGuard (GHC.GRHS _ conditions cmd) =
   CmdGuard
     { guardContext = LambdaGuard
-    , conditions = fmap (fmap mkExprStatement . fromGenLocated) conditions
-    , cmd = fmap mkCmd (fromGenLocated cmd)
+    , conditions =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) conditions
+    , cmd = fmap mkCmd (mkWithCommentsFromGenLocated cmd)
     }

--- a/src/HIndent/Ast/Import.hs
+++ b/src/HIndent/Ast/Import.hs
@@ -58,7 +58,7 @@ instance Pretty Import where
 mkImport :: GHC.ImportDecl GHC.GhcPs -> Import
 mkImport decl@GHC.ImportDecl {..} = Import {..}
   where
-    moduleName = mkModuleName <$> fromGenLocated ideclName
+    moduleName = mkModuleName <$> mkWithCommentsFromGenLocated ideclName
     isSafe = ideclSafe
     isBoot = ideclSource == GHC.IsBoot
     qualification =
@@ -66,7 +66,7 @@ mkImport decl@GHC.ImportDecl {..} = Import {..}
         GHC.NotQualified -> Nothing
         GHC.QualifiedPre -> Just Pre
         GHC.QualifiedPost -> Just Post
-    qualifiedAs = fmap mkModuleName . fromGenLocated <$> ideclAs
+    qualifiedAs = fmap mkModuleName . mkWithCommentsFromGenLocated <$> ideclAs
     packageName = mkTextValueFromStringLiteral <$> GHC.getPackageName decl
     importEntries = mkImportEntryCollection decl
 

--- a/src/HIndent/Ast/Import/Collection.hs
+++ b/src/HIndent/Ast/Import/Collection.hs
@@ -43,7 +43,7 @@ mkImportCollection :: GHC.HsModule' -> ImportCollection
 mkImportCollection GHC.HsModule {..} =
   ImportCollection
     $ fmap
-        (fmap (fmap mkImport . fromGenLocated))
+        (fmap (fmap mkImport . mkWithCommentsFromGenLocated))
         (extractImports' hsmodImports)
 
 hasImports :: ImportCollection -> Bool

--- a/src/HIndent/Ast/Import/Entry.hs
+++ b/src/HIndent/Ast/Import/Entry.hs
@@ -37,29 +37,33 @@ instance Pretty ImportEntry where
 mkImportEntry :: GHC.IE GHC.GhcPs -> ImportEntry
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkImportEntry (GHC.IEVar _ name _) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkImportEntry (GHC.IEThingAbs _ name _) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkImportEntry (GHC.IEThingAll _ name _) =
-  WithAllConstructors $ mkImportExportName <$> fromGenLocated name
+  WithAllConstructors $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkImportEntry (GHC.IEThingWith _ name _ constructors _) =
   WithSpecificConstructors
-    { name = mkImportExportName <$> fromGenLocated name
+    { name = mkImportExportName <$> mkWithCommentsFromGenLocated name
     , constructors =
-        fmap (fmap mkImportExportName . fromGenLocated) constructors
+        fmap
+          (fmap mkImportExportName . mkWithCommentsFromGenLocated)
+          constructors
     }
 #else
 mkImportEntry (GHC.IEVar _ name) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkImportEntry (GHC.IEThingAbs _ name) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkImportEntry (GHC.IEThingAll _ name) =
-  WithAllConstructors $ mkImportExportName <$> fromGenLocated name
+  WithAllConstructors $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkImportEntry (GHC.IEThingWith _ name _ constructors) =
   WithSpecificConstructors
-    { name = mkImportExportName <$> fromGenLocated name
+    { name = mkImportExportName <$> mkWithCommentsFromGenLocated name
     , constructors =
-        fmap (fmap mkImportExportName . fromGenLocated) constructors
+        fmap
+          (fmap mkImportExportName . mkWithCommentsFromGenLocated)
+          constructors
     }
 #endif
 mkImportEntry _ = undefined

--- a/src/HIndent/Ast/Import/Entry/Collection.hs
+++ b/src/HIndent/Ast/Import/Entry/Collection.hs
@@ -41,13 +41,13 @@ mkImportEntryCollection GHC.ImportDecl {..} =
     Just (GHC.Exactly, xs) ->
       Just
         $ fmap (\entries -> ImportEntryCollection {kind = Importing, ..})
-        $ fromGenLocated
-        $ fmap (fmap (fmap mkImportEntry . fromGenLocated)) xs
+        $ mkWithCommentsFromGenLocated
+        $ fmap (fmap (fmap mkImportEntry . mkWithCommentsFromGenLocated)) xs
     Just (GHC.EverythingBut, xs) ->
       Just
         $ fmap (\entries -> ImportEntryCollection {kind = Hiding, ..})
-        $ fromGenLocated
-        $ fmap (fmap (fmap mkImportEntry . fromGenLocated)) xs
+        $ mkWithCommentsFromGenLocated
+        $ fmap (fmap (fmap mkImportEntry . mkWithCommentsFromGenLocated)) xs
 #else
 mkImportEntryCollection GHC.ImportDecl {..} =
   case ideclHiding of
@@ -55,13 +55,13 @@ mkImportEntryCollection GHC.ImportDecl {..} =
     Just (False, xs) ->
       Just
         $ fmap (\entries -> ImportEntryCollection {kind = Importing, ..})
-        $ fromGenLocated
-        $ fmap (fmap (fmap mkImportEntry . fromGenLocated)) xs
+        $ mkWithCommentsFromGenLocated
+        $ fmap (fmap (fmap mkImportEntry . mkWithCommentsFromGenLocated)) xs
     Just (True, xs) ->
       Just
         $ fmap (\entries -> ImportEntryCollection {kind = Hiding, ..})
-        $ fromGenLocated
-        $ fmap (fmap (fmap mkImportEntry . fromGenLocated)) xs
+        $ mkWithCommentsFromGenLocated
+        $ fmap (fmap (fmap mkImportEntry . mkWithCommentsFromGenLocated)) xs
 #endif
 sortEntriesByName :: ImportEntryCollection -> ImportEntryCollection
 sortEntriesByName ImportEntryCollection {..} =

--- a/src/HIndent/Ast/LocalBinds/Declaration/Collection.hs
+++ b/src/HIndent/Ast/LocalBinds/Declaration/Collection.hs
@@ -8,7 +8,7 @@ import Data.Function
 import Data.List (sortBy)
 import qualified GHC.Types.SrcLoc as GHC
 import HIndent.Ast.LocalBinds.Declaration
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
@@ -30,7 +30,7 @@ mkLocalDeclarationCollection ::
   -> LocalDeclarationCollection
 mkLocalDeclarationCollection sigs binds =
   LocalDeclarationCollection
-    $ fmap fromGenLocated
+    $ fmap mkWithCommentsFromGenLocated
     $ sortBy (compare `on` GHC.realSrcSpan . GHC.locA . GHC.getLoc)
     $ fmap (fmap mkLocalSignatureDeclaration) sigs
         ++ fmap (fmap mkLocalBindingDeclaration) binds

--- a/src/HIndent/Ast/LocalBinds/ImplicitBinding.hs
+++ b/src/HIndent/Ast/LocalBinds/ImplicitBinding.hs
@@ -12,7 +12,7 @@ import HIndent.Ast.Type.ImplicitParameterName
   ( ImplicitParameterName
   , mkImplicitParameterName
   )
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
@@ -34,14 +34,14 @@ mkImplicitBinding :: GHC.IPBind GHC.GhcPs -> ImplicitBinding
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkImplicitBinding (GHC.IPBind _ lhs rhs) =
   ImplicitBinding
-    { name = mkImplicitParameterName <$> fromGenLocated lhs
-    , expression = mkExpression <$> fromGenLocated rhs
+    { name = mkImplicitParameterName <$> mkWithCommentsFromGenLocated lhs
+    , expression = mkExpression <$> mkWithCommentsFromGenLocated rhs
     }
 #else
 mkImplicitBinding (GHC.IPBind _ (Left lhs) rhs) =
   ImplicitBinding
-    { name = mkImplicitParameterName <$> fromGenLocated lhs
-    , expression = mkExpression <$> fromGenLocated rhs
+    { name = mkImplicitParameterName <$> mkWithCommentsFromGenLocated lhs
+    , expression = mkExpression <$> mkWithCommentsFromGenLocated rhs
     }
 mkImplicitBinding (GHC.IPBind _ (Right _) _) =
   error "`ghc-lib-parser` never generates this AST node."

--- a/src/HIndent/Ast/LocalBinds/ImplicitBindings.hs
+++ b/src/HIndent/Ast/LocalBinds/ImplicitBindings.hs
@@ -7,7 +7,7 @@ import HIndent.Ast.LocalBinds.ImplicitBinding
   ( ImplicitBinding
   , mkImplicitBinding
   )
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
@@ -26,4 +26,4 @@ instance Pretty ImplicitBindings where
 mkImplicitBindings :: GHC.HsIPBinds GHC.GhcPs -> ImplicitBindings
 mkImplicitBindings (GHC.IPBinds _ xs) =
   ImplicitBindings
-    {bindings = fmap (fmap mkImplicitBinding . fromGenLocated) xs}
+    {bindings = fmap (fmap mkImplicitBinding . mkWithCommentsFromGenLocated) xs}

--- a/src/HIndent/Ast/Match.hs
+++ b/src/HIndent/Ast/Match.hs
@@ -30,12 +30,17 @@ import HIndent.Ast.NodeComments
 import HIndent.Ast.Pattern (Pattern, mkPattern)
 import HIndent.Ast.Type.Strictness (Strictness, mkStrictness)
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated, prettyWith)
+import HIndent.Ast.WithComments
+  ( WithComments
+  , mkWithCommentsFromEpaLocated
+  , mkWithCommentsFromGenLocated
+  , prettyWith
+  )
 #else
 import HIndent.Ast.WithComments
   ( WithComments
-  , fromGenLocated
   , mkWithComments
+  , mkWithCommentsFromGenLocated
   , prettyWith
   )
 #endif
@@ -105,54 +110,68 @@ mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamSingle, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace $ GHC.unLoc m_pats
     , patterns =
-        fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+        fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+          $ mkWithCommentsFromEpaLocated m_pats
     , rhs = mkLambdaGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt _, ..} =
   Case
     { rhs = mkCaseGuardedRhs m_grhss
     , patterns =
-        fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+        fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+          $ mkWithCommentsFromEpaLocated m_pats
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
     { rhs = mkCaseGuardedRhs m_grhss
     , patterns =
-        fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+        fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+          $ mkWithCommentsFromEpaLocated m_pats
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = ctxt@GHC.FunRhs {}, ..} =
   mkFunctionMatch ctxt patterns (mkGuardedRhs m_grhss)
   where
     patterns =
-      fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+      fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+        $ mkWithCommentsFromEpaLocated m_pats
 mkExprMatch _ = error "`ghc-lib-parser` never generates this AST node."
 #elif MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExprMatch :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Match
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamSingle, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace m_pats
-    , patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    , patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkLambdaGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamCase, ..} =
   Case
     { rhs = mkCaseGuardedRhs m_grhss
-    , patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    , patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamCases, ..} =
   Case
-    { patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    { patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkCaseGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
-    { patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    { patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkCaseGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = ctxt@GHC.FunRhs {}, ..} =
   mkFunctionMatch ctxt patterns (mkGuardedRhs m_grhss)
   where
-    patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    patterns =
+      mkWithComments
+        $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
 mkExprMatch _ = error "`ghc-lib-parser` never generates this AST node."
 #elif MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkExprMatch :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Match
@@ -163,39 +182,53 @@ mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LambdaExpr, ..} =
     , rhs = mkLambdaGuardedRhs m_grhss
     }
   where
-    patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    patterns =
+      mkWithComments
+        $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LamCaseAlt {}, ..} =
   Case
-    { patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    { patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkCaseGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
-    { patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    { patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkCaseGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = ctxt@GHC.FunRhs {}, ..} =
   mkFunctionMatch ctxt patterns (mkGuardedRhs m_grhss)
   where
-    patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    patterns =
+      mkWithComments
+        $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
 mkExprMatch _ = error "`ghc-lib-parser` never generates this AST node."
 #else
 mkExprMatch :: GHC.Match GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> Match
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.LambdaExpr, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace m_pats
-    , patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    , patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkLambdaGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
-    { patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    { patterns =
+        mkWithComments
+          $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
     , rhs = mkCaseGuardedRhs m_grhss
     }
 mkExprMatch GHC.Match {GHC.m_ctxt = ctxt@GHC.FunRhs {}, ..} =
   mkFunctionMatch ctxt patterns (mkGuardedRhs m_grhss)
   where
-    patterns = mkWithComments $ fmap (fmap mkPattern . fromGenLocated) m_pats
+    patterns =
+      mkWithComments
+        $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) m_pats
 mkExprMatch _ = error "`ghc-lib-parser` never generates this AST node."
 #endif
 
@@ -205,19 +238,22 @@ mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamSingle, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace (GHC.unLoc m_pats)
     , patterns =
-        fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+        fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+          $ mkWithCommentsFromEpaLocated m_pats
     , rhs = mkLambdaCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt _, ..} =
   Case
     { patterns =
-        fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+        fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+          $ mkWithCommentsFromEpaLocated m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
     { patterns =
-        fmap (fmap (fromGenLocated . fmap mkPattern)) $ fromGenLocated $ m_pats
+        fmap (fmap (mkWithCommentsFromGenLocated . fmap mkPattern))
+          $ mkWithCommentsFromEpaLocated m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch _ = error "`ghc-lib-parser` never generates this AST node."
@@ -226,22 +262,30 @@ mkCmdMatch :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Match
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamSingle, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace m_pats
-    , patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    , patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkLambdaCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamCase, ..} =
   Case
-    { patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    { patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LamAlt GHC.LamCases, ..} =
   Case
-    { patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    { patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
-    { patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    { patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch _ = error "`ghc-lib-parser` never generates this AST node."
@@ -250,17 +294,23 @@ mkCmdMatch :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Match
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LambdaExpr, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace m_pats
-    , patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    , patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkLambdaCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LamCaseAlt {}, ..} =
   Case
-    { patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    { patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
-    { patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    { patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkCaseCmdGuardedRhs m_grhss
     }
 mkCmdMatch _ = error "`ghc-lib-parser` never generates this AST node."
@@ -269,13 +319,17 @@ mkCmdMatch :: GHC.Match GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> Match
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.LambdaExpr, ..} =
   Lambda
     { needsSpaceAfterLambda = lambdaNeedsSpace m_pats
-    , patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    , patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     , rhs = mkLambdaCmdGuardedRhs m_grhss
     }
 mkCmdMatch GHC.Match {GHC.m_ctxt = GHC.CaseAlt, ..} =
   Case
     { rhs = mkCaseCmdGuardedRhs m_grhss
-    , patterns = mkWithComments $ fmap mkPattern . fromGenLocated <$> m_pats
+    , patterns =
+        mkWithComments
+          $ fmap mkPattern . mkWithCommentsFromGenLocated <$> m_pats
     }
 mkCmdMatch _ = error "`ghc-lib-parser` never generates this AST node."
 #endif
@@ -295,7 +349,7 @@ mkFunctionMatch ::
 mkFunctionMatch GHC.FunRhs {mc_fixity = Fixity.Prefix, ..} patterns rhs =
   FunctionPrefix
     { strictness = mkStrictness mc_strictness
-    , name = mkPrefixName <$> fromGenLocated mc_fun
+    , name = mkPrefixName <$> mkWithCommentsFromGenLocated mc_fun
     , ..
     }
 mkFunctionMatch GHC.FunRhs {mc_fixity = Fixity.Infix, ..} pats rhs =
@@ -304,7 +358,8 @@ mkFunctionMatch GHC.FunRhs {mc_fixity = Fixity.Infix, ..} pats rhs =
     operands =
       flip fmap pats $ \case
         left:right:rest ->
-          InfixOperands {operator = mkInfixName <$> fromGenLocated mc_fun, ..}
+          InfixOperands
+            {operator = mkInfixName <$> mkWithCommentsFromGenLocated mc_fun, ..}
         _ -> error "FunctionInfix match must have at least two patterns."
 mkFunctionMatch _ _ _ = error "`ghc-lib-parser` never generates this AST node."
 

--- a/src/HIndent/Ast/MatchGroup.hs
+++ b/src/HIndent/Ast/MatchGroup.hs
@@ -9,8 +9,8 @@ import qualified GHC.Hs as GHC
 import HIndent.Ast.Match (Match, mkCmdMatch, mkExprMatch)
 import HIndent.Ast.WithComments
   ( WithComments
-  , fromGenLocated
   , getNode
+  , mkWithCommentsFromGenLocated
   , prettyWith
   )
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
@@ -30,15 +30,15 @@ mkExprMatchGroup ::
      GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> MatchGroup
 mkExprMatchGroup =
   MatchGroup
-    . fmap (fmap (fmap mkExprMatch . fromGenLocated))
-    . fromGenLocated
+    . fmap (fmap (fmap mkExprMatch . mkWithCommentsFromGenLocated))
+    . mkWithCommentsFromGenLocated
     . GHC.mg_alts
 
 mkCmdMatchGroup :: GHC.MatchGroup GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> MatchGroup
 mkCmdMatchGroup =
   MatchGroup
-    . fmap (fmap (fmap mkCmdMatch . fromGenLocated))
-    . fromGenLocated
+    . fmap (fmap (fmap mkCmdMatch . mkWithCommentsFromGenLocated))
+    . mkWithCommentsFromGenLocated
     . GHC.mg_alts
 
 hasMatches :: MatchGroup -> Bool

--- a/src/HIndent/Ast/Module/Declaration.hs
+++ b/src/HIndent/Ast/Module/Declaration.hs
@@ -44,6 +44,6 @@ mkModuleDeclaration m =
     Nothing -> Nothing
     Just name' -> Just ModuleDeclaration {..}
       where
-        name = mkModuleName <$> fromGenLocated name'
+        name = mkModuleName <$> mkWithCommentsFromGenLocated name'
         warning = mkModuleWarning m
         exports = mkExportCollection m

--- a/src/HIndent/Ast/Module/Export/Collection.hs
+++ b/src/HIndent/Ast/Module/Export/Collection.hs
@@ -23,6 +23,8 @@ instance Pretty ExportCollection where
 mkExportCollection :: GHC.HsModule' -> Maybe (WithComments ExportCollection)
 mkExportCollection =
   fmap
-    (fmap (ExportCollection . fmap (fmap mkExportEntry . fromGenLocated))
-       . fromGenLocated)
+    (fmap
+       (ExportCollection
+          . fmap (fmap mkExportEntry . mkWithCommentsFromGenLocated))
+       . mkWithCommentsFromGenLocated)
     . GHC.hsmodExports

--- a/src/HIndent/Ast/Module/Export/Entry.hs
+++ b/src/HIndent/Ast/Module/Export/Entry.hs
@@ -38,27 +38,29 @@ instance Pretty ExportEntry where
 mkExportEntry :: GHC.IE GHC.GhcPs -> ExportEntry
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkExportEntry (GHC.IEVar _ name _) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkExportEntry (GHC.IEThingAbs _ name _) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkExportEntry (GHC.IEThingAll _ name _) =
-  WithAllConstructors $ mkImportExportName <$> fromGenLocated name
+  WithAllConstructors $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkExportEntry (GHC.IEThingWith _ name _ constructors _) =
-  WithSpecificConstructors (mkImportExportName <$> fromGenLocated name)
-    $ fmap mkImportExportName . fromGenLocated <$> constructors
+  WithSpecificConstructors
+    (mkImportExportName <$> mkWithCommentsFromGenLocated name)
+    $ fmap mkImportExportName . mkWithCommentsFromGenLocated <$> constructors
 #else
 mkExportEntry (GHC.IEVar _ name) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkExportEntry (GHC.IEThingAbs _ name) =
-  SingleIdentifier $ mkImportExportName <$> fromGenLocated name
+  SingleIdentifier $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkExportEntry (GHC.IEThingAll _ name) =
-  WithAllConstructors $ mkImportExportName <$> fromGenLocated name
+  WithAllConstructors $ mkImportExportName <$> mkWithCommentsFromGenLocated name
 mkExportEntry (GHC.IEThingWith _ name _ constructors) =
-  WithSpecificConstructors (mkImportExportName <$> fromGenLocated name)
-    $ fmap mkImportExportName . fromGenLocated <$> constructors
+  WithSpecificConstructors
+    (mkImportExportName <$> mkWithCommentsFromGenLocated name)
+    $ fmap mkImportExportName . mkWithCommentsFromGenLocated <$> constructors
 #endif
 mkExportEntry (GHC.IEModuleContents _ name) =
-  ByModule $ mkModuleName <$> fromGenLocated name
+  ByModule $ mkModuleName <$> mkWithCommentsFromGenLocated name
 mkExportEntry GHC.IEGroup {} = neverAppears
 mkExportEntry GHC.IEDoc {} = neverAppears
 mkExportEntry GHC.IEDocNamed {} = neverAppears

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -46,7 +46,8 @@ instance Pretty ModuleWarning where
 
 mkModuleWarning :: GHC.HsModule' -> Maybe (WithComments ModuleWarning)
 mkModuleWarning =
-  fmap (fromGenLocated . fmap fromWarningTxt) . GHC.getDeprecMessage
+  fmap (mkWithCommentsFromGenLocated . fmap fromWarningTxt)
+    . GHC.getDeprecMessage
 
 fromWarningTxt :: GHC.WarningTxt' -> ModuleWarning
 #if MIN_VERSION_ghc_lib_parser(9, 8, 1)

--- a/src/HIndent/Ast/Name/ImportExport.hs
+++ b/src/HIndent/Ast/Name/ImportExport.hs
@@ -50,14 +50,14 @@ instance Ord ImportExportName where
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 mkImportExportName :: GHC.IEWrappedName GHC.GhcPs -> ImportExportName
 mkImportExportName (GHC.IEName _ name) =
-  Regular $ fromGenLocated $ fmap mkPrefixName name
+  Regular $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 mkImportExportName (GHC.IEPattern _ name) =
-  Pattern $ fromGenLocated $ fmap mkPrefixName name
+  Pattern $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 mkImportExportName (GHC.IEType _ name) =
-  Type $ fromGenLocated $ fmap mkPrefixName name
+  Type $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkImportExportName (GHC.IEData _ name) =
-  Data $ fromGenLocated $ fmap mkPrefixName name
+  Data $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkImportExportName GHC.IEDefault {} =
@@ -66,14 +66,14 @@ mkImportExportName GHC.IEDefault {} =
 #else
 mkImportExportName :: GHC.IEWrappedName GHC.RdrName -> ImportExportName
 mkImportExportName (GHC.IEName name) =
-  Regular $ fromGenLocated $ fmap mkPrefixName name
+  Regular $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 mkImportExportName (GHC.IEPattern _ name) =
-  Pattern $ fromGenLocated $ fmap mkPrefixName name
+  Pattern $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 mkImportExportName (GHC.IEType _ name) =
-  Type $ fromGenLocated $ fmap mkPrefixName name
+  Type $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkImportExportName (GHC.IEData _ name) =
-  Data $ fromGenLocated $ fmap mkPrefixName name
+  Data $ mkWithCommentsFromGenLocated $ fmap mkPrefixName name
 #endif
 #endif
 getNameString :: ImportExportName -> String

--- a/src/HIndent/Ast/Name/RecordField.hs
+++ b/src/HIndent/Ast/Name/RecordField.hs
@@ -15,7 +15,11 @@ import qualified GHC.Data.FastString as GHC
 import qualified GHC.Hs as GHC
 import HIndent.Ast.Name.Prefix (PrefixName, fromString, mkPrefixName)
 import HIndent.Ast.NodeComments (NodeComments(..))
-import HIndent.Ast.WithComments (WithComments, flattenComments, fromGenLocated)
+import HIndent.Ast.WithComments
+  ( WithComments
+  , flattenComments
+  , mkWithCommentsFromGenLocated
+  )
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators (hDotSep)
 import HIndent.Pretty.NodeComments
@@ -36,10 +40,12 @@ instance Pretty FieldName where
 mkFieldNameFromFieldOcc :: GHC.FieldOcc GHC.GhcPs -> FieldName
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkFieldNameFromFieldOcc GHC.FieldOcc {..} =
-  FieldName $ pure $ mkPrefixName <$> fromGenLocated foLabel
+  FieldName $ pure $ mkPrefixName <$> mkWithCommentsFromGenLocated foLabel
 #else
 mkFieldNameFromFieldOcc GHC.FieldOcc {..} =
-  FieldName $ pure $ mkPrefixName <$> fromGenLocated rdrNameFieldOcc
+  FieldName
+    $ pure
+    $ mkPrefixName <$> mkWithCommentsFromGenLocated rdrNameFieldOcc
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkFieldNameFromAmbiguousFieldOcc :: GHC.FieldOcc GHC.GhcPs -> FieldName
@@ -47,9 +53,9 @@ mkFieldNameFromAmbiguousFieldOcc = mkFieldNameFromFieldOcc
 #else
 mkFieldNameFromAmbiguousFieldOcc :: GHC.AmbiguousFieldOcc GHC.GhcPs -> FieldName
 mkFieldNameFromAmbiguousFieldOcc (GHC.Unambiguous GHC.NoExtField name) =
-  FieldName $ pure $ mkPrefixName <$> fromGenLocated name
+  FieldName $ pure $ mkPrefixName <$> mkWithCommentsFromGenLocated name
 mkFieldNameFromAmbiguousFieldOcc (GHC.Ambiguous GHC.NoExtField name) =
-  FieldName $ pure $ mkPrefixName <$> fromGenLocated name
+  FieldName $ pure $ mkPrefixName <$> mkWithCommentsFromGenLocated name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkFieldNameFromFieldLabelStrings :: GHC.FieldLabelStrings GHC.GhcPs -> FieldName
@@ -60,9 +66,9 @@ mkFieldNameFromFieldLabelStrings (GHC.FieldLabelStrings labels) =
       flattenComments
         . fmap
             (fmap (fromString . GHC.unpackFS . GHC.field_label)
-               . fromGenLocated
+               . mkWithCommentsFromGenLocated
                . GHC.dfoLabel)
-        . fromGenLocated
+        . mkWithCommentsFromGenLocated
 #else
 mkFieldNameFromFieldLabelStrings :: GHC.FieldLabelStrings GHC.GhcPs -> FieldName
 mkFieldNameFromFieldLabelStrings (GHC.FieldLabelStrings labels) =
@@ -74,7 +80,7 @@ mkFieldNameFromFieldLabelStrings (GHC.FieldLabelStrings labels) =
       flattenComments
         . fmap
             (fmap (fromString . GHC.unpackFS . GHC.field_label)
-               . fromGenLocated
+               . mkWithCommentsFromGenLocated
                . GHC.dfoLabel)
-        . fromGenLocated
+        . mkWithCommentsFromGenLocated
 #endif

--- a/src/HIndent/Ast/Pattern.hs
+++ b/src/HIndent/Ast/Pattern.hs
@@ -118,103 +118,119 @@ instance Pretty Pattern where
 
 mkPattern :: GHC.Pat GHC.GhcPs -> Pattern
 mkPattern GHC.WildPat {} = WildCard
-mkPattern (GHC.VarPat _ x) = Variable $ mkPrefixName <$> fromGenLocated x
+mkPattern (GHC.VarPat _ x) =
+  Variable $ mkPrefixName <$> mkWithCommentsFromGenLocated x
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkPattern GHC.EmbTyPat {} = notGeneratedByParser
 mkPattern GHC.InvisPat {} = notGeneratedByParser
 #endif
-mkPattern (GHC.LazyPat _ x) = Lazy $ mkPattern <$> fromGenLocated x
+mkPattern (GHC.LazyPat _ x) =
+  Lazy $ mkPattern <$> mkWithCommentsFromGenLocated x
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1) && !MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkPattern (GHC.AsPat _ a _ b) =
   As
-    { name = mkPrefixName <$> fromGenLocated a
-    , pat = mkPattern <$> fromGenLocated b
+    { name = mkPrefixName <$> mkWithCommentsFromGenLocated a
+    , pat = mkPattern <$> mkWithCommentsFromGenLocated b
     }
 #else
 mkPattern (GHC.AsPat _ a b) =
   As
-    { name = mkPrefixName <$> fromGenLocated a
-    , pat = mkPattern <$> fromGenLocated b
+    { name = mkPrefixName <$> mkWithCommentsFromGenLocated a
+    , pat = mkPattern <$> mkWithCommentsFromGenLocated b
     }
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1) && !MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkPattern (GHC.ParPat _ _ inner _) =
-  Parenthesized $ mkPattern <$> fromGenLocated inner
+  Parenthesized $ mkPattern <$> mkWithCommentsFromGenLocated inner
 #else
 mkPattern (GHC.ParPat _ inner) =
-  Parenthesized $ mkPattern <$> fromGenLocated inner
+  Parenthesized $ mkPattern <$> mkWithCommentsFromGenLocated inner
 #endif
-mkPattern (GHC.BangPat _ x) = Bang $ mkPattern <$> fromGenLocated x
-mkPattern (GHC.ListPat _ xs) = List $ fmap (fmap mkPattern . fromGenLocated) xs
+mkPattern (GHC.BangPat _ x) =
+  Bang $ mkPattern <$> mkWithCommentsFromGenLocated x
+mkPattern (GHC.ListPat _ xs) =
+  List $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) xs
 mkPattern (GHC.TuplePat _ pats GHC.Boxed) =
-  Tuple {boxed = True, patterns = fmap (fmap mkPattern . fromGenLocated) pats}
+  Tuple
+    { boxed = True
+    , patterns = fmap (fmap mkPattern . mkWithCommentsFromGenLocated) pats
+    }
 mkPattern (GHC.TuplePat _ pats GHC.Unboxed) =
-  Tuple {boxed = False, patterns = fmap (fmap mkPattern . fromGenLocated) pats}
+  Tuple
+    { boxed = False
+    , patterns = fmap (fmap mkPattern . mkWithCommentsFromGenLocated) pats
+    }
 mkPattern (GHC.SumPat _ x position numElem) =
   Sum
-    {pat = mkPattern <$> fromGenLocated x, position = position, arity = numElem}
+    { pat = mkPattern <$> mkWithCommentsFromGenLocated x
+    , position = position
+    , arity = numElem
+    }
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkPattern GHC.ConPat {..} =
   case pat_args of
     GHC.PrefixCon as ->
       PrefixConstructor
-        { name = mkPrefixName <$> fromGenLocated pat_con
-        , patterns = fmap (fmap mkPattern . fromGenLocated) as
+        { name = mkPrefixName <$> mkWithCommentsFromGenLocated pat_con
+        , patterns = fmap (fmap mkPattern . mkWithCommentsFromGenLocated) as
         }
     GHC.RecCon rec ->
       RecordConstructor
-        { name = mkPrefixName <$> fromGenLocated pat_con
+        { name = mkPrefixName <$> mkWithCommentsFromGenLocated pat_con
         , fields = mkRecordFieldsPat rec
         }
     GHC.InfixCon a b ->
       InfixConstructor
-        { left = mkPattern <$> fromGenLocated a
-        , operator = mkInfixName <$> fromGenLocated pat_con
-        , right = mkPattern <$> fromGenLocated b
+        { left = mkPattern <$> mkWithCommentsFromGenLocated a
+        , operator = mkInfixName <$> mkWithCommentsFromGenLocated pat_con
+        , right = mkPattern <$> mkWithCommentsFromGenLocated b
         }
 #else
 mkPattern GHC.ConPat {..} =
   case pat_args of
     GHC.PrefixCon _ as ->
       PrefixConstructor
-        { name = mkPrefixName <$> fromGenLocated pat_con
-        , patterns = fmap (fmap mkPattern . fromGenLocated) as
+        { name = mkPrefixName <$> mkWithCommentsFromGenLocated pat_con
+        , patterns = fmap (fmap mkPattern . mkWithCommentsFromGenLocated) as
         }
     GHC.RecCon rec ->
       RecordConstructor
-        { name = mkPrefixName <$> fromGenLocated pat_con
+        { name = mkPrefixName <$> mkWithCommentsFromGenLocated pat_con
         , fields = mkRecordFieldsPat rec
         }
     GHC.InfixCon a b ->
       InfixConstructor
-        { left = mkPattern <$> fromGenLocated a
-        , operator = mkInfixName <$> fromGenLocated pat_con
-        , right = mkPattern <$> fromGenLocated b
+        { left = mkPattern <$> mkWithCommentsFromGenLocated a
+        , operator = mkInfixName <$> mkWithCommentsFromGenLocated pat_con
+        , right = mkPattern <$> mkWithCommentsFromGenLocated b
         }
 #endif
 mkPattern (GHC.ViewPat _ l r) =
   View
-    { expression = mkExpression <$> fromGenLocated l
-    , pat = mkPattern <$> fromGenLocated r
+    { expression = mkExpression <$> mkWithCommentsFromGenLocated l
+    , pat = mkPattern <$> mkWithCommentsFromGenLocated r
     }
 mkPattern (GHC.SplicePat _ x) = Splice $ mkWithComments $ mkSplice x
 mkPattern (GHC.LitPat _ x) = Literal $ mkLiteralFromHsLit x
 mkPattern (GHC.NPat _ x _ _) = Literal $ mkLiteralFromHsOverLit $ GHC.unLoc x
 mkPattern (GHC.NPlusKPat _ n k _ _ _) =
   NPlusK
-    { n = mkPrefixName <$> fromGenLocated n
+    { n = mkPrefixName <$> mkWithCommentsFromGenLocated n
     , k = mkLiteralFromHsOverLit $ GHC.unLoc k
     }
 mkPattern (GHC.SigPat _ l r) =
   Signature
-    { pat = mkPattern <$> fromGenLocated l
+    { pat = mkPattern <$> mkWithCommentsFromGenLocated l
     , sig =
         flattenComments
           $ fmap mkType
-              <$> fromEpAnn (GHC.hsps_ext r) (fromGenLocated $ GHC.hsps_body r)
+              <$> fromEpAnn
+                    (GHC.hsps_ext r)
+                    (mkWithCommentsFromGenLocated $ GHC.hsps_body r)
     }
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
-mkPattern (GHC.OrPat _ pats) = Or $ fmap (fmap mkPattern . fromGenLocated) pats
+mkPattern (GHC.OrPat _ pats) =
+  Or $ fmap (fmap mkPattern . mkWithCommentsFromGenLocated) pats
 #endif
 newtype PatInsidePatDecl =
   PatInsidePatDecl Pattern

--- a/src/HIndent/Ast/Pattern/RecordFields.hs
+++ b/src/HIndent/Ast/Pattern/RecordFields.hs
@@ -9,7 +9,7 @@ module HIndent.Ast.Pattern.RecordFields
 import Data.Maybe (isJust)
 import HIndent.Ast.NodeComments
 import HIndent.Ast.Record.Field (PatField, mkPatField)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
@@ -36,6 +36,6 @@ mkRecordFieldsPat ::
      GHC.HsRecFields GHC.GhcPs (GHC.LPat GHC.GhcPs) -> RecordFieldsPat
 mkRecordFieldsPat GHC.HsRecFields {..} =
   RecordFieldsPat
-    { fields = fmap (fmap mkPatField . fromGenLocated) rec_flds
+    { fields = fmap (fmap mkPatField . mkWithCommentsFromGenLocated) rec_flds
     , dotdot = isJust rec_dotdot
     }

--- a/src/HIndent/Ast/Record/Field.hs
+++ b/src/HIndent/Ast/Record/Field.hs
@@ -14,7 +14,7 @@ import {-# SOURCE #-} HIndent.Ast.Expression (Expression, mkExpression)
 import HIndent.Ast.Name.RecordField (FieldName, mkFieldNameFromFieldOcc)
 import HIndent.Ast.NodeComments (NodeComments(..))
 import {-# SOURCE #-} HIndent.Ast.Pattern (Pattern, mkPattern)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated)
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
@@ -57,11 +57,11 @@ mkExprField ::
   -> ExprField
 mkExprField GHC.HsFieldBind {..} =
   Field
-    { name = mkFieldNameFromFieldOcc <$> fromGenLocated hfbLHS
+    { name = mkFieldNameFromFieldOcc <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just (mkExpression <$> fromGenLocated hfbRHS)
+          else Just (mkExpression <$> mkWithCommentsFromGenLocated hfbRHS)
     }
 #else
 mkExprField ::
@@ -69,11 +69,13 @@ mkExprField ::
   -> ExprField
 mkExprField GHC.HsRecField {..} =
   Field
-    { name = mkFieldNameFromFieldOcc <$> fromGenLocated hsRecFieldLbl
+    { name =
+        mkFieldNameFromFieldOcc <$> mkWithCommentsFromGenLocated hsRecFieldLbl
     , value =
         if hsRecPun
           then Nothing
-          else Just (mkExpression <$> fromGenLocated hsRecFieldArg)
+          else Just
+                 (mkExpression <$> mkWithCommentsFromGenLocated hsRecFieldArg)
     }
 #endif
 
@@ -82,21 +84,22 @@ mkPatField ::
      GHC.HsFieldBind (GHC.LFieldOcc GHC.GhcPs) (GHC.LPat GHC.GhcPs) -> PatField
 mkPatField GHC.HsFieldBind {..} =
   Field
-    { name = mkFieldNameFromFieldOcc <$> fromGenLocated hfbLHS
+    { name = mkFieldNameFromFieldOcc <$> mkWithCommentsFromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
-          else Just (mkPattern <$> fromGenLocated hfbRHS)
+          else Just (mkPattern <$> mkWithCommentsFromGenLocated hfbRHS)
     }
 #else
 mkPatField ::
      GHC.HsRecField' (GHC.FieldOcc GHC.GhcPs) (GHC.LPat GHC.GhcPs) -> PatField
 mkPatField GHC.HsRecField {..} =
   Field
-    { name = mkFieldNameFromFieldOcc <$> fromGenLocated hsRecFieldLbl
+    { name =
+        mkFieldNameFromFieldOcc <$> mkWithCommentsFromGenLocated hsRecFieldLbl
     , value =
         if hsRecPun
           then Nothing
-          else Just (mkPattern <$> fromGenLocated hsRecFieldArg)
+          else Just (mkPattern <$> mkWithCommentsFromGenLocated hsRecFieldArg)
     }
 #endif

--- a/src/HIndent/Ast/Statement.hs
+++ b/src/HIndent/Ast/Statement.hs
@@ -14,7 +14,11 @@ import {-# SOURCE #-} HIndent.Ast.Cmd (Cmd, mkCmd)
 import {-# SOURCE #-} HIndent.Ast.Expression (Expression, mkExpression)
 import HIndent.Ast.LocalBinds (LocalBinds, mkLocalBinds)
 import HIndent.Ast.Pattern (Pattern, mkPattern)
-import HIndent.Ast.WithComments (WithComments, fromGenLocated, prettyWith)
+import HIndent.Ast.WithComments
+  ( WithComments
+  , mkWithCommentsFromGenLocated
+  , prettyWith
+  )
 import {-# SOURCE #-} HIndent.Pretty (Pretty(..), pretty)
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments (CommentExtraction(..), emptyNodeComments)
@@ -64,14 +68,14 @@ instance Pretty a => Pretty (Statement a) where
 mkExprStatement ::
      GHC.StmtLR GHC.GhcPs GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> ExprStatement
 mkExprStatement (GHC.LastStmt _ expr _ _) =
-  Expression $ mkExpression <$> fromGenLocated expr
+  Expression $ mkExpression <$> mkWithCommentsFromGenLocated expr
 mkExprStatement (GHC.BindStmt _ pat expr) =
   Binding
-    { lhsPattern = mkPattern <$> fromGenLocated pat
-    , rhs = mkExpression <$> fromGenLocated expr
+    { lhsPattern = mkPattern <$> mkWithCommentsFromGenLocated pat
+    , rhs = mkExpression <$> mkWithCommentsFromGenLocated expr
     }
 mkExprStatement (GHC.BodyStmt _ body _ _) =
-  Expression $ mkExpression <$> fromGenLocated body
+  Expression $ mkExpression <$> mkWithCommentsFromGenLocated body
 mkExprStatement (GHC.LetStmt _ binds) =
   case mkLocalBinds binds of
     Just localBinds -> LetBinding localBinds
@@ -82,19 +86,20 @@ mkExprStatement (GHC.ParStmt _ blocks _ _) =
   Parallel
     $ fmap
         (\(GHC.ParStmtBlock _ stmts _ _) ->
-           fmap (fmap mkExprStatement . fromGenLocated) stmts)
+           fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) stmts)
         (toList blocks)
 mkExprStatement GHC.TransStmt {..} =
   Transform
-    { steps = fmap (fmap mkExprStatement . fromGenLocated) trS_stmts
-    , using = mkExpression <$> fromGenLocated trS_using
+    { steps =
+        fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated) trS_stmts
+    , using = mkExpression <$> mkWithCommentsFromGenLocated trS_using
     }
 mkExprStatement GHC.RecStmt {..} =
   Recursive
     { block =
         fmap
-          (fmap (fmap mkExprStatement . fromGenLocated))
-          (fromGenLocated recS_stmts)
+          (fmap (fmap mkExprStatement . mkWithCommentsFromGenLocated))
+          (mkWithCommentsFromGenLocated recS_stmts)
     }
 #if !MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkExprStatement GHC.ApplicativeStmt {} =
@@ -103,14 +108,14 @@ mkExprStatement GHC.ApplicativeStmt {} =
 mkCmdStatement ::
      GHC.StmtLR GHC.GhcPs GHC.GhcPs (GHC.LHsCmd GHC.GhcPs) -> CmdStatement
 mkCmdStatement (GHC.LastStmt _ cmd _ _) =
-  Expression $ mkCmd <$> fromGenLocated cmd
+  Expression $ mkCmd <$> mkWithCommentsFromGenLocated cmd
 mkCmdStatement (GHC.BindStmt _ pat cmd) =
   Binding
-    { lhsPattern = mkPattern <$> fromGenLocated pat
-    , rhs = mkCmd <$> fromGenLocated cmd
+    { lhsPattern = mkPattern <$> mkWithCommentsFromGenLocated pat
+    , rhs = mkCmd <$> mkWithCommentsFromGenLocated cmd
     }
 mkCmdStatement (GHC.BodyStmt _ cmd _ _) =
-  Expression $ mkCmd <$> fromGenLocated cmd
+  Expression $ mkCmd <$> mkWithCommentsFromGenLocated cmd
 mkCmdStatement (GHC.LetStmt _ binds) =
   case mkLocalBinds binds of
     Just localBinds -> LetBinding localBinds

--- a/src/HIndent/Ast/Type.hs
+++ b/src/HIndent/Ast/Type.hs
@@ -206,97 +206,110 @@ mkType :: GHC.HsType GHC.GhcPs -> Type
 mkType (GHC.HsForAllTy _ tele body) =
   UniversalType
     { telescope = mkForallFromTelescope tele
-    , body = mkType <$> fromGenLocated body
+    , body = mkType <$> mkWithCommentsFromGenLocated body
     }
 mkType GHC.HsQualTy {..} =
   ConstrainedType
     { context = mkWithComments $ Context hst_ctxt
-    , body = mkType <$> fromGenLocated hst_body
+    , body = mkType <$> mkWithCommentsFromGenLocated hst_body
     }
 mkType (GHC.HsTyVar _ GHC.IsPromoted x) =
-  Variable {isPromoted = True, name = mkPrefixName <$> fromGenLocated x}
+  Variable
+    {isPromoted = True, name = mkPrefixName <$> mkWithCommentsFromGenLocated x}
 mkType (GHC.HsTyVar _ GHC.NotPromoted x) =
-  Variable {isPromoted = False, name = mkPrefixName <$> fromGenLocated x}
+  Variable
+    {isPromoted = False, name = mkPrefixName <$> mkWithCommentsFromGenLocated x}
 mkType (GHC.HsAppTy _ l r) =
   Application
-    { function = mkType <$> fromGenLocated l
-    , argument = mkType <$> fromGenLocated r
+    { function = mkType <$> mkWithCommentsFromGenLocated l
+    , argument = mkType <$> mkWithCommentsFromGenLocated r
     }
 #if MIN_VERSION_ghc_lib_parser(9, 8, 1) && !MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkType (GHC.HsAppKindTy _ l _ r) =
   KindApplication
-    {base = mkType <$> fromGenLocated l, kind = mkType <$> fromGenLocated r}
+    { base = mkType <$> mkWithCommentsFromGenLocated l
+    , kind = mkType <$> mkWithCommentsFromGenLocated r
+    }
 #else
 mkType (GHC.HsAppKindTy _ l r) =
   KindApplication
-    {base = mkType <$> fromGenLocated l, kind = mkType <$> fromGenLocated r}
+    { base = mkType <$> mkWithCommentsFromGenLocated l
+    , kind = mkType <$> mkWithCommentsFromGenLocated r
+    }
 #endif
 mkType (GHC.HsFunTy _ arr a b) =
   Function
     { multiplicity = mkMultiplicity arr
-    , from = mkType <$> fromGenLocated a
-    , to = mkType <$> fromGenLocated b
+    , from = mkType <$> mkWithCommentsFromGenLocated a
+    , to = mkType <$> mkWithCommentsFromGenLocated b
     }
-mkType (GHC.HsListTy _ xs) = List {elementType = mkType <$> fromGenLocated xs}
+mkType (GHC.HsListTy _ xs) =
+  List {elementType = mkType <$> mkWithCommentsFromGenLocated xs}
 mkType (GHC.HsTupleTy _ sort xs) =
   Tuple
     { isUnboxed =
         case sort of
           GHC.HsUnboxedTuple -> True
           _ -> False
-    , elements = fmap (fmap mkType . fromGenLocated) xs
+    , elements = fmap (fmap mkType . mkWithCommentsFromGenLocated) xs
     }
 mkType (GHC.HsSumTy _ xs) =
-  Sum {elements = fmap (fmap mkType . fromGenLocated) xs}
+  Sum {elements = fmap (fmap mkType . mkWithCommentsFromGenLocated) xs}
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkType (GHC.HsOpTy _ _ l op r) =
   InfixType
-    { left = mkType <$> fromGenLocated l
-    , operator = mkInfixName <$> fromGenLocated op
-    , right = mkType <$> fromGenLocated r
+    { left = mkType <$> mkWithCommentsFromGenLocated l
+    , operator = mkInfixName <$> mkWithCommentsFromGenLocated op
+    , right = mkType <$> mkWithCommentsFromGenLocated r
     }
 #else
 mkType (GHC.HsOpTy _ l op r) =
   InfixType
-    { left = mkType <$> fromGenLocated l
-    , operator = mkInfixName <$> fromGenLocated op
-    , right = mkType <$> fromGenLocated r
+    { left = mkType <$> mkWithCommentsFromGenLocated l
+    , operator = mkInfixName <$> mkWithCommentsFromGenLocated op
+    , right = mkType <$> mkWithCommentsFromGenLocated r
     }
 #endif
 mkType (GHC.HsParTy _ inside) =
-  Parenthesized {inner = mkType <$> fromGenLocated inside}
+  Parenthesized {inner = mkType <$> mkWithCommentsFromGenLocated inside}
 mkType (GHC.HsIParamTy _ x ty) =
   ImplicitParameter
-    { ipName = mkImplicitParameterName <$> fromGenLocated x
-    , paramType = mkType <$> fromGenLocated ty
+    { ipName = mkImplicitParameterName <$> mkWithCommentsFromGenLocated x
+    , paramType = mkType <$> mkWithCommentsFromGenLocated ty
     }
 mkType GHC.HsStarTy {} = Star
 mkType (GHC.HsKindSig _ t k) =
   KindSig
-    { annotated = mkType <$> fromGenLocated t
-    , kind = mkType <$> fromGenLocated k
+    { annotated = mkType <$> mkWithCommentsFromGenLocated t
+    , kind = mkType <$> mkWithCommentsFromGenLocated k
     }
 mkType (GHC.HsSpliceTy _ sp) = Splice {splice = mkSplice sp}
 mkType GHC.HsDocTy {} = error "HsDocTy not supported"
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkType (GHC.XHsType (GHC.HsBangTy _ pack x)) =
-  StrictType {bang = mkBang pack, baseType = mkType <$> fromGenLocated x}
+  StrictType
+    {bang = mkBang pack, baseType = mkType <$> mkWithCommentsFromGenLocated x}
 mkType (GHC.XHsType (GHC.HsRecTy _ xs)) =
-  RecordType {fields = fmap (fromGenLocated . fmap mkRecordField) xs}
+  RecordType
+    {fields = fmap (mkWithCommentsFromGenLocated . fmap mkRecordField) xs}
 #else
 mkType (GHC.HsBangTy _ pack x) =
-  StrictType {bang = mkBang pack, baseType = mkType <$> fromGenLocated x}
+  StrictType
+    {bang = mkBang pack, baseType = mkType <$> mkWithCommentsFromGenLocated x}
 mkType (GHC.HsRecTy _ xs) =
-  RecordType {fields = fmap (fromGenLocated . fmap mkRecordField) xs}
+  RecordType
+    {fields = fmap (mkWithCommentsFromGenLocated . fmap mkRecordField) xs}
 #endif
 mkType (GHC.HsExplicitListTy _ _ xs) =
-  PromotedList {elements = fmap (fmap mkType . fromGenLocated) xs}
+  PromotedList {elements = fmap (fmap mkType . mkWithCommentsFromGenLocated) xs}
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 mkType (GHC.HsExplicitTupleTy _ _ xs) =
-  PromotedTuple {elements = fmap (fmap mkType . fromGenLocated) xs}
+  PromotedTuple
+    {elements = fmap (fmap mkType . mkWithCommentsFromGenLocated) xs}
 #else
 mkType (GHC.HsExplicitTupleTy _ xs) =
-  PromotedTuple {elements = fmap (fmap mkType . fromGenLocated) xs}
+  PromotedTuple
+    {elements = fmap (fmap mkType . mkWithCommentsFromGenLocated) xs}
 #endif
 mkType (GHC.HsTyLit _ x) = Literal {literal = mkLiteralFromHsTyLit x}
 mkType GHC.HsWildCardTy {} = Wildcard
@@ -309,12 +322,12 @@ mkTypeFromConDeclField GHC.CDF {..}
   | otherwise =
     addComments (getComments baseType) (mkWithComments StrictType {..})
   where
-    baseType = mkType <$> fromGenLocated cdf_type
+    baseType = mkType <$> mkWithCommentsFromGenLocated cdf_type
     bang = mkBang (GHC.HsSrcBang GHC.NoSourceText cdf_unpack cdf_bang)
 #else
 mkTypeFromConDeclField :: GHC.ConDeclField GHC.GhcPs -> WithComments Type
 mkTypeFromConDeclField GHC.ConDeclField {..} =
-  mkType <$> fromGenLocated cd_fld_type
+  mkType <$> mkWithCommentsFromGenLocated cd_fld_type
 #endif
 mkTypeFromHsSigType :: GHC.HsSigType GHC.GhcPs -> WithComments Type
 mkTypeFromHsSigType GHC.HsSig {..} =
@@ -322,12 +335,15 @@ mkTypeFromHsSigType GHC.HsSig {..} =
     Just telescope ->
       mkWithComments
         $ UniversalType
-            {telescope = telescope, body = mkType <$> fromGenLocated sig_body}
-    Nothing -> mkType <$> fromGenLocated sig_body
+            { telescope = telescope
+            , body = mkType <$> mkWithCommentsFromGenLocated sig_body
+            }
+    Nothing -> mkType <$> mkWithCommentsFromGenLocated sig_body
 
 mkTypeFromLHsWcType ::
      GHC.LHsWcType (GHC.NoGhcTc GHC.GhcPs) -> WithComments Type
-mkTypeFromLHsWcType GHC.HsWC {..} = mkType <$> fromGenLocated hswc_body
+mkTypeFromLHsWcType GHC.HsWC {..} =
+  mkType <$> mkWithCommentsFromGenLocated hswc_body
 
 newtype VerticalFuncType =
   VerticalFuncType Type

--- a/src/HIndent/Ast/Type/Argument.hs
+++ b/src/HIndent/Ast/Type/Argument.hs
@@ -34,14 +34,14 @@ mkTypeArgument ::
   -> Maybe TypeArgument
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkTypeArgument (GHC.HsValArg _ argType) =
-  Just TypeArgument {argType = mkType <$> fromGenLocated argType}
+  Just TypeArgument {argType = mkType <$> mkWithCommentsFromGenLocated argType}
 mkTypeArgument (GHC.HsTypeArg _ argKind) =
-  Just KindArgument {argKind = mkType <$> fromGenLocated argKind}
+  Just KindArgument {argKind = mkType <$> mkWithCommentsFromGenLocated argKind}
 mkTypeArgument GHC.HsArgPar {} = Nothing
 #else
 mkTypeArgument (GHC.HsValArg argType) =
-  Just TypeArgument {argType = mkType <$> fromGenLocated argType}
+  Just TypeArgument {argType = mkType <$> mkWithCommentsFromGenLocated argType}
 mkTypeArgument (GHC.HsTypeArg _ argKind) =
-  Just KindArgument {argKind = mkType <$> fromGenLocated argKind}
+  Just KindArgument {argKind = mkType <$> mkWithCommentsFromGenLocated argKind}
 mkTypeArgument GHC.HsArgPar {} = Nothing
 #endif

--- a/src/HIndent/Ast/Type/Forall.hs
+++ b/src/HIndent/Ast/Type/Forall.hs
@@ -35,11 +35,11 @@ mkForallFromTelescope :: GHC.HsForAllTelescope GHC.GhcPs -> WithComments Forall
 mkForallFromTelescope GHC.HsForAllVis {..} =
   fromEpAnn hsf_xvis
     $ Visible
-    $ fmap (fmap mkTypeVariable . fromGenLocated) hsf_vis_bndrs
+    $ fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated) hsf_vis_bndrs
 mkForallFromTelescope GHC.HsForAllInvis {..} =
   fromEpAnn hsf_xinvis
     $ Invisible
-    $ fmap (fmap mkTypeVariable . fromGenLocated) hsf_invis_bndrs
+    $ fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated) hsf_invis_bndrs
 
 mkForallFromOuter ::
      GHC.HsOuterTyVarBndrs flag GHC.GhcPs -> Maybe (WithComments Forall)
@@ -47,5 +47,5 @@ mkForallFromOuter (GHC.HsOuterExplicit ann xs) =
   Just
     $ fromEpAnn ann
     $ Invisible
-    $ fmap (fmap mkTypeVariable . fromGenLocated) xs
+    $ fmap (fmap mkTypeVariable . mkWithCommentsFromGenLocated) xs
 mkForallFromOuter GHC.HsOuterImplicit {} = Nothing

--- a/src/HIndent/Ast/Type/Multiplicity.hs
+++ b/src/HIndent/Ast/Type/Multiplicity.hs
@@ -33,17 +33,17 @@ mkMultiplicity :: GHC.HsMultAnn GHC.GhcPs -> Multiplicity
 mkMultiplicity GHC.HsUnannotated {} = MkUnrestricted
 mkMultiplicity GHC.HsLinearAnn {} = MkLinear
 mkMultiplicity (GHC.HsExplicitMult _ mult) =
-  MkExplicit (mkType <$> fromGenLocated mult)
+  MkExplicit (mkType <$> mkWithCommentsFromGenLocated mult)
 #else
 mkMultiplicity :: GHC.HsArrow GHC.GhcPs -> Multiplicity
 mkMultiplicity (GHC.HsUnrestrictedArrow _) = MkUnrestricted
 mkMultiplicity (GHC.HsLinearArrow _) = MkLinear
 #if MIN_VERSION_ghc_lib_parser(9, 10, 0)
 mkMultiplicity (GHC.HsExplicitMult _ mult) =
-  MkExplicit (mkType <$> fromGenLocated mult)
+  MkExplicit (mkType <$> mkWithCommentsFromGenLocated mult)
 #else
 mkMultiplicity (GHC.HsExplicitMult _ mult _) =
-  MkExplicit (mkType <$> fromGenLocated mult)
+  MkExplicit (mkType <$> mkWithCommentsFromGenLocated mult)
 #endif
 #endif
 isUnrestricted :: Multiplicity -> Bool

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -36,19 +36,19 @@ mkTypeVariable GHC.HsTvb {..} = TypeVariable {..}
   where
     name =
       case tvb_var of
-        GHC.HsBndrVar _ n -> fromGenLocated $ fmap mkPrefixName n
+        GHC.HsBndrVar _ n -> mkWithCommentsFromGenLocated $ fmap mkPrefixName n
         GHC.HsBndrWildCard _ -> mkWithComments (Prefix.fromString "_")
     kind =
       case tvb_kind of
-        GHC.HsBndrKind _ k -> Just $ mkType <$> fromGenLocated k
+        GHC.HsBndrKind _ k -> Just $ mkType <$> mkWithCommentsFromGenLocated k
         GHC.HsBndrNoKind _ -> Nothing
 #else
 mkTypeVariable (GHC.UserTyVar _ _ n) = TypeVariable {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName n
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
     kind = Nothing
 mkTypeVariable (GHC.KindedTyVar _ _ n k) = TypeVariable {..}
   where
-    name = fromGenLocated $ fmap mkPrefixName n
-    kind = Just $ mkType <$> fromGenLocated k
+    name = mkWithCommentsFromGenLocated $ fmap mkPrefixName n
+    kind = Just $ mkType <$> mkWithCommentsFromGenLocated k
 #endif

--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -6,6 +6,8 @@
 module HIndent.Ast.WithComments
   ( WithComments
   , prettyWith
+  , mkWithCommentsFromGenLocated
+  , mkWithCommentsFromEpaLocated
   , fromGenLocated
   , fromEpAnn
   , mkWithComments
@@ -17,13 +19,19 @@ module HIndent.Ast.WithComments
 
 import Control.Monad
 import Control.Monad.RWS
-import qualified GHC.Hs as GHC
+import qualified GHC.Parser.Annotation as GHC
 import qualified GHC.Types.SrcLoc as GHC
 import HIndent.Ast.Comment (Comment, getColumn, mkComment)
 import HIndent.Ast.IsGenLocatedLocation
   ( CommentGroup(..)
   , mkCommentGroupFromEpAnn
   )
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+import HIndent.Ast.IsGenLocatedLocation
+  ( IsGenLocatedLocation(..)
+  , mkCommentGroupFromEpaLocation
+  )
+#endif
 import qualified HIndent.Ast.NodeComments as NodeComments
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
@@ -86,7 +94,26 @@ printCommentsAfter p =
         indentedWithFixedLevel (fromIntegral $ getCommentColumn comment)
           $ pretty comment
         eolCommentsArePrinted
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+mkWithCommentsFromGenLocated ::
+     IsGenLocatedLocation l => GHC.GenLocated l a -> WithComments a
+mkWithCommentsFromGenLocated (GHC.L ann a) =
+  WithComments (mkCommentGroupFromGenLocatedLocation ann) a
 
+mkWithCommentsFromEpaLocated ::
+     GHC.GenLocated GHC.EpaLocation a -> WithComments a
+mkWithCommentsFromEpaLocated (GHC.L ann a) =
+  WithComments (mkCommentGroupFromEpaLocation ann) a
+#else
+mkWithCommentsFromGenLocated ::
+     GHC.GenLocated (GHC.SrcSpanAnn' (GHC.EpAnn ann)) a -> WithComments a
+mkWithCommentsFromGenLocated (GHC.L ann a) =
+  WithComments (mkCommentGroupFromEpAnn $ GHC.ann ann) a
+
+mkWithCommentsFromEpaLocated ::
+     GHC.GenLocated (GHC.SrcSpanAnn' (GHC.EpAnn ann)) a -> WithComments a
+mkWithCommentsFromEpaLocated = mkWithCommentsFromGenLocated
+#endif
 fromGenLocated :: (CommentExtraction l) => GHC.GenLocated l a -> WithComments a
 fromGenLocated (GHC.L l a) = WithComments (fromNodeComments $ nodeComments l) a
 


### PR DESCRIPTION
### Description of the PR

This is a step to migrate from `NodeComments` to `CommentGroup`.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
