### PR TITLE
refactor: use Int for printer metrics

### DIFF
--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -65,8 +65,7 @@ prettyWith WithComments {..} f = do
 printCommentsBefore :: CommentGroup -> Printer ()
 printCommentsBefore p =
   forM_ (commentsBefore p) $ \comment -> do
-    indentedWithFixedLevel (fromIntegral $ getCommentColumn comment)
-      $ pretty comment
+    indentedWithFixedLevel (getCommentColumn comment) $ pretty comment
     newline
 
 -- | Prints comments that are on the same line as the given AST node.
@@ -74,7 +73,7 @@ printCommentOnSameLine :: CommentGroup -> Printer ()
 printCommentOnSameLine (commentsOnSameLine -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
-    then indentedWithFixedLevel (fromIntegral $ getCommentColumn c)
+    then indentedWithFixedLevel (getCommentColumn c)
            $ spaced
            $ fmap pretty
            $ c : cs
@@ -91,8 +90,7 @@ printCommentsAfter p =
       isThereCommentsOnSameLine <- gets psEolComment
       unless isThereCommentsOnSameLine newline
       forM_ xs $ \comment -> do
-        indentedWithFixedLevel (fromIntegral $ getCommentColumn comment)
-          $ pretty comment
+        indentedWithFixedLevel (getCommentColumn comment) $ pretty comment
         eolCommentsArePrinted
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 mkWithCommentsFromGenLocated ::

--- a/src/HIndent/Config.hs
+++ b/src/HIndent/Config.hs
@@ -8,7 +8,6 @@ module HIndent.Config
   ) where
 
 import Control.Applicative
-import Data.Int
 import Data.Maybe
 import Data.Yaml
 import qualified Data.Yaml as Y
@@ -21,8 +20,8 @@ import qualified Path.IO as Path
 -- | Configurations shared among the different styles. Styles may pay
 -- attention to or completely disregard this configuration.
 data Config = Config
-  { configMaxColumns :: !Int64 -- ^ Maximum columns to fit code into ideally.
-  , configIndentSpaces :: !Int64 -- ^ How many spaces to indent?
+  { configMaxColumns :: !Int -- ^ Maximum columns to fit code into ideally.
+  , configIndentSpaces :: !Int -- ^ How many spaces to indent?
   , configTrailingNewline :: !Bool -- ^ End with a newline.
   , configSortImports :: !Bool -- ^ Sort imports in groups.
   , configLineBreaks :: [String] -- ^ Break line when meets these operators.

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -83,7 +83,7 @@ printCommentsAnd (GHC.L l e) f = do
 printCommentsBefore :: CommentExtraction a => a -> Printer ()
 printCommentsBefore p =
   forM_ (commentsBefore $ nodeComments p) $ \(GHC.L loc c) -> do
-    let col = fromIntegral $ GHC.srcSpanStartCol (getAnc loc) - 1
+    let col = GHC.srcSpanStartCol (getAnc loc) - 1
     indentedWithFixedLevel col $ pretty c
     newline
 
@@ -92,8 +92,7 @@ printCommentOnSameLine :: CommentExtraction a => a -> Printer ()
 printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
-    then indentedWithFixedLevel
-           (fromIntegral $ GHC.srcSpanStartCol $ getAnc $ GHC.getLoc c)
+    then indentedWithFixedLevel (GHC.srcSpanStartCol $ getAnc $ GHC.getLoc c)
            $ spaced
            $ fmap pretty
            $ c : cs
@@ -110,7 +109,7 @@ printCommentsAfter p =
       isThereCommentsOnSameLine <- gets psEolComment
       unless isThereCommentsOnSameLine newline
       forM_ xs $ \(GHC.L loc c) -> do
-        let col = fromIntegral $ GHC.srcSpanStartCol (getAnc loc) - 1
+        let col = GHC.srcSpanStartCol (getAnc loc) - 1
         indentedWithFixedLevel col $ pretty c
         eolCommentsArePrinted
 

--- a/src/HIndent/Pretty/Combinators/Getter.hs
+++ b/src/HIndent/Pretty/Combinators/Getter.hs
@@ -5,13 +5,12 @@ module HIndent.Pretty.Combinators.Getter
   ) where
 
 import Control.Monad.RWS hiding (state)
-import Data.Int
 import HIndent.Pretty.Combinators.String
 import HIndent.Printer
 
 -- | Returns the column from which a new string is printed. It may be
 -- different from 'psColumn' immediately after printing a comment.
-startingColumn :: Printer Int64
+startingColumn :: Printer Int
 startingColumn = do
   before <- get
   string ""
@@ -22,7 +21,7 @@ startingColumn = do
 -- Returns how many characters the printer moved the cursor horizontally.
 -- The returned value maybe negative if the printer prints multiple lines
 -- and the column of the last position is less than before.
-printerLength :: Printer a -> Printer Int64
+printerLength :: Printer a -> Printer Int
 printerLength p = do
   before <- get
   _ <- p

--- a/src/HIndent/Pretty/Combinators/Indent.hs
+++ b/src/HIndent/Pretty/Combinators/Indent.hs
@@ -9,7 +9,6 @@ module HIndent.Pretty.Combinators.Indent
   ) where
 
 import Control.Monad.State
-import Data.Int
 import HIndent.Config
 import HIndent.Pretty.Combinators.String
 import HIndent.Printer
@@ -23,7 +22,7 @@ indentedBlock p = do
 
 -- | This function runs the given printer with an additional indent. The
 -- indent has the specified number of spaces.
-indentedWithSpace :: Int64 -> Printer a -> Printer a
+indentedWithSpace :: Int -> Printer a -> Printer a
 indentedWithSpace i p = do
   level <- gets psIndentLevel
   indentedWithFixedLevel (level + i) p
@@ -46,7 +45,7 @@ hd |=> p = do
 
 infixl 1 |=>
 -- | This function runs the given printer with the passed indent level.
-indentedWithFixedLevel :: Int64 -> Printer a -> Printer a
+indentedWithFixedLevel :: Int -> Printer a -> Printer a
 indentedWithFixedLevel i p = do
   l <- gets psIndentLevel
   modify (\s -> s {psIndentLevel = i})
@@ -58,9 +57,9 @@ indentedWithFixedLevel i p = do
 -- position and then the second argument.
 prefixed :: String -> Printer () -> Printer ()
 prefixed s p = do
-  indentedWithSpace (-(fromIntegral $ length s)) $ string s
+  indentedWithSpace (-(length s)) $ string s
   p
 
 -- | This function returns the current indent level.
-getIndentSpaces :: Printer Int64
+getIndentSpaces :: Printer Int
 getIndentSpaces = gets (configIndentSpaces . psConfig)

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -243,7 +243,7 @@ vWrappedLineup sep (prefix, suffix) ps =
     >> space |=> do
          prefixedLined [sep, ' '] ps
          newline
-         indentedWithSpace (-(fromIntegral (length prefix) + 1)) $ string suffix
+         indentedWithSpace (-(length prefix + 1)) $ string suffix
 
 -- | Similar to 'vWrappedLineup' but the suffix is in the same line as the
 -- last element.

--- a/src/HIndent/Pretty/Combinators/String.hs
+++ b/src/HIndent/Pretty/Combinators/String.hs
@@ -33,10 +33,10 @@ string x
     st <- get
     let indentSpaces =
           if psNewline st
-            then replicate (fromIntegral $ psIndentLevel st) ' '
+            then replicate (psIndentLevel st) ' '
             else ""
         out = indentSpaces <> x
-        psColumn' = psColumn st + fromIntegral (length out)
+        psColumn' = psColumn st + length out
         columnFits = psColumn' <= configMaxColumns (psConfig st)
     when hardFail $ guard columnFits
     modify

--- a/src/HIndent/Printer.hs
+++ b/src/HIndent/Printer.hs
@@ -15,7 +15,6 @@ import Control.Applicative
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.ByteString.Builder
-import Data.Int (Int64)
 import HIndent.Config
 
 -- | A pretty printing monad.
@@ -31,16 +30,16 @@ newtype Printer a = Printer
 
 -- | The state of the pretty printer.
 data PrintState = PrintState
-  { psIndentLevel :: !Int64
+  { psIndentLevel :: !Int
     -- ^ Current indentation level, i.e. every time there's a
     -- new-line, output this many spaces.
   , psOutput :: !Builder
     -- ^ The current output bytestring builder.
   , psNewline :: !Bool
     -- ^ Just outputted a newline?
-  , psColumn :: !Int64
+  , psColumn :: !Int
     -- ^ Current column.
-  , psLine :: !Int64
+  , psLine :: !Int
     -- ^ Current line number.
   , psConfig :: !Config
     -- ^ Configuration of max colums and indentation style.


### PR DESCRIPTION
### Description of the PR

`s/Int64/Int` because I couldn't find any practical reasons to use `Int64` specifically.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
