### PR TITLE
fix: preserve parens for infix function lhs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Preserve parentheses around infix function left-hand sides with extra arguments ([#1243])
+
 ### Removed
 
 ## [6.3.0] - 2026-01-24
@@ -428,6 +430,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#1243]: https://github.com/mihaimaruseac/hindent/pull/1243
 [#1163]: https://github.com/mihaimaruseac/hindent/pull/1163
 [#1143]: https://github.com/mihaimaruseac/hindent/pull/1143
 [#1140]: https://github.com/mihaimaruseac/hindent/pull/1140

--- a/TESTS.md
+++ b/TESTS.md
@@ -1341,6 +1341,13 @@ Pattern matching against a infix constructor with a module name prefix
 foo (a FOO.:@: b) = undefined
 ```
 
+Infix function with an extra argument
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/539
+(f >=> g) k = f k >>= g
+```
+
 ##### Pattern matchings against record
 
 Short

--- a/src/HIndent/Ast/Match.hs
+++ b/src/HIndent/Ast/Match.hs
@@ -60,8 +60,12 @@ instance CommentExtraction InfixOperands where
   nodeComments _ = NodeComments [] [] []
 
 instance Pretty InfixOperands where
+  pretty InfixOperands {rest = [], ..} =
+    spaced [pretty left, pretty operator, pretty right]
   pretty InfixOperands {..} =
-    spaced $ pretty left : pretty operator : pretty right : fmap pretty rest
+    spaced
+      $ parens (spaced [pretty left, pretty operator, pretty right])
+          : fmap pretty rest
 
 data Match
   = Lambda


### PR DESCRIPTION
### Description of the PR

Fixes: #539
Fixes: #1174 

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
