### PR TITLE
refactor: `s/pretty'/pretty`

### DIFF
--- a/src/HIndent/Ast/Cmd.hs
+++ b/src/HIndent/Ast/Cmd.hs
@@ -78,7 +78,7 @@ instance CommentExtraction Cmd where
   nodeComments _ = emptyNodeComments
 
 instance Pretty Cmd where
-  pretty' ArrowApp {..} =
+  pretty ArrowApp {..} =
     case arrowDirection of
       FunctionThenArgument ->
         spaced [pretty function, string operator, pretty argument]
@@ -91,22 +91,22 @@ instance Pretty Cmd where
           (Higher, ArgumentThenFunction) -> ">>-"
           (First, FunctionThenArgument) -> "-<"
           (First, ArgumentThenFunction) -> ">-"
-  pretty' ArrowForm {..} =
+  pretty ArrowForm {..} =
     bananaBrackets $ spaced $ pretty function : fmap pretty arguments
-  pretty' CmdApp {..} = spaced [pretty cmd, pretty argument]
-  pretty' Lambda {..} = pretty matches
-  pretty' LambdaCase {..} = do
+  pretty CmdApp {..} = spaced [pretty cmd, pretty argument]
+  pretty Lambda {..} = pretty matches
+  pretty LambdaCase {..} = do
     string
       $ if usesCases
           then "\\cases"
           else "\\case"
     newline
     indentedBlock $ pretty matches
-  pretty' Case {..} = do
+  pretty Case {..} = do
     spaced [string "case", pretty scrutinee, string "of"]
     newline
     indentedBlock $ pretty matches
-  pretty' If {..} = do
+  pretty If {..} = do
     string "if "
     pretty predicate
     newline
@@ -115,14 +115,14 @@ instance Pretty Cmd where
           [ string "then " >> pretty thenBranch
           , string "else " >> pretty elseBranch
           ]
-  pretty' Let {..} =
+  pretty Let {..} =
     lined
       [string "let " |=> pretty localBinds, string " in " |=> pretty inCommand]
-  pretty' DoBlock {..} = do
+  pretty DoBlock {..} = do
     string "do"
     newline
     indentedBlock $ prettyWith statements $ lined . fmap pretty
-  pretty' (Parenthesized cmd) = parens $ pretty cmd
+  pretty (Parenthesized cmd) = parens $ pretty cmd
 
 mkCmd :: GHC.HsCmd GHC.GhcPs -> Cmd
 mkCmd (GHC.HsCmdArrApp _ f arg appKind isFwd) =
@@ -238,9 +238,9 @@ instance CommentExtraction CmdDoBlock where
   nodeComments _ = emptyNodeComments
 
 instance Pretty CmdDoBlock where
-  pretty' (CmdDoBlock DoBlock {statements = stmts}) =
+  pretty (CmdDoBlock DoBlock {statements = stmts}) =
     prettyWith stmts $ lined . fmap pretty
-  pretty' (CmdDoBlock _) =
+  pretty (CmdDoBlock _) =
     error "mkCmdDoBlock must be used before pretty-printing CmdDoBlock"
 
 mkCmdDoBlock :: Cmd -> Maybe CmdDoBlock

--- a/src/HIndent/Ast/Comment.hs
+++ b/src/HIndent/Ast/Comment.hs
@@ -31,8 +31,8 @@ instance CommentExtraction Comment where
   nodeComments _ = mempty
 
 instance Pretty Comment where
-  pretty' Line {..} = pretty text
-  pretty' Block {..} =
+  pretty Line {..} = pretty text
+  pretty Block {..} =
     case Text.lines $ toText text of
       [] -> pure ()
       [x] -> string x

--- a/src/HIndent/Ast/Context.hs
+++ b/src/HIndent/Ast/Context.hs
@@ -21,7 +21,7 @@ instance CommentExtraction Context where
   nodeComments (Context _) = NodeComments [] [] []
 
 instance Pretty Context where
-  pretty' (Context xs) = hor <-|> ver
+  pretty (Context xs) = hor <-|> ver
     where
       hor = parensConditional $ hCommaSep $ fmap pretty xs
         where

--- a/src/HIndent/Ast/Declaration.hs
+++ b/src/HIndent/Ast/Declaration.hs
@@ -75,25 +75,25 @@ instance CommentExtraction Declaration where
   nodeComments RoleAnnotDecl {} = NodeComments [] [] []
 
 instance Pretty Declaration where
-  pretty' (DataFamily x) = pretty x
-  pretty' (TypeFamily x) = pretty x
-  pretty' (DataDeclaration x) = pretty x
-  pretty' (ClassDeclaration x) = pretty x
-  pretty' (TypeSynonym x) = pretty x
-  pretty' (ClassInstance x) = pretty x
-  pretty' (DataFamilyInstance x) = pretty x
-  pretty' (TypeFamilyInstance x) = pretty x
-  pretty' (StandAloneDeriving x) = pretty x
-  pretty' (Bind x) = pretty x
-  pretty' (Signature x) = pretty x
-  pretty' (StandaloneKindSignature x) = pretty x
-  pretty' (Default x) = pretty x
-  pretty' (Foreign x) = pretty x
-  pretty' (Warnings x) = pretty x
-  pretty' (Annotation x) = pretty x
-  pretty' (RuleDecl x) = pretty x
-  pretty' (Splice x) = pretty x
-  pretty' (RoleAnnotDecl x) = pretty x
+  pretty (DataFamily x) = pretty x
+  pretty (TypeFamily x) = pretty x
+  pretty (DataDeclaration x) = pretty x
+  pretty (ClassDeclaration x) = pretty x
+  pretty (TypeSynonym x) = pretty x
+  pretty (ClassInstance x) = pretty x
+  pretty (DataFamilyInstance x) = pretty x
+  pretty (TypeFamilyInstance x) = pretty x
+  pretty (StandAloneDeriving x) = pretty x
+  pretty (Bind x) = pretty x
+  pretty (Signature x) = pretty x
+  pretty (StandaloneKindSignature x) = pretty x
+  pretty (Default x) = pretty x
+  pretty (Foreign x) = pretty x
+  pretty (Warnings x) = pretty x
+  pretty (Annotation x) = pretty x
+  pretty (RuleDecl x) = pretty x
+  pretty (Splice x) = pretty x
+  pretty (RoleAnnotDecl x) = pretty x
 
 mkDeclaration :: GHC.HsDecl GHC.GhcPs -> Declaration
 mkDeclaration (GHC.TyClD _ (GHC.FamDecl _ x)) =

--- a/src/HIndent/Ast/Declaration/Annotation.hs
+++ b/src/HIndent/Ast/Declaration/Annotation.hs
@@ -25,7 +25,7 @@ instance CommentExtraction Annotation where
   nodeComments Annotation {} = NodeComments [] [] []
 
 instance Pretty Annotation where
-  pretty' Annotation {..} =
+  pretty Annotation {..} =
     spaced [string "{-# ANN", pretty provenance, pretty expr, string "#-}"]
 
 mkAnnotation :: GHC.AnnDecl GHC.GhcPs -> Annotation

--- a/src/HIndent/Ast/Declaration/Annotation/Provenance.hs
+++ b/src/HIndent/Ast/Declaration/Annotation/Provenance.hs
@@ -24,9 +24,9 @@ instance CommentExtraction Provenance where
   nodeComments Module = NodeComments [] [] []
 
 instance Pretty Provenance where
-  pretty' (Value x) = pretty x
-  pretty' (Type x) = string "type " >> pretty x
-  pretty' Module = string "module"
+  pretty (Value x) = pretty x
+  pretty (Type x) = string "type " >> pretty x
+  pretty Module = string "module"
 
 mkProvenance :: GHC.AnnProvenance GHC.GhcPs -> Provenance
 mkProvenance (GHC.ValueAnnProvenance x) =

--- a/src/HIndent/Ast/Declaration/Annotation/Role.hs
+++ b/src/HIndent/Ast/Declaration/Annotation/Role.hs
@@ -24,7 +24,7 @@ instance CommentExtraction RoleAnnotation where
   nodeComments RoleAnnotation {} = NodeComments [] [] []
 
 instance Pretty RoleAnnotation where
-  pretty' RoleAnnotation {..} =
+  pretty RoleAnnotation {..} =
     spaced
       $ [string "type role", pretty name]
           ++ fmap (`prettyWith` maybe (string "_") pretty) roles

--- a/src/HIndent/Ast/Declaration/Bind.hs
+++ b/src/HIndent/Ast/Declaration/Bind.hs
@@ -34,9 +34,9 @@ instance CommentExtraction Bind where
   nodeComments PatternSynonym {} = emptyNodeComments
 
 instance Pretty Bind where
-  pretty' (Function matches) = pretty matches
-  pretty' Pattern {..} = pretty lhs >> pretty rhs
-  pretty' (PatternSynonym ps) = pretty ps
+  pretty (Function matches) = pretty matches
+  pretty Pattern {..} = pretty lhs >> pretty rhs
+  pretty (PatternSynonym ps) = pretty ps
 
 mkBind :: GHC.HsBind GHC.GhcPs -> Bind
 mkBind GHC.FunBind {..} = Function $ mkExprMatchGroup fun_matches

--- a/src/HIndent/Ast/Declaration/Bind/GuardedRhs.hs
+++ b/src/HIndent/Ast/Declaration/Bind/GuardedRhs.hs
@@ -44,7 +44,7 @@ instance CommentExtraction GuardedRhs where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty GuardedRhs where
-  pretty' GuardedRhs {..} = do
+  pretty GuardedRhs {..} = do
     mapM_ pretty guards
     whenJust whereClause $ \clause ->
       indentedBlock $ newlinePrefixed [prettyWith clause pretty]

--- a/src/HIndent/Ast/Declaration/Class.hs
+++ b/src/HIndent/Ast/Declaration/Class.hs
@@ -34,7 +34,7 @@ instance CommentExtraction ClassDeclaration where
   nodeComments ClassDeclaration {} = NodeComments [] [] []
 
 instance Pretty ClassDeclaration where
-  pretty' ClassDeclaration {..} = do
+  pretty ClassDeclaration {..} = do
     if isJust context
       then verHead
       else horHead <-|> verHead

--- a/src/HIndent/Ast/Declaration/Class/Body.hs
+++ b/src/HIndent/Ast/Declaration/Class/Body.hs
@@ -22,7 +22,7 @@ instance CommentExtraction ClassBody where
   nodeComments ClassBody {} = NodeComments [] [] []
 
 instance Pretty ClassBody where
-  pretty' (ClassBody members) = newlinePrefixed $ fmap pretty members
+  pretty (ClassBody members) = newlinePrefixed $ fmap pretty members
 
 mkClassBody ::
      [GHC.LSig GHC.GhcPs]

--- a/src/HIndent/Ast/Declaration/Class/FunctionalDependency.hs
+++ b/src/HIndent/Ast/Declaration/Class/FunctionalDependency.hs
@@ -23,7 +23,7 @@ instance CommentExtraction FunctionalDependency where
   nodeComments FunctionalDependency {} = NodeComments [] [] []
 
 instance Pretty FunctionalDependency where
-  pretty' (FunctionalDependency {..}) =
+  pretty (FunctionalDependency {..}) =
     spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to
 
 mkFunctionalDependency :: GHC.FunDep GHC.GhcPs -> FunctionalDependency

--- a/src/HIndent/Ast/Declaration/Class/Member.hs
+++ b/src/HIndent/Ast/Declaration/Class/Member.hs
@@ -31,12 +31,12 @@ instance CommentExtraction ClassMember where
   nodeComments AssociatedTypeFamily {} = NodeComments [] [] []
 
 instance Pretty ClassMember where
-  pretty' (Signature signature) = pretty signature
-  pretty' (Method bind) = pretty bind
-  pretty' (AssociatedDataFamily dataFamily) = pretty dataFamily
-  pretty' (AssociatedTypeDefault associatedTypeDefault) =
+  pretty (Signature signature) = pretty signature
+  pretty (Method bind) = pretty bind
+  pretty (AssociatedDataFamily dataFamily) = pretty dataFamily
+  pretty (AssociatedTypeDefault associatedTypeDefault) =
     pretty associatedTypeDefault
-  pretty' (AssociatedTypeFamily typeFamily) = pretty typeFamily
+  pretty (AssociatedTypeFamily typeFamily) = pretty typeFamily
 
 mkClassSignatureMember :: GHC.Sig GHC.GhcPs -> ClassMember
 mkClassSignatureMember = Signature . mkSignature

--- a/src/HIndent/Ast/Declaration/Class/NameAndTypeVariables.hs
+++ b/src/HIndent/Ast/Declaration/Class/NameAndTypeVariables.hs
@@ -33,8 +33,8 @@ instance CommentExtraction NameAndTypeVariables where
   nodeComments Infix {} = NodeComments [] [] []
 
 instance Pretty NameAndTypeVariables where
-  pretty' Prefix {..} = spaced $ pretty pName : fmap pretty typeVariables
-  pretty' Infix {..} = do
+  pretty Prefix {..} = spaced $ pretty pName : fmap pretty typeVariables
+  pretty Infix {..} = do
     parens $ spaced [pretty left, pretty iName, pretty right]
     spacePrefixed $ fmap pretty remains
 

--- a/src/HIndent/Ast/Declaration/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Collection.hs
@@ -24,7 +24,7 @@ instance CommentExtraction DeclarationCollection where
   nodeComments DeclarationCollection {} = NodeComments [] [] []
 
 instance Pretty DeclarationCollection where
-  pretty' (DeclarationCollection decls) =
+  pretty (DeclarationCollection decls) =
     mapM_ (\(x, sp) -> pretty x >> fromMaybe (return ()) sp)
       $ addDeclSeparator decls
     where

--- a/src/HIndent/Ast/Declaration/Data.hs
+++ b/src/HIndent/Ast/Declaration/Data.hs
@@ -22,7 +22,7 @@ instance CommentExtraction DataDeclaration where
   nodeComments DataDeclaration {} = NodeComments [] [] []
 
 instance Pretty DataDeclaration where
-  pretty' DataDeclaration {..} = pretty header >> pretty body
+  pretty DataDeclaration {..} = pretty header >> pretty body
 
 mkDataDeclaration :: GHC.TyClDecl GHC.GhcPs -> Maybe DataDeclaration
 mkDataDeclaration decl@GHC.DataDecl {..} =

--- a/src/HIndent/Ast/Declaration/Data/Body.hs
+++ b/src/HIndent/Ast/Declaration/Data/Body.hs
@@ -41,7 +41,7 @@ instance CommentExtraction DataBody where
   nodeComments Haskell98 {} = NodeComments [] [] []
 
 instance Pretty DataBody where
-  pretty' GADT {..} = do
+  pretty GADT {..} = do
     whenJust kind $ \x -> string " :: " >> pretty x
     string " where"
     case constructors of
@@ -55,7 +55,7 @@ instance Pretty DataBody where
           when (hasDerivings derivings) $ do
             newline
             pretty derivings
-  pretty' Haskell98 {..} = do
+  pretty Haskell98 {..} = do
     whenJust kind $ \x -> string " :: " >> pretty x
     case constructorsH98 of
       [] -> indentedBlock derivingsAfterNewline

--- a/src/HIndent/Ast/Declaration/Data/Constructor/Field.hs
+++ b/src/HIndent/Ast/Declaration/Data/Constructor/Field.hs
@@ -21,7 +21,7 @@ instance CommentExtraction ConstructorField where
   nodeComments ConstructorField {} = NodeComments [] [] []
 
 instance Pretty ConstructorField where
-  pretty' ConstructorField {..} = pretty ty
+  pretty ConstructorField {..} = pretty ty
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkConstructorField :: GHC.HsConDeclField GHC.GhcPs -> ConstructorField
 mkConstructorField field = ConstructorField {ty = mkTypeFromConDeclField field}

--- a/src/HIndent/Ast/Declaration/Data/Deriving.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving.hs
@@ -26,14 +26,14 @@ instance CommentExtraction Deriving where
   nodeComments Deriving {} = NodeComments [] [] []
 
 instance Pretty Deriving where
-  pretty' Deriving {strategy = Just strategy, ..}
+  pretty Deriving {strategy = Just strategy, ..}
     | isViaStrategy (getNode strategy) = do
       spaced
         [ string "deriving"
         , prettyWith classes (hvTuple . fmap pretty)
         , pretty strategy
         ]
-  pretty' Deriving {..} = do
+  pretty Deriving {..} = do
     string "deriving "
     whenJust strategy $ \x -> pretty x >> space
     prettyWith classes (hvTuple . fmap pretty)

--- a/src/HIndent/Ast/Declaration/Data/Deriving/Clause.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving/Clause.hs
@@ -19,7 +19,7 @@ instance CommentExtraction DerivingClause where
   nodeComments DerivingClause {} = NodeComments [] [] []
 
 instance Pretty DerivingClause where
-  pretty' (DerivingClause xs) = lined $ fmap pretty xs
+  pretty (DerivingClause xs) = lined $ fmap pretty xs
 
 mkDerivingClause :: GHC.HsDeriving GHC.GhcPs -> DerivingClause
 mkDerivingClause =

--- a/src/HIndent/Ast/Declaration/Data/Deriving/Strategy.hs
+++ b/src/HIndent/Ast/Declaration/Data/Deriving/Strategy.hs
@@ -31,10 +31,10 @@ instance CommentExtraction DerivingStrategy where
   nodeComments Via {} = NodeComments [] [] []
 
 instance Pretty DerivingStrategy where
-  pretty' Stock = string "stock"
-  pretty' Anyclass = string "anyclass"
-  pretty' Newtype = string "newtype"
-  pretty' (Via x) = string "via " >> pretty x
+  pretty Stock = string "stock"
+  pretty Anyclass = string "anyclass"
+  pretty Newtype = string "newtype"
+  pretty (Via x) = string "via " >> pretty x
 
 mkDerivingStrategy :: GHC.DerivStrategy GHC.GhcPs -> DerivingStrategy
 mkDerivingStrategy GHC.StockStrategy {} = Stock

--- a/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/GADT/Constructor.hs
@@ -33,7 +33,7 @@ instance CommentExtraction GADTConstructor where
   nodeComments GADTConstructor {} = NodeComments [] [] []
 
 instance Pretty GADTConstructor where
-  pretty' (GADTConstructor {..}) = do
+  pretty (GADTConstructor {..}) = do
     hCommaSep $ fmap (`prettyWith` pretty) names
     hor <-|> ver
     where

--- a/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor.hs
+++ b/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor.hs
@@ -29,10 +29,10 @@ instance CommentExtraction Haskell98Constructor where
   nodeComments Haskell98Constructor {} = NodeComments [] [] []
 
 instance Pretty Haskell98Constructor where
-  pretty' Haskell98Constructor {existentialVariables = [], ..} = do
+  pretty Haskell98Constructor {existentialVariables = [], ..} = do
     whenJust context $ \c -> pretty c >> string " => "
     pretty body
-  pretty' Haskell98Constructor {..} = do
+  pretty Haskell98Constructor {..} = do
     string "forall "
     spaced (fmap pretty existentialVariables)
     string ". " |=> do

--- a/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor/Body.hs
+++ b/src/HIndent/Ast/Declaration/Data/Haskell98/Constructor/Body.hs
@@ -39,12 +39,12 @@ instance CommentExtraction Haskell98ConstructorBody where
   nodeComments Record {} = NodeComments [] [] []
 
 instance Pretty Haskell98ConstructorBody where
-  pretty' Infix {..} = spaced [pretty left, pretty iName, pretty right]
-  pretty' Prefix {..} = pretty pName >> hor <-|> ver
+  pretty Infix {..} = spaced [pretty left, pretty iName, pretty right]
+  pretty Prefix {..} = pretty pName >> hor <-|> ver
     where
       hor = spacePrefixed $ fmap pretty types
       ver = indentedBlock $ newlinePrefixed $ fmap pretty types
-  pretty' Record {..} = do
+  pretty Record {..} = do
     pretty rName
     prettyWith records $ \r ->
       newline >> indentedBlock (vFields $ fmap pretty r)

--- a/src/HIndent/Ast/Declaration/Data/Header.hs
+++ b/src/HIndent/Ast/Declaration/Data/Header.hs
@@ -29,7 +29,7 @@ instance CommentExtraction Header where
   nodeComments Header {} = NodeComments [] [] []
 
 instance Pretty Header where
-  pretty' Header {..} = do
+  pretty Header {..} = do
     (pretty newOrData >> space) |=> do
       whenJust context $ \c -> pretty c >> string " =>" >> newline
       pretty name

--- a/src/HIndent/Ast/Declaration/Data/NewOrData.hs
+++ b/src/HIndent/Ast/Declaration/Data/NewOrData.hs
@@ -22,8 +22,8 @@ instance CommentExtraction NewOrData where
   nodeComments Data = NodeComments [] [] []
 
 instance Pretty NewOrData where
-  pretty' Newtype = string "newtype"
-  pretty' Data = string "data"
+  pretty Newtype = string "newtype"
+  pretty Data = string "data"
 
 mkNewOrData :: GHC.HsDataDefn GHC.GhcPs -> NewOrData
 #if MIN_VERSION_ghc_lib_parser(9, 6, 0)

--- a/src/HIndent/Ast/Declaration/Data/Record/Field.hs
+++ b/src/HIndent/Ast/Declaration/Data/Record/Field.hs
@@ -25,7 +25,7 @@ instance CommentExtraction RecordField where
   nodeComments RecordField {} = NodeComments [] [] []
 
 instance Pretty RecordField where
-  pretty' RecordField {..} =
+  pretty RecordField {..} =
     spaced [hCommaSep $ fmap pretty names, string "::", pretty ty]
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkRecordField :: GHC.HsConDeclRecField GHC.GhcPs -> RecordField

--- a/src/HIndent/Ast/Declaration/Default.hs
+++ b/src/HIndent/Ast/Declaration/Default.hs
@@ -21,7 +21,7 @@ instance CommentExtraction DefaultDeclaration where
   nodeComments DefaultDeclaration {} = NodeComments [] [] []
 
 instance Pretty DefaultDeclaration where
-  pretty' (DefaultDeclaration xs) =
+  pretty (DefaultDeclaration xs) =
     spaced [string "default", hTuple $ fmap pretty xs]
 
 mkDefaultDeclaration :: GHC.DefaultDecl GHC.GhcPs -> DefaultDeclaration

--- a/src/HIndent/Ast/Declaration/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Family/Data.hs
@@ -31,7 +31,7 @@ instance CommentExtraction DataFamily where
   nodeComments DataFamily {} = NodeComments [] [] []
 
 instance Pretty DataFamily where
-  pretty' DataFamily {..} = do
+  pretty DataFamily {..} = do
     string "data "
     when isTopLevel $ string "family "
     pretty name

--- a/src/HIndent/Ast/Declaration/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type.hs
@@ -37,7 +37,7 @@ instance CommentExtraction TypeFamily where
   nodeComments TypeFamily {} = NodeComments [] [] []
 
 instance Pretty TypeFamily where
-  pretty' TypeFamily {..} = do
+  pretty TypeFamily {..} = do
     string "type "
     when isTopLevel $ string "family "
     pretty name

--- a/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
@@ -26,7 +26,7 @@ instance CommentExtraction TypeEquation where
   nodeComments TypeEquation {} = NodeComments [] [] []
 
 instance Pretty TypeEquation where
-  pretty' TypeEquation {..} = spaced [lhs, string "=", pretty bind]
+  pretty TypeEquation {..} = spaced [lhs, string "=", pretty bind]
     where
       lhs = spaced $ [pretty name] <> [pretty types | hasTypeArguments types]
 

--- a/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Injectivity.hs
@@ -23,7 +23,7 @@ instance CommentExtraction Injectivity where
   nodeComments Injectivity {} = NodeComments [] [] []
 
 instance Pretty Injectivity where
-  pretty' Injectivity {..} = spaced $ pretty from : string "->" : fmap pretty to
+  pretty Injectivity {..} = spaced $ pretty from : string "->" : fmap pretty to
 
 mkInjectivity :: GHC.InjectivityAnn GHC.GhcPs -> Injectivity
 mkInjectivity (GHC.InjectivityAnn _ f t) = Injectivity {..}

--- a/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/ResultSignature.hs
@@ -25,9 +25,9 @@ instance CommentExtraction ResultSignature where
   nodeComments TypeVariable {} = NodeComments [] [] []
 
 instance Pretty ResultSignature where
-  pretty' NoSig = return ()
-  pretty' (Kind x) = string " :: " >> pretty x
-  pretty' (TypeVariable x) = string " = " >> pretty x
+  pretty NoSig = return ()
+  pretty (Kind x) = string " :: " >> pretty x
+  pretty (TypeVariable x) = string " = " >> pretty x
 
 mkResultSignature :: GHC.FamilyResultSig GHC.GhcPs -> ResultSignature
 mkResultSignature (GHC.NoSig _) = NoSig

--- a/src/HIndent/Ast/Declaration/Foreign.hs
+++ b/src/HIndent/Ast/Declaration/Foreign.hs
@@ -45,12 +45,12 @@ instance CommentExtraction ForeignDeclaration where
   nodeComments ForeignExport {} = NodeComments [] [] []
 
 instance Pretty ForeignDeclaration where
-  pretty' ForeignImport {..} =
+  pretty ForeignImport {..} =
     spaced
       $ [string "foreign import", pretty convention, pretty safety]
           ++ maybeToList (fmap pretty srcIdent)
           ++ [pretty dstIdent, string "::", pretty signature]
-  pretty' ForeignExport {..} =
+  pretty ForeignExport {..} =
     spaced
       $ [string "foreign export", pretty convention]
           ++ maybeToList (fmap pretty srcIdent)

--- a/src/HIndent/Ast/Declaration/Foreign/CallingConvention.hs
+++ b/src/HIndent/Ast/Declaration/Foreign/CallingConvention.hs
@@ -22,11 +22,11 @@ instance CommentExtraction CallingConvention where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty CallingConvention where
-  pretty' CCall = string "ccall"
-  pretty' CApi = string "capi"
-  pretty' StdCall = string "stdcall"
-  pretty' Prim = string "prim"
-  pretty' JavaScript = string "javascript"
+  pretty CCall = string "ccall"
+  pretty CApi = string "capi"
+  pretty StdCall = string "stdcall"
+  pretty Prim = string "prim"
+  pretty JavaScript = string "javascript"
 
 mkCallingConvention :: GHC.CCallConv -> CallingConvention
 mkCallingConvention GHC.CCallConv = CCall

--- a/src/HIndent/Ast/Declaration/Foreign/Safety.hs
+++ b/src/HIndent/Ast/Declaration/Foreign/Safety.hs
@@ -20,9 +20,9 @@ instance CommentExtraction Safety where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Safety where
-  pretty' Safe = string "safe"
-  pretty' Interruptible = string "interruptible"
-  pretty' Unsafe = string "unsafe"
+  pretty Safe = string "safe"
+  pretty Interruptible = string "interruptible"
+  pretty Unsafe = string "unsafe"
 
 mkSafety :: GHC.Safety -> Safety
 mkSafety GHC.PlaySafe = Safe

--- a/src/HIndent/Ast/Declaration/Instance/Class.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class.hs
@@ -31,7 +31,7 @@ instance CommentExtraction ClassInstance where
   nodeComments ClassInstance {} = NodeComments [] [] []
 
 instance Pretty ClassInstance where
-  pretty' ClassInstance {..} = do
+  pretty ClassInstance {..} = do
     string "instance " |=> do
       whenJust overlapMode $ \x -> do
         pretty x

--- a/src/HIndent/Ast/Declaration/Instance/Class/Body.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class/Body.hs
@@ -22,7 +22,7 @@ instance CommentExtraction ClassInstanceBody where
   nodeComments ClassInstanceBody {} = NodeComments [] [] []
 
 instance Pretty ClassInstanceBody where
-  pretty' (ClassInstanceBody members) = lined $ fmap pretty members
+  pretty (ClassInstanceBody members) = lined $ fmap pretty members
 
 mkClassInstanceBody ::
      [GHC.LSig GHC.GhcPs]

--- a/src/HIndent/Ast/Declaration/Instance/Class/Member.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class/Member.hs
@@ -28,12 +28,12 @@ instance CommentExtraction ClassInstanceMember where
   nodeComments Signature {} = NodeComments [] [] []
 
 instance Pretty ClassInstanceMember where
-  pretty' (AssociatedDataInstance associatedDataInstance) =
+  pretty (AssociatedDataInstance associatedDataInstance) =
     pretty associatedDataInstance
-  pretty' (AssociatedTypeInstance associatedTypeInstance) =
+  pretty (AssociatedTypeInstance associatedTypeInstance) =
     pretty associatedTypeInstance
-  pretty' (Method bind) = pretty bind
-  pretty' (Signature signature) = pretty signature
+  pretty (Method bind) = pretty bind
+  pretty (Signature signature) = pretty signature
 
 mkAssociatedDataInstanceMember ::
      GHC.DataFamInstDecl GHC.GhcPs -> ClassInstanceMember

--- a/src/HIndent/Ast/Declaration/Instance/Class/OverlapMode.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Class/OverlapMode.hs
@@ -25,10 +25,10 @@ instance CommentExtraction OverlapMode where
   nodeComments Incoherent = NodeComments [] [] []
 
 instance Pretty OverlapMode where
-  pretty' Overlappable = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps = string "{-# OVERLAPS #-}"
-  pretty' Incoherent = string "{-# INCOHERENT #-}"
+  pretty Overlappable = string "{-# OVERLAPPABLE #-}"
+  pretty Overlapping = string "{-# OVERLAPPING #-}"
+  pretty Overlaps = string "{-# OVERLAPS #-}"
+  pretty Incoherent = string "{-# INCOHERENT #-}"
 
 mkOverlapMode :: GHC.OverlapMode -> OverlapMode
 mkOverlapMode GHC.NoOverlap {} =

--- a/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
@@ -29,7 +29,7 @@ instance CommentExtraction DataFamilyInstance where
   nodeComments DataFamilyInstance {} = NodeComments [] [] []
 
 instance Pretty DataFamilyInstance where
-  pretty' DataFamilyInstance {..} = do
+  pretty DataFamilyInstance {..} = do
     spaced
       $ [pretty newOrData, string "instance", pretty name]
           <> [pretty types | hasTypeArguments types]

--- a/src/HIndent/Ast/Declaration/Instance/Family/Data/Associated.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Data/Associated.hs
@@ -27,7 +27,7 @@ instance CommentExtraction AssociatedDataFamilyInstance where
   nodeComments AssociatedDataFamilyInstance {} = NodeComments [] [] []
 
 instance Pretty AssociatedDataFamilyInstance where
-  pretty' AssociatedDataFamilyInstance {..} = do
+  pretty AssociatedDataFamilyInstance {..} = do
     lhs
     pretty body
     where

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
@@ -26,7 +26,7 @@ instance CommentExtraction TypeFamilyInstance where
   nodeComments TypeFamilyInstance {} = NodeComments [] [] []
 
 instance Pretty TypeFamilyInstance where
-  pretty' TypeFamilyInstance {..} = do
+  pretty TypeFamilyInstance {..} = do
     spaced
       $ [string "type instance", pretty name]
           <> [pretty types | hasTypeArguments types]

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
@@ -26,7 +26,7 @@ instance CommentExtraction AssociatedType where
   nodeComments AssociatedType {} = NodeComments [] [] []
 
 instance Pretty AssociatedType where
-  pretty' AssociatedType {..} = spaced [lhs, string "=", pretty bind]
+  pretty AssociatedType {..} = spaced [lhs, string "=", pretty bind]
     where
       lhs =
         spaced

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
@@ -26,7 +26,7 @@ instance CommentExtraction AssociatedTypeDefault where
   nodeComments AssociatedTypeDefault {} = NodeComments [] [] []
 
 instance Pretty AssociatedTypeDefault where
-  pretty' AssociatedTypeDefault {..} = spaced [lhs, string "=", pretty bind]
+  pretty AssociatedTypeDefault {..} = spaced [lhs, string "=", pretty bind]
     where
       lhs =
         spaced

--- a/src/HIndent/Ast/Declaration/PatternSynonym.hs
+++ b/src/HIndent/Ast/Declaration/PatternSynonym.hs
@@ -50,15 +50,15 @@ instance CommentExtraction PatternSynonym where
   nodeComments Record {} = emptyNodeComments
 
 instance Pretty PatternSynonym where
-  pretty' Prefix {..} = do
+  pretty Prefix {..} = do
     string "pattern "
     spaced $ pretty name : fmap pretty args
     prettySuffix isImplicitBidirectional definition explicitMatches
-  pretty' Infix {..} = do
+  pretty Infix {..} = do
     string "pattern "
     spaced [pretty leftArg, pretty operator, pretty rightArg]
     prettySuffix isImplicitBidirectional definition explicitMatches
-  pretty' Record {..} = do
+  pretty Record {..} = do
     string "pattern "
     spaced [pretty name, hFields $ fmap pretty fields]
     prettySuffix isImplicitBidirectional definition explicitMatches

--- a/src/HIndent/Ast/Declaration/Rule.hs
+++ b/src/HIndent/Ast/Declaration/Rule.hs
@@ -29,7 +29,7 @@ instance CommentExtraction RuleDeclaration where
   nodeComments RuleDeclaration {} = NodeComments [] [] []
 
 instance Pretty RuleDeclaration where
-  pretty' (RuleDeclaration {..}) =
+  pretty (RuleDeclaration {..}) =
     spaced [pretty name, prettyLhs, string "=", pretty rhs]
     where
       prettyLhs =

--- a/src/HIndent/Ast/Declaration/Rule/Binder.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Binder.hs
@@ -24,8 +24,8 @@ instance CommentExtraction RuleBinder where
   nodeComments RuleBinder {} = NodeComments [] [] []
 
 instance Pretty RuleBinder where
-  pretty' RuleBinder {signature = Nothing, ..} = pretty name
-  pretty' RuleBinder {signature = Just sig, ..} =
+  pretty RuleBinder {signature = Nothing, ..} = pretty name
+  pretty RuleBinder {signature = Just sig, ..} =
     parens $ spaced [pretty name, string "::", pretty sig]
 
 mkRuleBinder :: GHC.RuleBndr GHC.GhcPs -> RuleBinder

--- a/src/HIndent/Ast/Declaration/Rule/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Collection.hs
@@ -21,7 +21,7 @@ instance CommentExtraction RuleCollection where
   nodeComments RuleCollection {} = NodeComments [] [] []
 
 instance Pretty RuleCollection where
-  pretty' (RuleCollection xs) =
+  pretty (RuleCollection xs) =
     lined $ string "{-# RULES" : fmap pretty xs ++ [string " #-}"]
 
 mkRuleCollection :: GHC.RuleDecls GHC.GhcPs -> RuleCollection

--- a/src/HIndent/Ast/Declaration/Rule/Name.hs
+++ b/src/HIndent/Ast/Declaration/Rule/Name.hs
@@ -18,7 +18,7 @@ instance CommentExtraction RuleName where
   nodeComments _ = emptyNodeComments
 
 instance Pretty RuleName where
-  pretty' (RuleName name) = doubleQuotes $ pretty name
+  pretty (RuleName name) = doubleQuotes $ pretty name
 
 mkRuleName :: GHC.RuleName -> RuleName
 mkRuleName = RuleName . mkTextValueFromString . GHC.unpackFS

--- a/src/HIndent/Ast/Declaration/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Signature.hs
@@ -85,7 +85,7 @@ instance CommentExtraction Signature where
   nodeComments Complete {} = NodeComments [] [] []
 
 instance Pretty Signature where
-  pretty' Type {..} = do
+  pretty Type {..} = do
     printFunName
     string " ::"
     horizontal <-|> vertical
@@ -102,14 +102,14 @@ instance Pretty Signature where
             newline
             indentedBlock $ indentedWithSpace 3 $ pretty parameters
       printFunName = hCommaSep $ fmap pretty names
-  pretty' Pattern {..} =
+  pretty Pattern {..} =
     spaced
       [ string "pattern"
       , hCommaSep $ fmap pretty names
       , string "::"
       , pretty signature
       ]
-  pretty' DefaultClassMethod {..} = do
+  pretty DefaultClassMethod {..} = do
     string "default "
     hCommaSep $ fmap pretty names
     string " ::"
@@ -119,7 +119,7 @@ instance Pretty Signature where
       ver = do
         newline
         indentedBlock $ indentedWithSpace 3 $ pretty methodSig
-  pretty' ClassMethod {..} = do
+  pretty ClassMethod {..} = do
     hCommaSep $ fmap pretty names
     string " ::"
     hor <-|> ver
@@ -128,15 +128,15 @@ instance Pretty Signature where
       ver = do
         newline
         indentedBlock $ indentedWithSpace 3 $ pretty methodSig
-  pretty' Fixity {..} = spaced [pretty fixity, hCommaSep $ fmap pretty opNames]
-  pretty' Inline {..} = do
+  pretty Fixity {..} = spaced [pretty fixity, hCommaSep $ fmap pretty opNames]
+  pretty Inline {..} = do
     string "{-# "
     pretty spec
     whenJust phase $ \x -> space >> pretty x
     space
     pretty name
     string " #-}"
-  pretty' Specialise {..} =
+  pretty Specialise {..} =
     spaced
       [ string "{-# SPECIALISE"
       , pretty name
@@ -144,16 +144,16 @@ instance Pretty Signature where
       , hCommaSep $ fmap pretty sigs
       , string "#-}"
       ]
-  pretty' SpecialiseExpr {..} =
+  pretty SpecialiseExpr {..} =
     spaced [string "{-# SPECIALISE", pretty expression, string "#-}"]
-  pretty' (SpecialiseInstance sig) =
+  pretty (SpecialiseInstance sig) =
     spaced [string "{-# SPECIALISE instance", pretty sig, string "#-}"]
-  pretty' (Minimal xs) =
+  pretty (Minimal xs) =
     string "{-# MINIMAL " |=> do
       pretty xs
       string " #-}"
-  pretty' (Scc name) = spaced [string "{-# SCC", pretty name, string "#-}"]
-  pretty' (Complete names) =
+  pretty (Scc name) = spaced [string "{-# SCC", pretty name, string "#-}"]
+  pretty (Complete names) =
     spaced [string "{-# COMPLETE", hCommaSep $ fmap pretty names, string "#-}"]
 
 mkSignature :: GHC.Sig GHC.GhcPs -> Signature

--- a/src/HIndent/Ast/Declaration/Signature/BooleanFormula.hs
+++ b/src/HIndent/Ast/Declaration/Signature/BooleanFormula.hs
@@ -27,10 +27,10 @@ instance CommentExtraction BooleanFormula where
   nodeComments Parens {} = NodeComments [] [] []
 
 instance Pretty BooleanFormula where
-  pretty' (Var x) = pretty x
-  pretty' (And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs) = hvBarSep $ fmap pretty xs
-  pretty' (Parens x) = parens $ pretty x
+  pretty (Var x) = pretty x
+  pretty (And xs) = hvCommaSep $ fmap pretty xs
+  pretty (Or xs) = hvBarSep $ fmap pretty xs
+  pretty (Parens x) = parens $ pretty x
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkBooleanFormula :: GHC.BooleanFormula GHC.GhcPs -> BooleanFormula
 #else

--- a/src/HIndent/Ast/Declaration/Signature/Fixity.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Fixity.hs
@@ -23,7 +23,7 @@ instance CommentExtraction Fixity where
   nodeComments Fixity {} = NodeComments [] [] []
 
 instance Pretty Fixity where
-  pretty' Fixity {..} =
+  pretty Fixity {..} =
     spaced [pretty associativity, string $ Text.pack $ show level]
 
 mkFixity :: GHC.Fixity -> Fixity

--- a/src/HIndent/Ast/Declaration/Signature/Fixity/Associativity.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Fixity/Associativity.hs
@@ -22,9 +22,9 @@ instance CommentExtraction Associativity where
   nodeComments None = NodeComments [] [] []
 
 instance Pretty Associativity where
-  pretty' LeftAssoc = string "infixl"
-  pretty' RightAssoc = string "infixr"
-  pretty' None = string "infix"
+  pretty LeftAssoc = string "infixl"
+  pretty RightAssoc = string "infixr"
+  pretty None = string "infix"
 
 mkAssociativity :: GHC.FixityDirection -> Associativity
 mkAssociativity GHC.InfixL = LeftAssoc

--- a/src/HIndent/Ast/Declaration/Signature/Inline/Phase.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Inline/Phase.hs
@@ -25,9 +25,9 @@ instance CommentExtraction InlinePhase where
   nodeComments InlinePhase {} = NodeComments [] [] []
 
 instance Pretty InlinePhase where
-  pretty' InlinePhase {beforeOrAfter = Before, ..} =
+  pretty InlinePhase {beforeOrAfter = Before, ..} =
     brackets (string $ Text.pack $ '~' : show phase)
-  pretty' InlinePhase {beforeOrAfter = After, ..} =
+  pretty InlinePhase {beforeOrAfter = After, ..} =
     brackets (string $ Text.pack $ show phase)
 
 mkInlinePhase :: GHC.Activation -> Maybe InlinePhase

--- a/src/HIndent/Ast/Declaration/Signature/Inline/Spec.hs
+++ b/src/HIndent/Ast/Declaration/Signature/Inline/Spec.hs
@@ -25,10 +25,10 @@ instance CommentExtraction InlineSpec where
   nodeComments Opaque = NodeComments [] [] []
 
 instance Pretty InlineSpec where
-  pretty' Inline = string "INLINE"
-  pretty' Inlinable = string "INLINABLE"
-  pretty' NoInline = string "NOINLINE"
-  pretty' Opaque = string "OPAQUE"
+  pretty Inline = string "INLINE"
+  pretty Inlinable = string "INLINABLE"
+  pretty NoInline = string "NOINLINE"
+  pretty Opaque = string "OPAQUE"
 
 mkInlineSpec :: GHC.InlineSpec -> InlineSpec
 mkInlineSpec GHC.Inline {} = Inline

--- a/src/HIndent/Ast/Declaration/Signature/StandaloneKind.hs
+++ b/src/HIndent/Ast/Declaration/Signature/StandaloneKind.hs
@@ -24,7 +24,7 @@ instance CommentExtraction StandaloneKind where
   nodeComments StandaloneKind {} = NodeComments [] [] []
 
 instance Pretty StandaloneKind where
-  pretty' StandaloneKind {..} =
+  pretty StandaloneKind {..} =
     spaced [string "type", pretty name, string "::", pretty kind]
 
 mkStandaloneKind :: GHC.StandaloneKindSig GHC.GhcPs -> StandaloneKind

--- a/src/HIndent/Ast/Declaration/Splice.hs
+++ b/src/HIndent/Ast/Declaration/Splice.hs
@@ -17,7 +17,7 @@ instance CommentExtraction SpliceDeclaration where
   nodeComments SpliceDeclaration {} = NodeComments [] [] []
 
 instance Pretty SpliceDeclaration where
-  pretty' (SpliceDeclaration splice) = pretty splice
+  pretty (SpliceDeclaration splice) = pretty splice
 
 mkSpliceDeclaration :: GHC.SpliceDecl GHC.GhcPs -> SpliceDeclaration
 mkSpliceDeclaration (GHC.SpliceDecl _ sp _) =

--- a/src/HIndent/Ast/Declaration/StandAloneDeriving.hs
+++ b/src/HIndent/Ast/Declaration/StandAloneDeriving.hs
@@ -25,7 +25,7 @@ instance CommentExtraction StandAloneDeriving where
   nodeComments StandAloneDeriving {} = NodeComments [] [] []
 
 instance Pretty StandAloneDeriving where
-  pretty' StandAloneDeriving {strategy = Just strategy, ..}
+  pretty StandAloneDeriving {strategy = Just strategy, ..}
     | isViaStrategy (getNode strategy) =
       spaced
         [ string "deriving"
@@ -33,7 +33,7 @@ instance Pretty StandAloneDeriving where
         , string "instance"
         , pretty className
         ]
-  pretty' StandAloneDeriving {..} = do
+  pretty StandAloneDeriving {..} = do
     string "deriving "
     whenJust strategy $ \x -> pretty x >> space
     string "instance "

--- a/src/HIndent/Ast/Declaration/TypeSynonym.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym.hs
@@ -24,7 +24,7 @@ instance CommentExtraction TypeSynonym where
   nodeComments TypeSynonym {} = NodeComments [] [] []
 
 instance Pretty TypeSynonym where
-  pretty' TypeSynonym {..} = do
+  pretty TypeSynonym {..} = do
     string "type "
     pretty lhs
     hor <-|> ver

--- a/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
+++ b/src/HIndent/Ast/Declaration/TypeSynonym/Lhs.hs
@@ -32,8 +32,8 @@ instance CommentExtraction TypeSynonymLhs where
   nodeComments Infix {} = NodeComments [] [] []
 
 instance Pretty TypeSynonymLhs where
-  pretty' Prefix {..} = spaced $ pretty pName : fmap pretty typeVariables
-  pretty' Infix {..} = spaced [pretty left, pretty iName, pretty right]
+  pretty Prefix {..} = spaced $ pretty pName : fmap pretty typeVariables
+  pretty Infix {..} = spaced [pretty left, pretty iName, pretty right]
 
 mkTypeSynonymLhs :: GHC.TyClDecl GHC.GhcPs -> TypeSynonymLhs
 mkTypeSynonymLhs GHC.SynDecl {tcdFixity = GHC.Prefix, ..} = Prefix {..}

--- a/src/HIndent/Ast/Declaration/Warning.hs
+++ b/src/HIndent/Ast/Declaration/Warning.hs
@@ -29,7 +29,7 @@ instance CommentExtraction WarningDeclaration where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty WarningDeclaration where
-  pretty' WarningDeclaration {..} = do
+  pretty WarningDeclaration {..} = do
     lined
       [ string "{-# " >> pretty kind
       , spaced [hCommaSep $ fmap pretty names, hCommaSep $ fmap pretty reasons]

--- a/src/HIndent/Ast/Declaration/Warning/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Warning/Collection.hs
@@ -20,7 +20,7 @@ instance CommentExtraction WarningCollection where
   nodeComments WarningCollection {} = NodeComments [] [] []
 
 instance Pretty WarningCollection where
-  pretty' (WarningCollection xs) = lined $ fmap pretty xs
+  pretty (WarningCollection xs) = lined $ fmap pretty xs
 
 mkWarningCollection :: GHC.WarnDecls GHC.GhcPs -> WarningCollection
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)

--- a/src/HIndent/Ast/Declaration/Warning/Kind.hs
+++ b/src/HIndent/Ast/Declaration/Warning/Kind.hs
@@ -17,5 +17,5 @@ instance CommentExtraction Kind where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Kind where
-  pretty' Warning = string "WARNING"
-  pretty' Deprecated = string "DEPRECATED"
+  pretty Warning = string "WARNING"
+  pretty Deprecated = string "DEPRECATED"

--- a/src/HIndent/Ast/Expression.hs
+++ b/src/HIndent/Ast/Expression.hs
@@ -174,13 +174,13 @@ instance CommentExtraction Expression where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Expression where
-  pretty' (Variable name) = pretty name
-  pretty' (UnboundVariable name) = pretty name
-  pretty' (OverloadedLabel label) = pretty label
-  pretty' (ImplicitParameter name) = pretty name
-  pretty' (Literal lit) = pretty lit
-  pretty' (Lambda matches) = pretty matches
-  pretty' LambdaCase {..} = do
+  pretty (Variable name) = pretty name
+  pretty (UnboundVariable name) = pretty name
+  pretty (OverloadedLabel label) = pretty label
+  pretty (ImplicitParameter name) = pretty name
+  pretty (Literal lit) = pretty lit
+  pretty (Lambda matches) = pretty matches
+  pretty LambdaCase {..} = do
     string
       $ if usesCases
           then "\\cases"
@@ -190,7 +190,7 @@ instance Pretty Expression where
       else do
         newline
         indentedBlock $ pretty matches
-  pretty' (Application (headExpr :| argList)) = horizontal <-|> vertical
+  pretty (Application (headExpr :| argList)) = horizontal <-|> vertical
     where
       horizontal = spaced $ pretty <$> headExpr : argList
       vertical = do
@@ -210,11 +210,11 @@ instance Pretty Expression where
           else newline
         spaces' <- getIndentSpaces
         indentedWithSpace spaces' $ lined $ fmap pretty argList
-  pretty' TypeApplication {..} = do
+  pretty TypeApplication {..} = do
     pretty expression
     string " @"
     pretty typeArg
-  pretty' OperatorApplication {..} = horizontal <-|> vertical
+  pretty OperatorApplication {..} = horizontal <-|> vertical
     where
       horizontal = do
         pretty firstOperand
@@ -236,11 +236,11 @@ instance Pretty Expression where
           shouldBeInline Lambda {} = True
           shouldBeInline LambdaCase {} = True
           shouldBeInline _ = False
-  pretty' (Negation expr) = string "-" >> pretty expr
-  pretty' (Parenthesized expr) = parens $ pretty expr
-  pretty' LeftSection {..} = spaced [pretty left, pretty operator]
-  pretty' RightSection {..} = (pretty operator >> space) |=> pretty right
-  pretty' Tuple {..} = horizontal <-|> vertical
+  pretty (Negation expr) = string "-" >> pretty expr
+  pretty (Parenthesized expr) = parens $ pretty expr
+  pretty LeftSection {..} = spaced [pretty left, pretty operator]
+  pretty RightSection {..} = (pretty operator >> space) |=> pretty right
+  pretty Tuple {..} = horizontal <-|> vertical
     where
       horizontal = parH $ prettyArg pretty <$> arguments
       vertical =
@@ -252,7 +252,7 @@ instance Pretty Expression where
         if isBoxed
           then (hTuple, parens)
           else (hUnboxedTuple, unboxedParens)
-  pretty' Sum {..} = do
+  pretty Sum {..} = do
     string "(#"
     forM_ [1 .. arity] $ \idx -> do
       if idx == position
@@ -260,7 +260,7 @@ instance Pretty Expression where
         else space
       when (idx < arity) $ string "|"
     string "#)"
-  pretty' CaseExpression {..} = do
+  pretty CaseExpression {..} = do
     string "case " |=> do
       pretty scrutinee
       string " of"
@@ -269,7 +269,7 @@ instance Pretty Expression where
       else do
         newline
         indentedBlock $ pretty matches
-  pretty' IfExpression {..} = do
+  pretty IfExpression {..} = do
     string "if " |=> pretty predicate
     indentedBlock
       $ newlinePrefixed [branch "then " thenBranch, branch "else " elseBranch]
@@ -281,56 +281,56 @@ instance Pretty Expression where
               string str
               pretty expr
             _ -> string str |=> pretty expr
-  pretty' (MultiIf multiIfClauses) =
+  pretty (MultiIf multiIfClauses) =
     string "if " |=> lined (fmap pretty multiIfClauses)
-  pretty' LetBinding {..} =
+  pretty LetBinding {..} =
     lined
       [string "let " |=> pretty bindings, string " in " |=> pretty expression]
-  pretty' DoBlock {..} = do
+  pretty DoBlock {..} = do
     pretty qualifiedDo
     newline
     indentedBlock $ prettyWith statements (lined . fmap pretty)
-  pretty' (ListComprehension listComprehension) = pretty listComprehension
-  pretty' (ListLiteral listItems) = horizontal <-|> vertical
+  pretty (ListComprehension listComprehension) = pretty listComprehension
+  pretty (ListLiteral listItems) = horizontal <-|> vertical
     where
       horizontal = brackets $ hCommaSep $ fmap pretty listItems
       vertical = vList $ fmap pretty listItems
-  pretty' RecordConstruction {..} = horizontal <-|> vertical
+  pretty RecordConstruction {..} = horizontal <-|> vertical
     where
       horizontal = spaced [pretty name, pretty fields]
       vertical = do
         pretty name
         (space >> pretty fields) <-|> (newline >> indentedBlock (pretty fields))
-  pretty' (RecordUpdate fields) = pretty fields
-  pretty' FieldProjection {..} = do
+  pretty (RecordUpdate fields) = pretty fields
+  pretty FieldProjection {..} = do
     pretty expression
     dot
     pretty selector
-  pretty' (Projection projectionFields) =
+  pretty (Projection projectionFields) =
     parens $ forM_ projectionFields prettyProjectionField
     where
       prettyProjectionField projectionField = do
         string "."
         pretty projectionField
-  pretty' TypeSignature {..} =
+  pretty TypeSignature {..} =
     spaced [pretty expression, string "::", pretty signature]
-  pretty' (ArithmeticSequence rangeExpression) = pretty rangeExpression
-  pretty' (TypedQuotation expr) = typedBrackets $ pretty expr
-  pretty' (UntypedQuotation bracket) = pretty bracket
-  pretty' ProcExpression {..} = hor <-|> ver
+  pretty (ArithmeticSequence rangeExpression) = pretty rangeExpression
+  pretty (TypedQuotation expr) = typedBrackets $ pretty expr
+  pretty (UntypedQuotation bracket) = pretty bracket
+  pretty ProcExpression {..} = hor <-|> ver
     where
       hor = spaced [string "proc", pretty pat, string "->", pretty cmd]
       ver = do
         spaced [string "proc", pretty pat, string "->"]
         newline
         indentedBlock $ pretty cmd
-  pretty' ProcDo {..} = do
+  pretty ProcDo {..} = do
     spaced [string "proc", pretty pat, string "-> do"]
     newline
     indentedBlock $ pretty block
-  pretty' (StaticExpression expr) = spaced [string "static", pretty expr]
-  pretty' PragmaticExpression {..} = spaced [pretty pragma, pretty expression]
-  pretty' (Splice splice') = pretty splice'
+  pretty (StaticExpression expr) = spaced [string "static", pretty expr]
+  pretty PragmaticExpression {..} = spaced [pretty pragma, pretty expression]
+  pretty (Splice splice') = pretty splice'
 
 mkExpression :: GHC.HsExpr GHC.GhcPs -> Expression
 mkExpression (GHC.HsVar _ name) =
@@ -667,10 +667,10 @@ instance CommentExtraction InfixExpr where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty InfixExpr where
-  pretty' (InfixExpr (Variable name)) = pretty $ mkPrefixAsInfix <$> name
-  pretty' (InfixExpr (UnboundVariable name)) = pretty $ mkPrefixAsInfix <$> name
-  pretty' (InfixExpr (Parenthesized inner)) = pretty $ fmap InfixExpr inner
-  pretty' (InfixExpr x) = pretty x
+  pretty (InfixExpr (Variable name)) = pretty $ mkPrefixAsInfix <$> name
+  pretty (InfixExpr (UnboundVariable name)) = pretty $ mkPrefixAsInfix <$> name
+  pretty (InfixExpr (Parenthesized inner)) = pretty $ fmap InfixExpr inner
+  pretty (InfixExpr x) = pretty x
 
 data GuardExpression
   = GuardWithDo Expression
@@ -683,9 +683,9 @@ instance CommentExtraction GuardExpression where
   nodeComments (GuardExpression expr) = nodeComments expr
 
 instance Pretty GuardExpression where
-  pretty' (GuardWithDo expr) = space >> pretty expr
-  pretty' (GuardWithAppAndDo expr) = space >> pretty expr
-  pretty' (GuardExpression expr) = horizontal <-|> vertical
+  pretty (GuardWithDo expr) = space >> pretty expr
+  pretty (GuardWithAppAndDo expr) = space >> pretty expr
+  pretty (GuardExpression expr) = horizontal <-|> vertical
     where
       horizontal = space >> pretty expr
       vertical = newline >> indentedBlock (pretty expr)

--- a/src/HIndent/Ast/Expression/Bracket.hs
+++ b/src/HIndent/Ast/Expression/Bracket.hs
@@ -35,14 +35,14 @@ instance CommentExtraction Bracket where
   nodeComments Variable {} = NodeComments [] [] []
 
 instance Pretty Bracket where
-  pretty' (TypedExpression x) = typedBrackets $ pretty x
-  pretty' (UntypedExpression x) = brackets $ wrapWithBars $ pretty x
-  pretty' (Pattern x) = brackets $ string "p" >> wrapWithBars (pretty x)
-  pretty' (Declaration decls) =
+  pretty (TypedExpression x) = typedBrackets $ pretty x
+  pretty (UntypedExpression x) = brackets $ wrapWithBars $ pretty x
+  pretty (Pattern x) = brackets $ string "p" >> wrapWithBars (pretty x)
+  pretty (Declaration decls) =
     brackets $ string "d| " |=> lined (fmap pretty decls) >> string " |"
-  pretty' (Type x) = brackets $ string "t" >> wrapWithBars (pretty x)
-  pretty' (Variable True var) = string "'" >> pretty var
-  pretty' (Variable False var) = string "''" >> pretty var
+  pretty (Type x) = brackets $ string "t" >> wrapWithBars (pretty x)
+  pretty (Variable True var) = string "'" >> pretty var
+  pretty (Variable False var) = string "''" >> pretty var
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1)
 mkBracket :: GHC.HsQuote GHC.GhcPs -> Bracket
 #else

--- a/src/HIndent/Ast/Expression/DoOrMdo.hs
+++ b/src/HIndent/Ast/Expression/DoOrMdo.hs
@@ -18,8 +18,8 @@ instance CommentExtraction DoOrMdo where
   nodeComments = const emptyNodeComments
 
 instance Pretty DoOrMdo where
-  pretty' Do = string "do"
-  pretty' Mdo = string "mdo"
+  pretty Do = string "do"
+  pretty Mdo = string "mdo"
 
 mkDoOrMdo :: GHC.HsDoFlavour -> DoOrMdo
 mkDoOrMdo (GHC.DoExpr _) = Do

--- a/src/HIndent/Ast/Expression/FieldSelector.hs
+++ b/src/HIndent/Ast/Expression/FieldSelector.hs
@@ -22,7 +22,7 @@ instance CommentExtraction FieldSelector where
   nodeComments FieldSelector {} = NodeComments [] [] []
 
 instance Pretty FieldSelector where
-  pretty' FieldSelector {..} = pretty name
+  pretty FieldSelector {..} = pretty name
 
 mkFieldSelector :: GHC.DotFieldOcc GHC.GhcPs -> FieldSelector
 mkFieldSelector GHC.DotFieldOcc {..} =

--- a/src/HIndent/Ast/Expression/ListComprehension.hs
+++ b/src/HIndent/Ast/Expression/ListComprehension.hs
@@ -26,7 +26,7 @@ instance CommentExtraction ListComprehension where
   nodeComments _ = emptyNodeComments
 
 instance Pretty ListComprehension where
-  pretty' ListComprehension {..} = horizontal <-|> vertical
+  pretty ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
         brackets

--- a/src/HIndent/Ast/Expression/OverloadedLabel.hs
+++ b/src/HIndent/Ast/Expression/OverloadedLabel.hs
@@ -19,7 +19,7 @@ instance CommentExtraction OverloadedLabel where
   nodeComments OverloadedLabel {} = emptyNodeComments
 
 instance Pretty OverloadedLabel where
-  pretty' (OverloadedLabel value) = string "#" >> pretty value
+  pretty (OverloadedLabel value) = string "#" >> pretty value
 
 mkOverloadedLabel :: GHC.FastString -> OverloadedLabel
 mkOverloadedLabel value =

--- a/src/HIndent/Ast/Expression/Pragmatic.hs
+++ b/src/HIndent/Ast/Expression/Pragmatic.hs
@@ -27,7 +27,7 @@ instance CommentExtraction ExpressionPragma where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty ExpressionPragma where
-  pretty' SccPragma {..} = spaced [string "{-# SCC", pretty label, string "#-}"]
+  pretty SccPragma {..} = spaced [string "{-# SCC", pretty label, string "#-}"]
 
 mkExpressionPragma :: GHC.HsPragE GHC.GhcPs -> WithComments ExpressionPragma
 #if MIN_VERSION_ghc_lib_parser(9, 8, 1)

--- a/src/HIndent/Ast/Expression/QualifiedDo.hs
+++ b/src/HIndent/Ast/Expression/QualifiedDo.hs
@@ -19,11 +19,11 @@ instance CommentExtraction QualifiedDo where
   nodeComments = const emptyNodeComments
 
 instance Pretty QualifiedDo where
-  pretty' (QualifiedDo (Just moduleName) doOrMdo) = do
+  pretty (QualifiedDo (Just moduleName) doOrMdo) = do
     pretty moduleName
     string "."
     pretty doOrMdo
-  pretty' (QualifiedDo Nothing doOrMdo) = pretty doOrMdo
+  pretty (QualifiedDo Nothing doOrMdo) = pretty doOrMdo
 
 mkQualifiedDo :: GHC.HsDoFlavour -> QualifiedDo
 mkQualifiedDo stmtContext@(GHC.DoExpr moduleName) =

--- a/src/HIndent/Ast/Expression/RangeExpression.hs
+++ b/src/HIndent/Ast/Expression/RangeExpression.hs
@@ -37,11 +37,11 @@ instance CommentExtraction RangeExpression where
   nodeComments FromThenTo {} = emptyNodeComments
 
 instance Pretty RangeExpression where
-  pretty' (From f) = brackets $ spaced [pretty f, string ".."]
-  pretty' FromThen {..} =
+  pretty (From f) = brackets $ spaced [pretty f, string ".."]
+  pretty FromThen {..} =
     brackets $ spaced [pretty from >> comma >> pretty next, string ".."]
-  pretty' FromTo {..} = brackets $ spaced [pretty from, string "..", pretty to]
-  pretty' FromThenTo {..} =
+  pretty FromTo {..} = brackets $ spaced [pretty from, string "..", pretty to]
+  pretty FromThenTo {..} =
     brackets
       $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 

--- a/src/HIndent/Ast/Expression/RecordConstructionField.hs
+++ b/src/HIndent/Ast/Expression/RecordConstructionField.hs
@@ -25,7 +25,7 @@ instance CommentExtraction RecordConstructionFields where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty RecordConstructionFields where
-  pretty' RecordConstructionFields {..} =
+  pretty RecordConstructionFields {..} =
     hvFields (fmap pretty fields ++ [string ".." | dotdot])
 
 mkRecordConstructionFields ::

--- a/src/HIndent/Ast/Expression/RecordUpdateField.hs
+++ b/src/HIndent/Ast/Expression/RecordUpdateField.hs
@@ -44,7 +44,7 @@ instance CommentExtraction RecordUpdateFields where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty RecordUpdateFields where
-  pretty' RecordUpdateFields {..} = horizontal <-|> vertical
+  pretty RecordUpdateFields {..} = horizontal <-|> vertical
     where
       horizontal =
         spaced

--- a/src/HIndent/Ast/Expression/Splice.hs
+++ b/src/HIndent/Ast/Expression/Splice.hs
@@ -41,10 +41,10 @@ instance CommentExtraction Splice where
   nodeComments QuasiQuote {} = NodeComments [] [] []
 
 instance Pretty Splice where
-  pretty' (Typed x) = string "$$" >> pretty x
-  pretty' (UntypedDollar x) = string "$" >> pretty x
-  pretty' (UntypedBare x) = pretty x
-  pretty' (QuasiQuote l r) =
+  pretty (Typed x) = string "$$" >> pretty x
+  pretty (UntypedDollar x) = string "$" >> pretty x
+  pretty (UntypedBare x) = pretty x
+  pretty (QuasiQuote l r) =
     brackets $ do
       pretty l
       wrapWithBars

--- a/src/HIndent/Ast/FileHeaderPragma.hs
+++ b/src/HIndent/Ast/FileHeaderPragma.hs
@@ -21,7 +21,7 @@ instance CommentExtraction FileHeaderPragma where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty FileHeaderPragma where
-  pretty' (FileHeaderPragma value) = pretty value
+  pretty (FileHeaderPragma value) = pretty value
 
 mkFileHeaderPragma :: GHC.EpaCommentTok -> Maybe FileHeaderPragma
 mkFileHeaderPragma =

--- a/src/HIndent/Ast/FileHeaderPragma/Collection.hs
+++ b/src/HIndent/Ast/FileHeaderPragma/Collection.hs
@@ -22,7 +22,7 @@ instance CommentExtraction FileHeaderPragmaCollection where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty FileHeaderPragmaCollection where
-  pretty' (FileHeaderPragmaCollection xs) = lined $ fmap pretty xs
+  pretty (FileHeaderPragmaCollection xs) = lined $ fmap pretty xs
 
 mkFileHeaderPragmaCollection :: GHC.HsModule' -> FileHeaderPragmaCollection
 mkFileHeaderPragmaCollection =

--- a/src/HIndent/Ast/Guard.hs
+++ b/src/HIndent/Ast/Guard.hs
@@ -52,7 +52,7 @@ instance CommentExtraction Guard where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Guard where
-  pretty' ExprGuard {..}
+  pretty ExprGuard {..}
     | null conditions = do
       space
       string (contextSeparator guardContext)
@@ -66,7 +66,7 @@ instance Pretty Guard where
         space
         string (contextSeparator guardContext)
         pretty expr
-  pretty' CmdGuard {..}
+  pretty CmdGuard {..}
     | null conditions = do
       space
       string (contextSeparator guardContext)

--- a/src/HIndent/Ast/Import.hs
+++ b/src/HIndent/Ast/Import.hs
@@ -43,7 +43,7 @@ instance CommentExtraction Import where
   nodeComments Import {} = NodeComments [] [] []
 
 instance Pretty Import where
-  pretty' Import {..} = do
+  pretty Import {..} = do
     string "import "
     when isBoot $ string "{-# SOURCE #-} "
     when isSafe $ string "safe "

--- a/src/HIndent/Ast/Import/Collection.hs
+++ b/src/HIndent/Ast/Import/Collection.hs
@@ -30,7 +30,7 @@ instance CommentExtraction ImportCollection where
   nodeComments ImportCollection {} = NodeComments [] [] []
 
 instance Pretty ImportCollection where
-  pretty' (ImportCollection xs) =
+  pretty (ImportCollection xs) =
     importDecls >>= blanklined . fmap outputImportGroup
     where
       outputImportGroup = lined . fmap pretty

--- a/src/HIndent/Ast/Import/Entry.hs
+++ b/src/HIndent/Ast/Import/Entry.hs
@@ -30,9 +30,9 @@ instance CommentExtraction ImportEntry where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty ImportEntry where
-  pretty' (SingleIdentifier wrapped) = pretty wrapped
-  pretty' (WithAllConstructors wrapped) = pretty wrapped >> string "(..)"
-  pretty' WithSpecificConstructors {..} =
+  pretty (SingleIdentifier wrapped) = pretty wrapped
+  pretty (WithAllConstructors wrapped) = pretty wrapped >> string "(..)"
+  pretty WithSpecificConstructors {..} =
     pretty name >> hFillingTuple (fmap pretty constructors)
 
 mkImportEntry :: GHC.IE GHC.GhcPs -> ImportEntry

--- a/src/HIndent/Ast/Import/Entry/Collection.hs
+++ b/src/HIndent/Ast/Import/Entry/Collection.hs
@@ -28,7 +28,7 @@ instance CommentExtraction ImportEntryCollection where
   nodeComments ImportEntryCollection {} = NodeComments [] [] []
 
 instance Pretty ImportEntryCollection where
-  pretty' ImportEntryCollection {..} = do
+  pretty ImportEntryCollection {..} = do
     when (kind == Hiding) $ string " hiding"
     (space >> hTuple (fmap pretty entries))
       <-|> (newline >> indentedBlock (vTuple $ fmap pretty entries))

--- a/src/HIndent/Ast/Literal.hs
+++ b/src/HIndent/Ast/Literal.hs
@@ -26,10 +26,10 @@ instance CommentExtraction Literal where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Literal where
-  pretty' (Inline value) = pretty value
-  pretty' (MultilineString []) = pure ()
-  pretty' (MultilineString [value]) = pretty value
-  pretty' (MultilineString (value:values)) = do
+  pretty (Inline value) = pretty value
+  pretty (MultilineString []) = pure ()
+  pretty (MultilineString [value]) = pretty value
+  pretty (MultilineString (value:values)) = do
     pretty value
     newline
     indentedWithFixedLevel 0 $ lined $ fmap pretty values

--- a/src/HIndent/Ast/LocalBinds.hs
+++ b/src/HIndent/Ast/LocalBinds.hs
@@ -31,8 +31,8 @@ instance CommentExtraction LocalBinds where
   nodeComments _ = emptyNodeComments
 
 instance Pretty LocalBinds where
-  pretty' Value {..} = pretty' declarations
-  pretty' ImplicitParameters {..} = pretty' implicitBindings
+  pretty Value {..} = pretty declarations
+  pretty ImplicitParameters {..} = pretty implicitBindings
 
 mkLocalBinds :: GHC.HsLocalBinds GHC.GhcPs -> Maybe (WithComments LocalBinds)
 mkLocalBinds (GHC.HsValBinds ann binds) =

--- a/src/HIndent/Ast/LocalBinds/Declaration.hs
+++ b/src/HIndent/Ast/LocalBinds/Declaration.hs
@@ -18,8 +18,8 @@ instance CommentExtraction LocalDeclaration where
   nodeComments _ = emptyNodeComments
 
 instance Pretty LocalDeclaration where
-  pretty' (Binding bind) = pretty bind
-  pretty' (Signature signature) = pretty signature
+  pretty (Binding bind) = pretty bind
+  pretty (Signature signature) = pretty signature
 
 mkLocalSignatureDeclaration :: GHC.Sig GHC.GhcPs -> LocalDeclaration
 mkLocalSignatureDeclaration = Signature . mkSignature

--- a/src/HIndent/Ast/LocalBinds/Declaration/Collection.hs
+++ b/src/HIndent/Ast/LocalBinds/Declaration/Collection.hs
@@ -21,7 +21,7 @@ instance CommentExtraction LocalDeclarationCollection where
   nodeComments _ = emptyNodeComments
 
 instance Pretty LocalDeclarationCollection where
-  pretty' (LocalDeclarationCollection declarations) =
+  pretty (LocalDeclarationCollection declarations) =
     lined $ fmap pretty declarations
 
 mkLocalDeclarationCollection ::

--- a/src/HIndent/Ast/LocalBinds/ImplicitBinding.hs
+++ b/src/HIndent/Ast/LocalBinds/ImplicitBinding.hs
@@ -28,7 +28,7 @@ instance CommentExtraction ImplicitBinding where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty ImplicitBinding where
-  pretty' ImplicitBinding {..} =
+  pretty ImplicitBinding {..} =
     spaced [pretty name, string "=", pretty expression]
 
 mkImplicitBinding :: GHC.IPBind GHC.GhcPs -> ImplicitBinding

--- a/src/HIndent/Ast/LocalBinds/ImplicitBindings.hs
+++ b/src/HIndent/Ast/LocalBinds/ImplicitBindings.hs
@@ -21,7 +21,7 @@ instance CommentExtraction ImplicitBindings where
   nodeComments _ = emptyNodeComments
 
 instance Pretty ImplicitBindings where
-  pretty' (ImplicitBindings xs) = lined $ fmap pretty xs
+  pretty (ImplicitBindings xs) = lined $ fmap pretty xs
 
 mkImplicitBindings :: GHC.HsIPBinds GHC.GhcPs -> ImplicitBindings
 mkImplicitBindings (GHC.IPBinds _ xs) =

--- a/src/HIndent/Ast/Match.hs
+++ b/src/HIndent/Ast/Match.hs
@@ -60,7 +60,7 @@ instance CommentExtraction InfixOperands where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty InfixOperands where
-  pretty' InfixOperands {..} =
+  pretty InfixOperands {..} =
     spaced $ pretty left : pretty operator : pretty right : fmap pretty rest
 
 data Match
@@ -88,21 +88,21 @@ instance CommentExtraction Match where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Match where
-  pretty' Lambda {..} = do
+  pretty Lambda {..} = do
     string "\\"
     when needsSpaceAfterLambda space
     prettyWith patterns $ spaced . fmap pretty
     pretty rhs
-  pretty' Case {..} = do
+  pretty Case {..} = do
     prettyWith patterns $ spaced . fmap pretty
     pretty rhs
-  pretty' FunctionPrefix {..} = do
+  pretty FunctionPrefix {..} = do
     whenJust strictness pretty
     pretty name
     prettyWith patterns $ \pats ->
       unless (null pats) $ spacePrefixed $ fmap pretty pats
     pretty rhs
-  pretty' FunctionInfix {..} = do
+  pretty FunctionInfix {..} = do
     pretty operands
     pretty rhs
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)

--- a/src/HIndent/Ast/MatchGroup.hs
+++ b/src/HIndent/Ast/MatchGroup.hs
@@ -24,7 +24,7 @@ instance CommentExtraction MatchGroup where
   nodeComments _ = mempty
 
 instance Pretty MatchGroup where
-  pretty' (MatchGroup alts) = prettyWith alts (lined . fmap pretty)
+  pretty (MatchGroup alts) = prettyWith alts (lined . fmap pretty)
 
 mkExprMatchGroup ::
      GHC.MatchGroup GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> MatchGroup

--- a/src/HIndent/Ast/Module.hs
+++ b/src/HIndent/Ast/Module.hs
@@ -29,7 +29,7 @@ instance CommentExtraction Module where
   nodeComments Module {} = NodeComments [] [] []
 
 instance Pretty Module where
-  pretty' Module {..}
+  pretty Module {..}
     | isEmpty = pure ()
     | otherwise = blanklined printers >> newline
     where

--- a/src/HIndent/Ast/Module/Declaration.hs
+++ b/src/HIndent/Ast/Module/Declaration.hs
@@ -27,7 +27,7 @@ instance CommentExtraction ModuleDeclaration where
   nodeComments ModuleDeclaration {} = NodeComments [] [] []
 
 instance Pretty ModuleDeclaration where
-  pretty' ModuleDeclaration {..} = do
+  pretty ModuleDeclaration {..} = do
     prettyWith name $ \n -> do
       string "module "
       pretty n

--- a/src/HIndent/Ast/Module/Export/Collection.hs
+++ b/src/HIndent/Ast/Module/Export/Collection.hs
@@ -18,7 +18,7 @@ instance CommentExtraction ExportCollection where
   nodeComments (ExportCollection _) = NodeComments [] [] []
 
 instance Pretty ExportCollection where
-  pretty' (ExportCollection xs) = vTuple $ fmap pretty xs
+  pretty (ExportCollection xs) = vTuple $ fmap pretty xs
 
 mkExportCollection :: GHC.HsModule' -> Maybe (WithComments ExportCollection)
 mkExportCollection =

--- a/src/HIndent/Ast/Module/Export/Entry.hs
+++ b/src/HIndent/Ast/Module/Export/Entry.hs
@@ -31,10 +31,10 @@ instance CommentExtraction ExportEntry where
   nodeComments ByModule {} = NodeComments [] [] []
 
 instance Pretty ExportEntry where
-  pretty' (SingleIdentifier s) = pretty s
-  pretty' (WithSpecificConstructors s xs) = pretty s >> hTuple (fmap pretty xs)
-  pretty' (WithAllConstructors s) = pretty s >> string "(..)"
-  pretty' (ByModule s) = string "module " >> pretty s
+  pretty (SingleIdentifier s) = pretty s
+  pretty (WithSpecificConstructors s xs) = pretty s >> hTuple (fmap pretty xs)
+  pretty (WithAllConstructors s) = pretty s >> string "(..)"
+  pretty (ByModule s) = string "module " >> pretty s
 
 mkExportEntry :: GHC.IE GHC.GhcPs -> ExportEntry
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)

--- a/src/HIndent/Ast/Module/Name.hs
+++ b/src/HIndent/Ast/Module/Name.hs
@@ -17,7 +17,7 @@ instance CommentExtraction ModuleName where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty ModuleName where
-  pretty' (ModuleName value) = pretty value
+  pretty (ModuleName value) = pretty value
 
 mkModuleName :: GHC.ModuleName -> ModuleName
 mkModuleName = ModuleName . mkTextValueFromString . GHC.moduleNameString

--- a/src/HIndent/Ast/Module/Warning.hs
+++ b/src/HIndent/Ast/Module/Warning.hs
@@ -37,7 +37,7 @@ instance CommentExtraction ModuleWarning where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty ModuleWarning where
-  pretty' ModuleWarning {..} =
+  pretty ModuleWarning {..} =
     spaced [string "{-#", pretty kind, prettyMsgs, string "#-}"]
     where
       prettyMsgs =

--- a/src/HIndent/Ast/Name/ImportExport.hs
+++ b/src/HIndent/Ast/Name/ImportExport.hs
@@ -38,10 +38,10 @@ instance CommentExtraction ImportExportName where
   nodeComments Data {} = NodeComments [] [] []
 
 instance Pretty ImportExportName where
-  pretty' (Regular name) = pretty name
-  pretty' (Pattern name) = spaced [string "pattern", pretty name]
-  pretty' (Type name) = string "type " >> pretty name
-  pretty' (Data name) = string "data " >> pretty name
+  pretty (Regular name) = pretty name
+  pretty (Pattern name) = spaced [string "pattern", pretty name]
+  pretty (Type name) = string "type " >> pretty name
+  pretty (Data name) = string "data " >> pretty name
 
 instance Eq ImportExportName where
   a == b = compare a b == EQ
@@ -79,7 +79,7 @@ mkImportExportName (GHC.IEData _ name) =
 #endif
 getNameString :: ImportExportName -> String
 getNameString n =
-  L.unpack $ S.toLazyByteString $ runPrinterStyle defaultConfig $ pretty' n
+  L.unpack $ S.toLazyByteString $ runPrinterStyle defaultConfig $ pretty n
 
 compareIdentifier :: String -> String -> Ordering
 compareIdentifier as@(a:_) bs@(b:_) =

--- a/src/HIndent/Ast/Name/Infix.hs
+++ b/src/HIndent/Ast/Name/Infix.hs
@@ -31,7 +31,7 @@ instance CommentExtraction InfixName where
   nodeComments InfixName {} = NodeComments [] [] []
 
 instance Pretty InfixName where
-  pretty' InfixName {..} =
+  pretty InfixName {..} =
     wrap $ hDotSep $ catMaybes [pretty <$> moduleName, Just $ pretty name]
     where
       wrap =

--- a/src/HIndent/Ast/Name/Prefix.hs
+++ b/src/HIndent/Ast/Name/Prefix.hs
@@ -32,7 +32,7 @@ instance CommentExtraction PrefixName where
   nodeComments PrefixName {} = NodeComments [] [] []
 
 instance Pretty PrefixName where
-  pretty' PrefixName {..} =
+  pretty PrefixName {..} =
     wrap $ hDotSep $ catMaybes [pretty <$> moduleName, Just $ pretty name]
     where
       wrap =
@@ -69,7 +69,7 @@ instance CommentExtraction PrefixAsInfix where
   nodeComments (PrefixAsInfix prefix) = nodeComments prefix
 
 instance Pretty PrefixAsInfix where
-  pretty' (PrefixAsInfix PrefixName {..}) =
+  pretty (PrefixAsInfix PrefixName {..}) =
     wrap $ hDotSep $ catMaybes [pretty <$> moduleName, Just $ pretty name]
     where
       wrap =

--- a/src/HIndent/Ast/Name/RecordField.hs
+++ b/src/HIndent/Ast/Name/RecordField.hs
@@ -35,7 +35,7 @@ instance CommentExtraction FieldName where
   nodeComments FieldName {} = NodeComments [] [] []
 
 instance Pretty FieldName where
-  pretty' (FieldName labels) = hDotSep $ pretty <$> NonEmpty.toList labels
+  pretty (FieldName labels) = hDotSep $ pretty <$> NonEmpty.toList labels
 
 mkFieldNameFromFieldOcc :: GHC.FieldOcc GHC.GhcPs -> FieldName
 #if MIN_VERSION_ghc_lib_parser(9, 4, 1)

--- a/src/HIndent/Ast/Pattern.hs
+++ b/src/HIndent/Ast/Pattern.hs
@@ -83,16 +83,16 @@ instance CommentExtraction Pattern where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Pattern where
-  pretty' WildCard = string "_"
-  pretty' (Variable name) = pretty name
-  pretty' (Lazy pat) = string "~" >> pretty pat
-  pretty' As {..} = pretty name >> string "@" >> pretty pat
-  pretty' (Parenthesized pat) = parens $ pretty pat
-  pretty' (Bang pat) = string "!" >> pretty pat
-  pretty' (List pats) = hList $ pretty <$> pats
-  pretty' Tuple {boxed = True, ..} = hTuple $ pretty <$> patterns
-  pretty' Tuple {boxed = False, ..} = hUnboxedTuple $ pretty <$> patterns
-  pretty' Sum {..} = do
+  pretty WildCard = string "_"
+  pretty (Variable name) = pretty name
+  pretty (Lazy pat) = string "~" >> pretty pat
+  pretty As {..} = pretty name >> string "@" >> pretty pat
+  pretty (Parenthesized pat) = parens $ pretty pat
+  pretty (Bang pat) = string "!" >> pretty pat
+  pretty (List pats) = hList $ pretty <$> pats
+  pretty Tuple {boxed = True, ..} = hTuple $ pretty <$> patterns
+  pretty Tuple {boxed = False, ..} = hUnboxedTuple $ pretty <$> patterns
+  pretty Sum {..} = do
     string "(#"
     forM_ [1 .. arity] $ \idx -> do
       if idx == position
@@ -100,22 +100,22 @@ instance Pretty Pattern where
         else string " "
       when (idx < arity) $ string "|"
     string "#)"
-  pretty' PrefixConstructor {..} = do
+  pretty PrefixConstructor {..} = do
     pretty name
     spacePrefixed $ pretty <$> patterns
-  pretty' InfixConstructor {..} = do
+  pretty InfixConstructor {..} = do
     pretty left
     InfixName.unlessSpecialOp (getNode operator) space
     pretty operator
     InfixName.unlessSpecialOp (getNode operator) space
     pretty right
-  pretty' RecordConstructor {..} = (pretty name >> space) |=> pretty fields
-  pretty' View {..} = spaced [pretty expression, string "->", pretty pat]
-  pretty' (Splice splice) = pretty splice
-  pretty' (Literal lit) = pretty lit
-  pretty' NPlusK {..} = pretty n >> string "+" >> pretty k
-  pretty' Signature {..} = spaced [pretty pat, string "::", pretty sig]
-  pretty' (Or pats) = inter (string "; ") $ pretty <$> NE.toList pats
+  pretty RecordConstructor {..} = (pretty name >> space) |=> pretty fields
+  pretty View {..} = spaced [pretty expression, string "->", pretty pat]
+  pretty (Splice splice) = pretty splice
+  pretty (Literal lit) = pretty lit
+  pretty NPlusK {..} = pretty n >> string "+" >> pretty k
+  pretty Signature {..} = spaced [pretty pat, string "::", pretty sig]
+  pretty (Or pats) = inter (string "; ") $ pretty <$> NE.toList pats
 
 mkPattern :: GHC.Pat GHC.GhcPs -> Pattern
 mkPattern GHC.WildPat {} = WildCard
@@ -240,9 +240,9 @@ instance CommentExtraction PatInsidePatDecl where
   nodeComments (PatInsidePatDecl p) = nodeComments p
 
 instance Pretty PatInsidePatDecl where
-  pretty' (PatInsidePatDecl InfixConstructor {..}) =
+  pretty (PatInsidePatDecl InfixConstructor {..}) =
     spaced [pretty left, pretty operator, pretty right]
-  pretty' (PatInsidePatDecl p) = pretty p
+  pretty (PatInsidePatDecl p) = pretty p
 
 mkPatInsidePatDecl :: GHC.Pat GHC.GhcPs -> PatInsidePatDecl
 mkPatInsidePatDecl = PatInsidePatDecl . mkPattern

--- a/src/HIndent/Ast/Pattern/RecordFields.hs
+++ b/src/HIndent/Ast/Pattern/RecordFields.hs
@@ -25,7 +25,7 @@ instance CommentExtraction RecordFieldsPat where
   nodeComments RecordFieldsPat {} = NodeComments [] [] []
 
 instance Pretty RecordFieldsPat where
-  pretty' (RecordFieldsPat fs dd) =
+  pretty (RecordFieldsPat fs dd) =
     case fieldPrinters of
       [] -> string "{}"
       [x] -> braces x

--- a/src/HIndent/Ast/Record/Field.hs
+++ b/src/HIndent/Ast/Record/Field.hs
@@ -40,14 +40,14 @@ instance CommentExtraction (Field rhs) where
   nodeComments Field {} = NodeComments [] [] []
 
 instance Pretty ExprField where
-  pretty' Field {..} = do
+  pretty Field {..} = do
     pretty name
     whenJust value $ \val -> do
       string " ="
       (space >> pretty val) <-|> (newline >> indentedBlock (pretty val))
 
 instance Pretty PatField where
-  pretty' Field {..} = do
+  pretty Field {..} = do
     pretty name
     whenJust value $ \val -> do
       string " = "

--- a/src/HIndent/Ast/Role.hs
+++ b/src/HIndent/Ast/Role.hs
@@ -22,9 +22,9 @@ instance CommentExtraction Role where
   nodeComments Phantom = NodeComments [] [] []
 
 instance Pretty Role where
-  pretty' Nominal = string "nominal"
-  pretty' Representational = string "representational"
-  pretty' Phantom = string "phantom"
+  pretty Nominal = string "nominal"
+  pretty Representational = string "representational"
+  pretty Phantom = string "phantom"
 
 mkRole :: GHC.Role -> Role
 mkRole GHC.Nominal = Nominal

--- a/src/HIndent/Ast/Statement.hs
+++ b/src/HIndent/Ast/Statement.hs
@@ -48,22 +48,22 @@ instance CommentExtraction (Statement a) where
   nodeComments _ = emptyNodeComments
 
 instance Pretty a => Pretty (Statement a) where
-  pretty' (Expression expr) = pretty expr
-  pretty' Binding {..} = do
+  pretty (Expression expr) = pretty expr
+  pretty Binding {..} = do
     pretty lhsPattern
     string " <-"
     hor <-|> ver
     where
       hor = space >> pretty rhs
       ver = newline >> indentedBlock (pretty rhs)
-  pretty' (LetBinding binds) = string "let " |=> pretty binds
-  pretty' (Parallel blocks)
+  pretty (LetBinding binds) = string "let " |=> pretty binds
+  pretty (Parallel blocks)
     | any ((> 1) . length) blocks =
       vBarSep $ fmap (vCommaSep . fmap pretty) blocks
     | otherwise = hvBarSep $ fmap (hvCommaSep . fmap pretty) blocks
-  pretty' Transform {..} =
+  pretty Transform {..} =
     vCommaSep $ fmap pretty steps ++ [string "then " >> pretty using]
-  pretty' Recursive {..} =
+  pretty Recursive {..} =
     string "rec " |=> prettyWith block (lined . fmap pretty)
 
 mkExprStatement ::

--- a/src/HIndent/Ast/TextValue.hs
+++ b/src/HIndent/Ast/TextValue.hs
@@ -26,7 +26,7 @@ instance CommentExtraction TextValue where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty TextValue where
-  pretty' (TextValue value) = string value
+  pretty (TextValue value) = string value
 
 mkTextValueFromString :: String -> TextValue
 mkTextValueFromString = TextValue . Text.pack

--- a/src/HIndent/Ast/Type.hs
+++ b/src/HIndent/Ast/Type.hs
@@ -148,16 +148,16 @@ instance CommentExtraction Type where
   nodeComments Wildcard = NodeComments [] [] []
 
 instance Pretty Type where
-  pretty' UniversalType {..} = (pretty telescope >> space) |=> pretty body
-  pretty' ConstrainedType {..} = hor <-|> ver
+  pretty UniversalType {..} = (pretty telescope >> space) |=> pretty body
+  pretty ConstrainedType {..} = hor <-|> ver
     where
       hor = spaced [pretty context, string "=>", pretty body]
       ver = do
         pretty context
         lined [string " =>", indentedBlock $ pretty body]
-  pretty' Variable {isPromoted = False, ..} = pretty name
-  pretty' Variable {isPromoted = True, ..} = string "'" >> pretty name
-  pretty' Application {..} = hor <-|> ver
+  pretty Variable {isPromoted = False, ..} = pretty name
+  pretty Variable {isPromoted = True, ..} = string "'" >> pretty name
+  pretty Application {..} = hor <-|> ver
     where
       hor = spaced [pretty function, pretty argument]
       ver = verticalApp function argument
@@ -166,20 +166,20 @@ instance Pretty Type where
           Application {function = l', argument = r'} ->
             verticalApp l' r' >> newline >> indentedBlock (pretty right)
           _ -> pretty left >> newline >> indentedBlock (pretty right)
-  pretty' KindApplication {..} = pretty base >> string " @" >> pretty kind
-  pretty' Function {..} =
+  pretty KindApplication {..} = pretty base >> string " @" >> pretty kind
+  pretty Function {..} =
     (pretty from
        >> if isUnrestricted multiplicity
             then string " -> "
             else space >> pretty multiplicity >> string " -> ")
       |=> pretty to
-  pretty' List {..} = brackets $ pretty elementType
-  pretty' Tuple {isUnboxed = True, elements = []} = string "(# #)"
-  pretty' Tuple {isUnboxed = False, elements = []} = string "()"
-  pretty' Tuple {isUnboxed = True, ..} = hvUnboxedTuple' $ fmap pretty elements
-  pretty' Tuple {isUnboxed = False, ..} = hvTuple' $ fmap pretty elements
-  pretty' Sum {..} = hvUnboxedSum' $ fmap pretty elements
-  pretty' InfixType {..} = do
+  pretty List {..} = brackets $ pretty elementType
+  pretty Tuple {isUnboxed = True, elements = []} = string "(# #)"
+  pretty Tuple {isUnboxed = False, elements = []} = string "()"
+  pretty Tuple {isUnboxed = True, ..} = hvUnboxedTuple' $ fmap pretty elements
+  pretty Tuple {isUnboxed = False, ..} = hvTuple' $ fmap pretty elements
+  pretty Sum {..} = hvUnboxedSum' $ fmap pretty elements
+  pretty InfixType {..} = do
     lineBreak <- gets (configLineBreaks . psConfig)
     if getInfixName (getNode operator) `elem` lineBreak
       then do
@@ -189,19 +189,19 @@ instance Pretty Type where
         space
         pretty right
       else spaced [pretty left, pretty operator, pretty right]
-  pretty' Parenthesized {..} = parens $ pretty inner
-  pretty' ImplicitParameter {..} =
+  pretty Parenthesized {..} = parens $ pretty inner
+  pretty ImplicitParameter {..} =
     spaced [pretty ipName, string "::", pretty paramType]
-  pretty' Star = string "*"
-  pretty' KindSig {..} = spaced [pretty annotated, string "::", pretty kind]
-  pretty' Splice {..} = pretty splice
-  pretty' StrictType {..} = pretty bang >> pretty baseType
-  pretty' RecordType {..} = hvFields $ fmap pretty fields
-  pretty' PromotedList {elements = []} = string "'[]"
-  pretty' PromotedList {..} = hvPromotedList $ fmap pretty elements
-  pretty' PromotedTuple {..} = hPromotedTuple $ fmap pretty elements
-  pretty' Literal {..} = pretty literal
-  pretty' Wildcard = string "_"
+  pretty Star = string "*"
+  pretty KindSig {..} = spaced [pretty annotated, string "::", pretty kind]
+  pretty Splice {..} = pretty splice
+  pretty StrictType {..} = pretty bang >> pretty baseType
+  pretty RecordType {..} = hvFields $ fmap pretty fields
+  pretty PromotedList {elements = []} = string "'[]"
+  pretty PromotedList {..} = hvPromotedList $ fmap pretty elements
+  pretty PromotedTuple {..} = hPromotedTuple $ fmap pretty elements
+  pretty Literal {..} = pretty literal
+  pretty Wildcard = string "_"
 
 mkType :: GHC.HsType GHC.GhcPs -> Type
 mkType (GHC.HsForAllTy _ tele body) =
@@ -353,7 +353,7 @@ instance CommentExtraction VerticalFuncType where
   nodeComments (VerticalFuncType t) = nodeComments t
 
 instance Pretty VerticalFuncType where
-  pretty' (VerticalFuncType Function {..}) = do
+  pretty (VerticalFuncType Function {..}) = do
     pretty $ fmap mkVerticalFuncType from
     newline
     if isUnrestricted multiplicity
@@ -362,7 +362,7 @@ instance Pretty VerticalFuncType where
         pretty multiplicity
         string " -> "
         pretty $ fmap mkVerticalFuncType to
-  pretty' (VerticalFuncType t) = pretty t
+  pretty (VerticalFuncType t) = pretty t
 
 mkVerticalFuncType :: Type -> VerticalFuncType
 mkVerticalFuncType = VerticalFuncType
@@ -374,7 +374,7 @@ instance CommentExtraction DeclSigType where
   nodeComments (DeclSigType t) = nodeComments t
 
 instance Pretty DeclSigType where
-  pretty' (DeclSigType UniversalType {..}) = do
+  pretty (DeclSigType UniversalType {..}) = do
     pretty telescope
     case getNode body of
       ConstrainedType ctxt b ->
@@ -388,14 +388,14 @@ instance Pretty DeclSigType where
         let hor = space >> pretty (DeclSigType <$> body)
             ver = newline >> pretty (DeclSigType <$> body)
          in hor <-|> ver
-  pretty' (DeclSigType ConstrainedType {..}) = hor <-|> ver
+  pretty (DeclSigType ConstrainedType {..}) = hor <-|> ver
     where
       hor = spaced [pretty context, string "=>", pretty body]
       ver = do
         pretty context
         newline
         prefixed "=> " $ pretty $ fmap mkVerticalFuncType body
-  pretty' (DeclSigType Function {..}) = hor <-|> ver
+  pretty (DeclSigType Function {..}) = hor <-|> ver
     where
       hor = do
         pretty from
@@ -412,7 +412,7 @@ instance Pretty DeclSigType where
             pretty multiplicity
             string " -> "
             pretty $ mkVerticalFuncType <$> to
-  pretty' (DeclSigType t) = pretty t
+  pretty (DeclSigType t) = pretty t
 
 mkDeclSigType :: GHC.HsSigType GHC.GhcPs -> WithComments DeclSigType
 mkDeclSigType hsSigType = DeclSigType <$> mkTypeFromHsSigType hsSigType
@@ -424,18 +424,18 @@ instance CommentExtraction InstDeclType where
   nodeComments (InstDeclType t) = nodeComments t
 
 instance Pretty InstDeclType where
-  pretty' (InstDeclType UniversalType {..}) = do
+  pretty (InstDeclType UniversalType {..}) = do
     pretty telescope
     space
     pretty $ InstDeclType <$> body
-  pretty' (InstDeclType ConstrainedType {..}) = hor <-|> ver
+  pretty (InstDeclType ConstrainedType {..}) = hor <-|> ver
     where
       hor = spaced [pretty context, string "=>", pretty body]
       ver = do
         pretty context >> string " =>"
         newline
         indentedWithFixedLevel 9 $ pretty body
-  pretty' (InstDeclType t) = pretty t
+  pretty (InstDeclType t) = pretty t
 
 mkInstDeclType :: GHC.HsSigType GHC.GhcPs -> WithComments InstDeclType
 mkInstDeclType hsSigType = InstDeclType <$> mkTypeFromHsSigType hsSigType

--- a/src/HIndent/Ast/Type/Argument.hs
+++ b/src/HIndent/Ast/Type/Argument.hs
@@ -27,8 +27,8 @@ instance CommentExtraction TypeArgument where
   nodeComments KindArgument {..} = nodeComments argKind
 
 instance Pretty TypeArgument where
-  pretty' TypeArgument {..} = pretty argType
-  pretty' KindArgument {..} = string "@" >> pretty argKind
+  pretty TypeArgument {..} = pretty argType
+  pretty KindArgument {..} = string "@" >> pretty argKind
 
 mkTypeArgument ::
      GHC.HsArg GHC.GhcPs (GHC.LHsType GHC.GhcPs) (GHC.LHsType GHC.GhcPs)

--- a/src/HIndent/Ast/Type/Argument/Collection.hs
+++ b/src/HIndent/Ast/Type/Argument/Collection.hs
@@ -19,7 +19,7 @@ instance CommentExtraction TypeArgumentCollection where
     mconcat $ fmap nodeComments arguments
 
 instance Pretty TypeArgumentCollection where
-  pretty' (TypeArgumentCollection arguments) = spaced $ fmap pretty arguments
+  pretty (TypeArgumentCollection arguments) = spaced $ fmap pretty arguments
 
 mkTypeArgumentCollection ::
      [GHC.HsArg GHC.GhcPs (GHC.LHsType GHC.GhcPs) (GHC.LHsType GHC.GhcPs)]

--- a/src/HIndent/Ast/Type/Bang.hs
+++ b/src/HIndent/Ast/Type/Bang.hs
@@ -22,10 +22,10 @@ instance CommentExtraction Bang where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Bang where
-  pretty' (Bang unpack strictness) = do
-    maybe (pure ()) pretty' unpack
+  pretty (Bang unpack strictness) = do
+    maybe (pure ()) pretty unpack
     unless (isNothing unpack) space
-    maybe (pure ()) pretty' strictness
+    maybe (pure ()) pretty strictness
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkBang :: GHC.HsSrcBang -> Bang
 mkBang (GHC.HsSrcBang _ unpack strictness) =

--- a/src/HIndent/Ast/Type/Forall.hs
+++ b/src/HIndent/Ast/Type/Forall.hs
@@ -23,11 +23,11 @@ instance CommentExtraction Forall where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Forall where
-  pretty' (Visible vars) = do
+  pretty (Visible vars) = do
     string "forall "
     spaced $ fmap pretty vars
     string " ->"
-  pretty' (Invisible vars) = do
+  pretty (Invisible vars) = do
     string "forall "
     spaced $ fmap pretty vars
     dot

--- a/src/HIndent/Ast/Type/ImplicitParameterName.hs
+++ b/src/HIndent/Ast/Type/ImplicitParameterName.hs
@@ -19,7 +19,7 @@ instance CommentExtraction ImplicitParameterName where
   nodeComments ImplicitParameterName {} = emptyNodeComments
 
 instance Pretty ImplicitParameterName where
-  pretty' (ImplicitParameterName name) = string "?" >> pretty name
+  pretty (ImplicitParameterName name) = string "?" >> pretty name
 
 mkImplicitParameterName :: GHC.HsIPName -> ImplicitParameterName
 mkImplicitParameterName (GHC.HsIPName fs) =

--- a/src/HIndent/Ast/Type/Multiplicity.hs
+++ b/src/HIndent/Ast/Type/Multiplicity.hs
@@ -26,9 +26,9 @@ instance CommentExtraction Multiplicity where
   nodeComments (MkExplicit mult) = nodeComments mult
 
 instance Pretty Multiplicity where
-  pretty' MkUnrestricted = pure ()
-  pretty' MkLinear = string "%1"
-  pretty' (MkExplicit mult) = string "%" >> pretty mult
+  pretty MkUnrestricted = pure ()
+  pretty MkLinear = string "%1"
+  pretty (MkExplicit mult) = string "%" >> pretty mult
 #if MIN_VERSION_ghc_lib_parser(9, 14, 0)
 mkMultiplicity :: GHC.HsMultAnn GHC.GhcPs -> Multiplicity
 mkMultiplicity GHC.HsUnannotated {} = MkUnrestricted

--- a/src/HIndent/Ast/Type/Strictness.hs
+++ b/src/HIndent/Ast/Type/Strictness.hs
@@ -21,8 +21,8 @@ instance CommentExtraction Strictness where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Strictness where
-  pretty' Lazy = string "~"
-  pretty' Strict = string "!"
+  pretty Lazy = string "~"
+  pretty Strict = string "!"
 
 mkStrictness :: GHC.SrcStrictness -> Maybe Strictness
 mkStrictness GHC.SrcLazy = Just Lazy

--- a/src/HIndent/Ast/Type/Unpackedness.hs
+++ b/src/HIndent/Ast/Type/Unpackedness.hs
@@ -21,8 +21,8 @@ instance CommentExtraction Unpackedness where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty Unpackedness where
-  pretty' Unpack = string "{-# UNPACK #-}"
-  pretty' NoUnpack = string "{-# NOUNPACK #-}"
+  pretty Unpack = string "{-# UNPACK #-}"
+  pretty NoUnpack = string "{-# NOUNPACK #-}"
 
 mkUnpackedness :: GHC.SrcUnpackedness -> Maybe Unpackedness
 mkUnpackedness GHC.SrcUnpack = Just Unpack

--- a/src/HIndent/Ast/Type/Variable.hs
+++ b/src/HIndent/Ast/Type/Variable.hs
@@ -27,9 +27,9 @@ instance CommentExtraction TypeVariable where
   nodeComments TypeVariable {} = NodeComments [] [] []
 
 instance Pretty TypeVariable where
-  pretty' TypeVariable {kind = Just kind, ..} =
+  pretty TypeVariable {kind = Just kind, ..} =
     parens $ pretty name >> string " :: " >> pretty kind
-  pretty' TypeVariable {kind = Nothing, ..} = pretty name
+  pretty TypeVariable {kind = Nothing, ..} = pretty name
 
 mkTypeVariable :: GHC.HsTyVarBndr a GHC.GhcPs -> TypeVariable
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)

--- a/src/HIndent/Ast/WhereClause.hs
+++ b/src/HIndent/Ast/WhereClause.hs
@@ -22,7 +22,7 @@ instance CommentExtraction WhereClause where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty WhereClause where
-  pretty' WhereClause {..} =
+  pretty WhereClause {..} =
     lined [string "where", prettyWith binds $ indentedBlock . pretty]
 
 mkWhereClause :: GHC.GRHSs GHC.GhcPs body -> Maybe (WithComments WhereClause)

--- a/src/HIndent/Ast/WithComments.hs
+++ b/src/HIndent/Ast/WithComments.hs
@@ -50,7 +50,7 @@ instance CommentExtraction (WithComments a) where
   nodeComments _ = mempty
 
 instance (Pretty a) => Pretty (WithComments a) where
-  pretty' withComments = prettyWith withComments pretty
+  pretty withComments = prettyWith withComments pretty
 
 -- | Prints comments included in the location information and then the
 -- AST node body.

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -17,7 +17,6 @@
 -- constructors only in remaining and type checking.
 module HIndent.Pretty
   ( Pretty(..)
-  , pretty
   , printCommentsAnd
   ) where
 
@@ -48,14 +47,6 @@ import qualified GHC.Core.DataCon as GHC
 #else
 import qualified GHC.Unit as GHC
 #endif
--- | This function pretty-prints the given AST node with comments.
-pretty :: Pretty a => a -> Printer ()
-pretty p = do
-  printCommentsBefore p
-  pretty' p
-  printCommentOnSameLine p
-  printCommentsAfter p
-
 -- | Prints comments included in the location information and then the
 -- AST node body.
 printCommentsAnd ::
@@ -103,15 +94,13 @@ printCommentsAfter p =
         indentedWithFixedLevel col $ pretty c
         eolCommentsArePrinted
 
--- | Pretty print including comments.
+-- | Pretty print.
 --
 -- @FastString@ does not implement this class because it may contain @\n@s
 -- and each type that may contain a @FastString@ value needs their own
 -- handlings.
-class CommentExtraction a =>
-      Pretty a
-  where
-  pretty' :: a -> Printer ()
+class Pretty a where
+  pretty :: a -> Printer ()
 
 data DataFamInstDeclFor
   = DataFamInstDeclForTopLevel
@@ -122,14 +111,14 @@ data DataFamInstDeclFor
 -- comments are present in the source code. See
 -- https://github.com/mihaimaruseac/hindent/issues/586#issuecomment-1374992624.
 instance (CommentExtraction l, Pretty e) => Pretty (GHC.GenLocated l e) where
-  pretty' (GHC.L _ e) = pretty e
+  pretty loc = printCommentsAnd loc pretty
 
 instance Pretty
            (GHC.StmtLR
               GHC.GhcPs
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsExpr GHC.GhcPs))) where
-  pretty' = prettyStmtLRExpr
+  pretty = prettyStmtLRExpr
 
 prettyStmtLRExpr ::
      GHC.StmtLR
@@ -168,10 +157,10 @@ prettyStmtLRExpr GHC.RecStmt {..} =
   string "rec " |=> printCommentsAnd recS_stmts (lined . fmap pretty)
 
 instance Pretty (GHC.ParStmtBlock GHC.GhcPs GHC.GhcPs) where
-  pretty' (GHC.ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
+  pretty (GHC.ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
 
 instance Pretty GHC.EpaComment where
-  pretty' GHC.EpaComment {..} = prettyEpaCommentTok ac_tok
+  pretty GHC.EpaComment {..} = prettyEpaCommentTok ac_tok
 
 prettyEpaCommentTok :: GHC.EpaCommentTok -> Printer ()
 prettyEpaCommentTok (GHC.EpaLineComment text) = string $ Text.pack text
@@ -191,22 +180,22 @@ instance Pretty
            (GHC.HsScaled
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsScaled _ ty) = pretty $ fmap mkType ty
+  pretty (GHC.HsScaled _ ty) = pretty $ fmap mkType ty
 #endif
 #if MIN_VERSION_ghc_lib_parser(9, 10, 1)
 instance Pretty GHC.StringLiteral where
-  pretty' GHC.StringLiteral {sl_st = GHC.SourceText s} =
+  pretty GHC.StringLiteral {sl_st = GHC.SourceText s} =
     string $ Text.pack $ FS.unpackFS s
-  pretty' GHC.StringLiteral {..} = string $ Text.pack $ FS.unpackFS sl_fs
+  pretty GHC.StringLiteral {..} = string $ Text.pack $ FS.unpackFS sl_fs
 #else
 instance Pretty GHC.StringLiteral where
-  pretty' = output
+  pretty = output
 #endif
 instance Pretty
            (GHC.FamEqn
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' GHC.FamEqn {..} = do
+  pretty GHC.FamEqn {..} = do
     pretty $ fmap mkPrefixName feqn_tycon
     spacePrefixed $ fmap pretty feqn_pats
     string " = "
@@ -214,7 +203,7 @@ instance Pretty
 
 -- | Pretty-print a data instance.
 instance Pretty (GHC.FamEqn GHC.GhcPs (GHC.HsDataDefn GHC.GhcPs)) where
-  pretty' = prettyFamEqn DataFamInstDeclForTopLevel
+  pretty = prettyFamEqn DataFamInstDeclForTopLevel
 #if MIN_VERSION_ghc_lib_parser(9, 6, 1)
 prettyFamEqn ::
      DataFamInstDeclFor
@@ -259,40 +248,40 @@ instance Pretty
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg _ x) = pretty $ mkType <$> x
-  pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty (mkType <$> x)
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty (GHC.HsValArg _ x) = pretty $ mkType <$> x
+  pretty (GHC.HsTypeArg _ x) = string "@" >> pretty (mkType <$> x)
+  pretty GHC.HsArgPar {} = notUsedInParsedStage
 #elif MIN_VERSION_ghc_lib_parser(9, 8, 1)
 instance Pretty
            (GHC.HsArg
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x) = pretty $ mkType <$> x
-  pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty (mkType <$> x)
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty (GHC.HsValArg x) = pretty $ mkType <$> x
+  pretty (GHC.HsTypeArg _ x) = string "@" >> pretty (mkType <$> x)
+  pretty GHC.HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
            (GHC.HsArg
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' (GHC.HsValArg x) = pretty $ mkType <$> x
-  pretty' (GHC.HsTypeArg _ x) = string "@" >> pretty (mkType <$> x)
-  pretty' GHC.HsArgPar {} = notUsedInParsedStage
+  pretty (GHC.HsValArg x) = pretty $ mkType <$> x
+  pretty (GHC.HsTypeArg _ x) = string "@" >> pretty (mkType <$> x)
+  pretty GHC.HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (GHC.WithHsDocIdentifiers GHC.StringLiteral GHC.GhcPs) where
-  pretty' GHC.WithHsDocIdentifiers {..} = pretty hsDocString
+  pretty GHC.WithHsDocIdentifiers {..} = pretty hsDocString
 #endif
 -- | Instance for wildcard types.
 instance Pretty
            (GHC.HsWildCardBndrs
               GHC.GhcPs
               (GHC.GenLocated GHC.SrcSpanAnnA (GHC.HsType GHC.GhcPs))) where
-  pretty' GHC.HsWC {..} = pretty $ mkType <$> hswc_body
+  pretty GHC.HsWC {..} = pretty $ mkType <$> hswc_body
 
 instance Pretty (GHC.DataFamInstDecl GHC.GhcPs) where
-  pretty' = prettyDataFamInstDecl DataFamInstDeclForTopLevel
+  pretty = prettyDataFamInstDecl DataFamInstDeclForTopLevel
 
 prettyDataFamInstDecl ::
      DataFamInstDeclFor -> GHC.DataFamInstDecl GHC.GhcPs -> Printer ()
@@ -300,7 +289,7 @@ prettyDataFamInstDecl dataFamInstDeclFor GHC.DataFamInstDecl {..} =
   prettyFamEqn dataFamInstDeclFor dfid_eqn
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty GHC.FieldLabelString where
-  pretty' = output
+  pretty = output
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9, 12, 1)
 -- | Marks an AST node as never appearing in an AST.

--- a/src/HIndent/Pretty.hs-boot
+++ b/src/HIndent/Pretty.hs-boot
@@ -3,7 +3,6 @@
 
 module HIndent.Pretty
   ( Pretty(..)
-  , pretty
   , printCommentsAnd
   ) where
 
@@ -13,12 +12,9 @@ import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import HIndent.Pretty.NodeComments
 import HIndent.Printer
 
-class CommentExtraction a =>
-      Pretty a
-  where
-  pretty' :: a -> Printer ()
+class Pretty a where
+  pretty :: a -> Printer ()
 
-pretty :: Pretty a => a -> Printer ()
 printCommentsAnd ::
      (CommentExtraction l)
   => GHC.GenLocated l e


### PR DESCRIPTION
### Description of the PR

`s/pretty'/pretty` because comments are now handled by `WithComments` rather than `CommentExtraction`.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
