### PR TITLE
refactor: use `pretty` for `instance Pretty GuardedRhs`

### DIFF
--- a/src/HIndent/Ast/Declaration/Bind/GuardedRhs.hs
+++ b/src/HIndent/Ast/Declaration/Bind/GuardedRhs.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Bind.GuardedRhs
@@ -24,11 +23,7 @@ import HIndent.Ast.Guard
   , mkMultiWayIfExprGuard
   )
 import HIndent.Ast.WhereClause (WhereClause, mkWhereClause)
-import HIndent.Ast.WithComments
-  ( WithComments
-  , mkWithCommentsFromGenLocated
-  , prettyWith
-  )
+import HIndent.Ast.WithComments (WithComments, mkWithCommentsFromGenLocated)
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
@@ -42,7 +37,7 @@ instance Pretty GuardedRhs where
   pretty GuardedRhs {..} = do
     mapM_ pretty guards
     whenJust whereClause $ \clause ->
-      indentedBlock $ newlinePrefixed [prettyWith clause pretty]
+      indentedBlock $ newlinePrefixed [pretty clause]
 
 mkGuardedRhs :: GHC.GRHSs GHC.GhcPs (GHC.LHsExpr GHC.GhcPs) -> GuardedRhs
 mkGuardedRhs grhss@GHC.GRHSs {..} =


### PR DESCRIPTION
### Description of the PR

`prettyWith clause pretty` is the same as `pretty clause`.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
