### PR TITLE
refactor: use Text in printer string combinators

### DIFF
--- a/src/HIndent/Ast/Cmd.hs
+++ b/src/HIndent/Ast/Cmd.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Comment.hs
+++ b/src/HIndent/Ast/Comment.hs
@@ -35,13 +35,13 @@ instance Pretty Comment where
   pretty' Block {..} =
     case Text.lines $ toText text of
       [] -> pure ()
-      [x] -> string $ Text.unpack x
+      [x] -> string x
       (x:xs) -> do
-        string $ Text.unpack x
+        string x
         newline
         -- 'indentedWithFixedLevel 0' is used because a 'BlockComment'
         -- contains indent spaces for all lines except the first one.
-        indentedWithFixedLevel 0 $ lined $ fmap (string . Text.unpack) xs
+        indentedWithFixedLevel 0 $ lined $ fmap string xs
 
 mkComment :: GHC.LEpaComment -> Comment
 mkComment comment@(GHC.L _ (GHC.EpaComment (GHC.EpaLineComment text) _)) =

--- a/src/HIndent/Ast/Context.hs
+++ b/src/HIndent/Ast/Context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Context

--- a/src/HIndent/Ast/Declaration/Annotation.hs
+++ b/src/HIndent/Ast/Declaration/Annotation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Annotation/Provenance.hs
+++ b/src/HIndent/Ast/Declaration/Annotation/Provenance.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Annotation.Provenance
   ( Provenance
   , mkProvenance

--- a/src/HIndent/Ast/Declaration/Annotation/Role.hs
+++ b/src/HIndent/Ast/Declaration/Annotation/Role.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Annotation.Role

--- a/src/HIndent/Ast/Declaration/Class.hs
+++ b/src/HIndent/Ast/Declaration/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Class/FunctionalDependency.hs
+++ b/src/HIndent/Ast/Declaration/Class/FunctionalDependency.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Class.FunctionalDependency

--- a/src/HIndent/Ast/Declaration/Data/Body.hs
+++ b/src/HIndent/Ast/Declaration/Data/Body.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}

--- a/src/HIndent/Ast/Declaration/Data/Deriving.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.Deriving

--- a/src/HIndent/Ast/Declaration/Data/Deriving/Strategy.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving/Strategy.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Data.Deriving.Strategy
   ( DerivingStrategy
   , mkDerivingStrategy

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor/Signature.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Data/Header.hs
+++ b/src/HIndent/Ast/Declaration/Data/Header.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Data.Header

--- a/src/HIndent/Ast/Declaration/Data/NewOrData.hs
+++ b/src/HIndent/Ast/Declaration/Data/NewOrData.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Data/Record/Field.hs
+++ b/src/HIndent/Ast/Declaration/Data/Record/Field.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Default.hs
+++ b/src/HIndent/Ast/Declaration/Default.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Declaration.Default

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Family.Data

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Family.Type

--- a/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Family.Type.Equation

--- a/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Family.Type.Injectivity

--- a/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Family.Type.ResultSignature
   ( ResultSignature(..)
   , mkResultSignature

--- a/src/HIndent/Ast/Declaration/Foreign.hs
+++ b/src/HIndent/Ast/Declaration/Foreign.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Foreign/CallingConvention.hs
+++ b/src/HIndent/Ast/Declaration/Foreign/CallingConvention.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Foreign.CallingConvention
   ( CallingConvention
   , mkCallingConvention

--- a/src/HIndent/Ast/Declaration/Foreign/Safety.hs
+++ b/src/HIndent/Ast/Declaration/Foreign/Safety.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Foreign.Safety
   ( Safety
   , mkSafety

--- a/src/HIndent/Ast/Declaration/Instance/Class.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Instance/Class/OverlapMode.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class/OverlapMode.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Declaration.Instance.Class.OverlapMode

--- a/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Data

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Type

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Type.Associated

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Type.Associated.Default

--- a/src/HIndent/Ast/Declaration/PatternSynonym.hs
+++ b/src/HIndent/Ast/Declaration/PatternSynonym.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Rule.hs
+++ b/src/HIndent/Ast/Declaration/Rule.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Rule/Binder.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Binder.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Rule.Binder

--- a/src/HIndent/Ast/Declaration/Rule/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Collection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Rule.Collection

--- a/src/HIndent/Ast/Declaration/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Signature.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/HIndent/Ast/Declaration/Signature/Fixity.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Fixity.hs
@@ -6,6 +6,7 @@ module HIndent.Ast.Declaration.Signature.Fixity
   , mkFixity
   ) where
 
+import qualified Data.Text as Text
 import qualified GHC.Types.Fixity as GHC
 import HIndent.Ast.Declaration.Signature.Fixity.Associativity
 import HIndent.Ast.NodeComments
@@ -22,7 +23,8 @@ instance CommentExtraction Fixity where
   nodeComments Fixity {} = NodeComments [] [] []
 
 instance Pretty Fixity where
-  pretty' Fixity {..} = spaced [pretty associativity, string $ show level]
+  pretty' Fixity {..} =
+    spaced [pretty associativity, string $ Text.pack $ show level]
 
 mkFixity :: GHC.Fixity -> Fixity
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)

--- a/src/HIndent/Ast/Declaration/Signature/Fixity/Associativity.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Fixity/Associativity.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Signature.Fixity.Associativity
   ( Associativity
   , mkAssociativity

--- a/src/HIndent/Ast/Declaration/Signature/Inline/Phase.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Inline/Phase.hs
@@ -5,6 +5,7 @@ module HIndent.Ast.Declaration.Signature.Inline.Phase
   , mkInlinePhase
   ) where
 
+import qualified Data.Text as Text
 import qualified GHC.Types.Basic as GHC
 import HIndent.Ast.NodeComments
 import {-# SOURCE #-} HIndent.Pretty
@@ -25,9 +26,9 @@ instance CommentExtraction InlinePhase where
 
 instance Pretty InlinePhase where
   pretty' InlinePhase {beforeOrAfter = Before, ..} =
-    brackets (string $ '~' : show phase)
+    brackets (string $ Text.pack $ '~' : show phase)
   pretty' InlinePhase {beforeOrAfter = After, ..} =
-    brackets (string $ show phase)
+    brackets (string $ Text.pack $ show phase)
 
 mkInlinePhase :: GHC.Activation -> Maybe InlinePhase
 mkInlinePhase (GHC.ActiveBefore _ phase) = Just $ InlinePhase Before phase

--- a/src/HIndent/Ast/Declaration/Signature/Inline/Spec.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Inline/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Declaration.Signature.Inline.Spec

--- a/src/HIndent/Ast/Declaration/Signature/StandaloneKind.hs
+++ b/src/HIndent/Ast/Declaration/Signature/StandaloneKind.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Signature.StandaloneKind

--- a/src/HIndent/Ast/Declaration/StandAloneDeriving.hs
+++ b/src/HIndent/Ast/Declaration/StandAloneDeriving.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.StandAloneDeriving

--- a/src/HIndent/Ast/Declaration/TypeSynonym.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.TypeSynonym

--- a/src/HIndent/Ast/Declaration/Warning.hs
+++ b/src/HIndent/Ast/Declaration/Warning.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Declaration/Warning/Kind.hs
+++ b/src/HIndent/Ast/Declaration/Warning/Kind.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Declaration.Warning.Kind
   ( Kind(..)
   ) where

--- a/src/HIndent/Ast/Expression.hs
+++ b/src/HIndent/Ast/Expression.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}

--- a/src/HIndent/Ast/Expression/Bracket.hs
+++ b/src/HIndent/Ast/Expression/Bracket.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Expression.Bracket

--- a/src/HIndent/Ast/Expression/ListComprehension.hs
+++ b/src/HIndent/Ast/Expression/ListComprehension.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/HIndent/Ast/Expression/OverloadedLabel.hs
+++ b/src/HIndent/Ast/Expression/OverloadedLabel.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Expression.OverloadedLabel

--- a/src/HIndent/Ast/Expression/Pragmatic.hs
+++ b/src/HIndent/Ast/Expression/Pragmatic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Expression/RangeExpression.hs
+++ b/src/HIndent/Ast/Expression/RangeExpression.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Expression/RecordConstructionField.hs
+++ b/src/HIndent/Ast/Expression/RecordConstructionField.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Expression/RecordUpdateField.hs
+++ b/src/HIndent/Ast/Expression/RecordUpdateField.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Expression/Splice.hs
+++ b/src/HIndent/Ast/Expression/Splice.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Expression.Splice
@@ -6,6 +7,7 @@ module HIndent.Ast.Expression.Splice
   , mkTypedSplice
   ) where
 
+import qualified Data.Text as Text
 import qualified GHC.Data.FastString as GHC
 import {-# SOURCE #-} HIndent.Ast.Expression (Expression, mkExpression)
 import HIndent.Ast.Name.Prefix
@@ -51,9 +53,9 @@ instance Pretty Splice where
         $ printers [] ""
         $ GHC.unpackFS r
     where
-      printers ps s [] = reverse (string (reverse s) : ps)
+      printers ps s [] = reverse (string (Text.pack $ reverse s) : ps)
       printers ps s ('\n':xs) =
-        printers (newline : string (reverse s) : ps) "" xs
+        printers (newline : string (Text.pack $ reverse s) : ps) "" xs
       printers ps s (x:xs) = printers ps (x : s) xs
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 mkSplice :: GHC.HsUntypedSplice GHC.GhcPs -> Splice

--- a/src/HIndent/Ast/Guard.hs
+++ b/src/HIndent/Ast/Guard.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -13,6 +14,7 @@ module HIndent.Ast.Guard
   ) where
 
 import Control.Monad (unless)
+import qualified Data.Text as Text
 import HIndent.Ast.Cmd (Cmd, mkCmd)
 import {-# SOURCE #-} HIndent.Ast.Expression
   ( GuardExpression
@@ -83,7 +85,7 @@ instance Pretty Guard where
             ver = newline >> indentedBlock (pretty cmd)
          in hor <-|> ver
 
-contextSeparator :: GuardContext -> String
+contextSeparator :: GuardContext -> Text.Text
 contextSeparator PlainGuard = "="
 contextSeparator CaseGuard = "->"
 contextSeparator LambdaGuard = "->"

--- a/src/HIndent/Ast/Import.hs
+++ b/src/HIndent/Ast/Import.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Import/Entry.hs
+++ b/src/HIndent/Ast/Import/Entry.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Import/Entry/Collection.hs
+++ b/src/HIndent/Ast/Import/Entry/Collection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/HIndent/Ast/LocalBinds/ImplicitBinding.hs
+++ b/src/HIndent/Ast/LocalBinds/ImplicitBinding.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Match.hs
+++ b/src/HIndent/Ast/Match.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/HIndent/Ast/Module/Declaration.hs
+++ b/src/HIndent/Ast/Module/Declaration.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Module.Declaration

--- a/src/HIndent/Ast/Module/Export/Entry.hs
+++ b/src/HIndent/Ast/Module/Export/Entry.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Module.Export.Entry

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Name/ImportExport.hs
+++ b/src/HIndent/Ast/Name/ImportExport.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Name.ImportExport

--- a/src/HIndent/Ast/Pattern.hs
+++ b/src/HIndent/Ast/Pattern.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/HIndent/Ast/Pattern/RecordFields.hs
+++ b/src/HIndent/Ast/Pattern/RecordFields.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Record/Field.hs
+++ b/src/HIndent/Ast/Record/Field.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/HIndent/Ast/Role.hs
+++ b/src/HIndent/Ast/Role.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Role
   ( Role
   , mkRole

--- a/src/HIndent/Ast/Statement.hs
+++ b/src/HIndent/Ast/Statement.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/TextValue.hs
+++ b/src/HIndent/Ast/TextValue.hs
@@ -26,7 +26,7 @@ instance CommentExtraction TextValue where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty TextValue where
-  pretty' (TextValue value) = string $ Text.unpack value
+  pretty' (TextValue value) = string value
 
 mkTextValueFromString :: String -> TextValue
 mkTextValueFromString = TextValue . Text.pack

--- a/src/HIndent/Ast/Type.hs
+++ b/src/HIndent/Ast/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}

--- a/src/HIndent/Ast/Type/Argument.hs
+++ b/src/HIndent/Ast/Type/Argument.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/Type/Forall.hs
+++ b/src/HIndent/Ast/Type/Forall.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Type.Forall

--- a/src/HIndent/Ast/Type/ImplicitParameterName.hs
+++ b/src/HIndent/Ast/Type/ImplicitParameterName.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module HIndent.Ast.Type.ImplicitParameterName
   ( ImplicitParameterName
   , mkImplicitParameterName

--- a/src/HIndent/Ast/Type/Multiplicity.hs
+++ b/src/HIndent/Ast/Type/Multiplicity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Type.Multiplicity

--- a/src/HIndent/Ast/Type/Strictness.hs
+++ b/src/HIndent/Ast/Type/Strictness.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Type.Strictness

--- a/src/HIndent/Ast/Type/Unpackedness.hs
+++ b/src/HIndent/Ast/Type/Unpackedness.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Type.Unpackedness

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/HIndent/Ast/WhereClause.hs
+++ b/src/HIndent/Ast/WhereClause.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.WhereClause

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -22,6 +23,7 @@ module HIndent.Pretty
 
 import Control.Monad
 import Control.Monad.RWS
+import qualified Data.Text as Text
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 import qualified GHC.Data.FastString as FS
 #endif
@@ -191,9 +193,9 @@ instance Pretty GHC.EpaComment where
   pretty' GHC.EpaComment {..} = prettyEpaCommentTok ac_tok
 
 prettyEpaCommentTok :: GHC.EpaCommentTok -> Printer ()
-prettyEpaCommentTok (GHC.EpaLineComment text) = string text
+prettyEpaCommentTok (GHC.EpaLineComment text) = string $ Text.pack text
 prettyEpaCommentTok (GHC.EpaBlockComment text) =
-  case lines text of
+  case Text.lines $ Text.pack text of
     [] -> pure ()
     [x] -> string x
     (x:xs) -> do
@@ -212,8 +214,9 @@ instance Pretty
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 instance Pretty GHC.StringLiteral where
-  pretty' GHC.StringLiteral {sl_st = GHC.SourceText s} = string $ FS.unpackFS s
-  pretty' GHC.StringLiteral {..} = string $ FS.unpackFS sl_fs
+  pretty' GHC.StringLiteral {sl_st = GHC.SourceText s} =
+    string $ Text.pack $ FS.unpackFS s
+  pretty' GHC.StringLiteral {..} = string $ Text.pack $ FS.unpackFS sl_fs
 #else
 instance Pretty GHC.StringLiteral where
   pretty' = output

--- a/src/HIndent/Pretty/Combinators/Getter.hs
+++ b/src/HIndent/Pretty/Combinators/Getter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Getters to fetch current status and printer information.
 module HIndent.Pretty.Combinators.Getter
   ( startingColumn

--- a/src/HIndent/Pretty/Combinators/Indent.hs
+++ b/src/HIndent/Pretty/Combinators/Indent.hs
@@ -9,6 +9,7 @@ module HIndent.Pretty.Combinators.Indent
   ) where
 
 import Control.Monad.State
+import qualified Data.Text as Text
 import HIndent.Config
 import HIndent.Pretty.Combinators.String
 import HIndent.Printer
@@ -55,9 +56,9 @@ indentedWithFixedLevel i p = do
 
 -- | Prints the text passed as the first argument before the current
 -- position and then the second argument.
-prefixed :: String -> Printer () -> Printer ()
+prefixed :: Text.Text -> Printer () -> Printer ()
 prefixed s p = do
-  indentedWithSpace (-(length s)) $ string s
+  indentedWithSpace (-(Text.length s)) $ string s
   p
 
 -- | This function returns the current indent level.

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Printer combinators for lining up multiple elements.
 module HIndent.Pretty.Combinators.Lineup
   ( -- * Tuples
@@ -44,6 +46,7 @@ module HIndent.Pretty.Combinators.Lineup
 import Control.Monad
 import Data.Foldable (toList)
 import Data.List (intersperse)
+import qualified Data.Text as Text
 import HIndent.Pretty.Combinators.Indent
 import HIndent.Pretty.Combinators.String
 import HIndent.Pretty.Combinators.Switch
@@ -202,13 +205,13 @@ vCommaSep = prefixedLined ", "
 -- | Prints elements separated by comma  in vertical with the given prefix
 -- and suffix.
 vCommaSepWrapped ::
-     Foldable f => (String, String) -> f (Printer ()) -> Printer ()
+     Foldable f => (Text.Text, Text.Text) -> f (Printer ()) -> Printer ()
 vCommaSepWrapped = vWrappedLineup ','
 
 -- | Similar to 'vCommaSepWrapped' but the suffix is in the same line as the last
 -- element.
 vCommaSepWrapped' ::
-     Foldable f => (String, String) -> f (Printer ()) -> Printer ()
+     Foldable f => (Text.Text, Text.Text) -> f (Printer ()) -> Printer ()
 vCommaSepWrapped' = vWrappedLineup' ','
 
 -- | Runs printers with a dot as the separator.
@@ -224,7 +227,7 @@ newlinePrefixed :: Foldable f => f (Printer ()) -> Printer ()
 newlinePrefixed = mapM_ (newline >>)
 
 -- | Runs printers with a prefix. The prefix is printed before the indent.
-prefixedLined :: Foldable f => String -> f (Printer ()) -> Printer ()
+prefixedLined :: Foldable f => Text.Text -> f (Printer ()) -> Printer ()
 prefixedLined pref printers =
   case toList printers of
     [] -> return ()
@@ -237,25 +240,33 @@ prefixedLined pref printers =
 -- | Prints elements in vertical with the given prefix, suffix, and
 -- separator.
 vWrappedLineup ::
-     Foldable f => Char -> (String, String) -> f (Printer ()) -> Printer ()
+     Foldable f
+  => Char
+  -> (Text.Text, Text.Text)
+  -> f (Printer ())
+  -> Printer ()
 vWrappedLineup sep (prefix, suffix) ps =
   string prefix
     >> space |=> do
-         prefixedLined [sep, ' '] ps
+         prefixedLined (Text.pack [sep, ' ']) ps
          newline
-         indentedWithSpace (-(length prefix + 1)) $ string suffix
+         indentedWithSpace (-(Text.length prefix + 1)) $ string suffix
 
 -- | Similar to 'vWrappedLineup' but the suffix is in the same line as the
 -- last element.
 vWrappedLineup' ::
-     Foldable f => Char -> (String, String) -> f (Printer ()) -> Printer ()
+     Foldable f
+  => Char
+  -> (Text.Text, Text.Text)
+  -> f (Printer ())
+  -> Printer ()
 vWrappedLineup' sep (prefix, suffix) printers =
   case toList printers of
     [x] -> spaced [string prefix, x, string suffix]
     ps ->
       string prefix
         >> space |=> do
-             prefixedLined [sep, ' '] ps
+             prefixedLined (Text.pack [sep, ' ']) ps
              string suffix
 
 -- Inserts the first printer between each element of the list passed as the

--- a/src/HIndent/Pretty/Combinators/Outputable.hs
+++ b/src/HIndent/Pretty/Combinators/Outputable.hs
@@ -7,6 +7,7 @@ module HIndent.Pretty.Combinators.Outputable
   , showOutputable
   ) where
 
+import qualified Data.Text as Text
 import GHC.Driver.Ppr
 import GHC.Driver.Session
 import GHC.Stack
@@ -27,7 +28,7 @@ import Language.Haskell.GhclibParserEx.GHC.Settings.Config
 --
 -- * All comments of the node's children are ignored.
 output :: (HasCallStack, Outputable a) => a -> Printer ()
-output = string . showOutputable
+output = string . Text.pack . showOutputable
 
 -- | Converts the given value to a 'String'.
 showOutputable :: Outputable a => a -> String

--- a/src/HIndent/Pretty/Combinators/String.hs
+++ b/src/HIndent/Pretty/Combinators/String.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Printer combinators related to print strings.
 module HIndent.Pretty.Combinators.String
@@ -12,6 +13,8 @@ module HIndent.Pretty.Combinators.String
 
 import Control.Monad.RWS
 import qualified Data.ByteString.Builder as S
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import GHC.Stack
 import HIndent.Config
 import HIndent.Printer
@@ -21,9 +24,9 @@ import Control.Monad
 -- | This function prints the given string.
 --
 -- The string must not include @\n@s. Use @newline@ to print them.
-string :: HasCallStack => String -> Printer ()
+string :: HasCallStack => Text.Text -> Printer ()
 string x
-  | '\n' `elem` x =
+  | "\n" `Text.isInfixOf` x =
     error
       $ "You tried to print " ++ show x ++ ". Use `newline` to print '\\n's."
   | otherwise = do
@@ -33,16 +36,16 @@ string x
     st <- get
     let indentSpaces =
           if psNewline st
-            then replicate (psIndentLevel st) ' '
+            then Text.replicate (psIndentLevel st) " "
             else ""
         out = indentSpaces <> x
-        psColumn' = psColumn st + length out
+        psColumn' = psColumn st + Text.length out
         columnFits = psColumn' <= configMaxColumns (psConfig st)
     when hardFail $ guard columnFits
     modify
       (\s ->
          s
-           { psOutput = psOutput st <> S.stringUtf8 out
+           { psOutput = psOutput st <> S.byteString (Text.encodeUtf8 out)
            , psNewline = False
            , psEolComment = False
            , psColumn = psColumn'

--- a/src/HIndent/Pretty/Combinators/Wrap.hs
+++ b/src/HIndent/Pretty/Combinators/Wrap.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Printer operators for wrapping texts with a prefix and a suffix.
 module HIndent.Pretty.Combinators.Wrap
   ( parens
@@ -15,6 +17,7 @@ module HIndent.Pretty.Combinators.Wrap
   , unboxedParens
   ) where
 
+import qualified Data.Text as Text
 import GHC.Types.Name
 import HIndent.Pretty.Combinators.Indent
 import HIndent.Pretty.Combinators.String
@@ -81,5 +84,5 @@ unboxedParens :: Printer a -> Printer a
 unboxedParens = wrap "(# " " #)"
 
 -- | This function wraps the printer with the prefix and the suffix.
-wrap :: String -> String -> Printer a -> Printer a
+wrap :: Text.Text -> Text.Text -> Printer a -> Printer a
 wrap open close p = string open |=> p <* string close


### PR DESCRIPTION
### Description of the PR

Refactor printer string combinators to use `Text` and update pretty-printing call sites.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
