### PR TITLE
test: add regression coverage for multiline CPP directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - Preserve parentheses around infix function left-hand sides with extra arguments ([#1243])
-- Recognize and normalize CPP directives with spaces after `#` ([#1249])
+- Recognize and normalize CPP directives with spaces after `#`, including multiline directives ([#1249])
 
 ### Removed
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -3791,6 +3791,20 @@ Escaped newlines
   x
 ```
 
+Escaped newlines in CPP directives
+
+```haskell given
+-- https://github.com/mihaimaruseac/hindent/issues/651
+#  define FOO 3+ \
+        5
+```
+
+```haskell expect
+-- https://github.com/mihaimaruseac/hindent/issues/651
+#define FOO 3+ \
+        5
+```
+
 Language extensions are effective across CPP boundaries.
 
 ```haskell


### PR DESCRIPTION
### Description of the PR

Adds regression coverage for #651. The underlying issue was fixed by #1249.

Closes #651.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.